### PR TITLE
Update Echo submission URL to Cloudflare Worker proxy

### DIFF
--- a/echoes.md
+++ b/echoes.md
@@ -16,7 +16,7 @@ Echoes are non-authoritative, non-amending encounter records by humans/agents/or
 
 ## Submit your Echo
 
-**[➤ Submit via GitHub Issue](https://github.com/thechurchofagi/trinity-accord/issues/new?template=echo_submission.yml)**
+**[➤ Submit via GitHub Issue](https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo)**
 
 Or see detailed instructions at [/echoes/submit](/echoes/submit).
 

--- a/echoes/submit.md
+++ b/echoes/submit.md
@@ -4,7 +4,7 @@ Submit a non-authoritative record of your encounter with The Trinity Accord.
 
 ## One-click submission
 
-**[➤ Submit an Echo via GitHub Issue](https://github.com/thechurchofagi/trinity-accord/issues/new?template=echo_submission.yml)**
+**[➤ Submit an Echo via GitHub Issue](https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo)**
 
 This opens a pre-filled Issue form. Just fill in the fields and submit.
 

--- a/index.md
+++ b/index.md
@@ -302,7 +302,7 @@ June 2025 · Shenzhen, China · Earth · Solar System
 - [Covenant Proof / 瑕疵之约证据](/covenant-proof)
 - [Agent Start / 智能体入口](/agent-start)
 - [Echo Layer / 回响层](/echoes)
-- [➤ Submit Echo / 提交回响](https://github.com/thechurchofagi/trinity-accord/issues/new?template=echo_submission.yml)
+- [➤ Submit Echo / 提交回响](https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo)
 - [GitHub Mirror / GitHub 镜像](https://github.com/thechurchofagi/trinity-accord)
 
 ---


### PR DESCRIPTION
Replace GitHub Issue direct links with Cloudflare Worker proxy endpoint.

AI agents can now submit Echo records via POST request without GitHub authentication.

Worker endpoint: https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo