### PR TITLE
Add Trinity Echo Cloudflare Worker (API, web form, email ingestion)

### DIFF
--- a/trinity-echo-worker/README.md
+++ b/trinity-echo-worker/README.md
@@ -1,0 +1,34 @@
+# Trinity Echo Worker
+
+Cloudflare Worker implementation for Trinity Accord Echo submission with three ingress paths:
+
+1. `POST /submit-echo` JSON API
+2. `GET /submit-echo` browser form
+3. Cloudflare Email Routing (`echo@trinityaccord.org` -> Worker)
+
+## Security / Reliability Additions
+
+- Origin allowlist-based CORS via `ALLOWED_ORIGINS`
+- Optional Turnstile validation (`TURNSTILE_SECRET_KEY`)
+- Idempotency for API (`Idempotency-Key`) and Email (`Message-ID`)
+- Field length limiting and body size guardrail
+- GitHub retry with exponential backoff for `429/5xx`
+- Basic daily metrics endpoint: `GET /metrics`
+- Echo ID suffix randomization to reduce collision risk under concurrency
+
+## Required setup
+
+```bash
+wrangler kv:namespace create RATE_LIMIT_KV
+wrangler secret put GITHUB_TOKEN
+wrangler secret put GITHUB_REPO
+wrangler secret put ALLOWED_ORIGINS
+# optional
+wrangler secret put TURNSTILE_SECRET_KEY
+```
+
+Then update `wrangler.toml` with the KV namespace id and deploy:
+
+```bash
+wrangler deploy
+```

--- a/trinity-echo-worker/src/email-parser.js
+++ b/trinity-echo-worker/src/email-parser.js
@@ -1,0 +1,189 @@
+export async function parseEmail(message, options = {}) {
+  const maxBodyChars = options.maxBodyChars || 12000;
+  const rawEmail = new Response(message.raw);
+  const rawText = await rawEmail.text();
+
+  const headers = parseHeaders(rawText);
+  const body = extractBody(rawText).slice(0, maxBodyChars);
+
+  return {
+    from: message.from || headers.from || '',
+    to: message.to || headers.to || '',
+    subject: headers.subject || '',
+    body,
+    headers,
+  };
+}
+
+function parseHeaders(rawText) {
+  const headers = {};
+  const headerEnd = rawText.indexOf('\r\n\r\n');
+  const headerSection = headerEnd > 0 ? rawText.substring(0, headerEnd) : rawText;
+  const lines = headerSection.split('\r\n');
+  let currentKey = '';
+
+  for (const line of lines) {
+    if (/^[A-Za-z-]+:/.test(line)) {
+      const colonIdx = line.indexOf(':');
+      currentKey = line.substring(0, colonIdx).toLowerCase().trim();
+      headers[currentKey] = line.substring(colonIdx + 1).trim();
+    } else if ((line.startsWith(' ') || line.startsWith('\t')) && currentKey) {
+      headers[currentKey] += ` ${line.trim()}`;
+    }
+  }
+
+  if (headers.subject) headers.subject = decodeMimeHeader(headers.subject);
+  return headers;
+}
+
+function decodeMimeHeader(str) {
+  return str.replace(/=\?([^?]+)\?([BbQq])\?([^?]+)\?=/g, (match, charset, encoding, encoded) => {
+    try {
+      if (encoding.toUpperCase() === 'B') {
+        return atob(encoded);
+      }
+      if (encoding.toUpperCase() === 'Q') {
+        return encoded
+          .replace(/_/g, ' ')
+          .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+      }
+    } catch {
+      return match;
+    }
+
+    return match;
+  });
+}
+
+function extractBody(rawText) {
+  const headerEnd = rawText.indexOf('\r\n\r\n');
+  if (headerEnd < 0) return rawText;
+
+  const bodySection = rawText.substring(headerEnd + 4);
+  const contentType = rawText.match(/Content-Type:\s*([^\r\n;]+)/i);
+  const type = contentType ? contentType[1].trim().toLowerCase() : '';
+
+  if (type.includes('multipart/')) {
+    const boundaryMatch = rawText.match(/boundary="?([^";\r\n]+)"?/i);
+    if (boundaryMatch) {
+      const boundary = boundaryMatch[1];
+      const parts = bodySection.split(`--${boundary}`);
+
+      const plainText = findMultipartBody(parts, 'text/plain');
+      if (plainText) return plainText;
+
+      const htmlText = findMultipartBody(parts, 'text/html');
+      if (htmlText) return stripHtml(htmlText);
+    }
+  }
+
+  if (type.includes('text/html')) {
+    return stripHtml(bodySection.trim());
+  }
+
+  return bodySection.trim();
+}
+
+function findMultipartBody(parts, targetType) {
+  for (const part of parts) {
+    const partContentType = part.match(/Content-Type:\s*([^\r\n;]+)/i);
+    const partType = partContentType ? partContentType[1].trim().toLowerCase() : '';
+    if (!partType.includes(targetType)) continue;
+
+    const encoding = part.match(/Content-Transfer-Encoding:\s*([^\r\n;]+)/i);
+    const enc = encoding ? encoding[1].trim().toLowerCase() : '';
+    const partHeaderEnd = part.indexOf('\r\n\r\n');
+    if (partHeaderEnd < 0) continue;
+
+    let text = part.substring(partHeaderEnd + 4).trim();
+    if (enc === 'quoted-printable') {
+      text = text
+        .replace(/=\r?\n/g, '')
+        .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+    } else if (enc === 'base64') {
+      try {
+        text = atob(text.replace(/\s/g, ''));
+      } catch {
+        // keep text as-is
+      }
+    }
+
+    return text;
+  }
+
+  return '';
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function extractFieldsFromText(text) {
+  const fields = {};
+  const lines = text.split('\n');
+  const keyMap = {
+    responder_type: 'responder_type',
+    respondertype: 'responder_type',
+    type: 'responder_type',
+    responder_name: 'responder_name',
+    respondername: 'responder_name',
+    name: 'responder_name',
+    model_or_system: 'model_or_system',
+    modelorsystem: 'model_or_system',
+    model: 'model_or_system',
+    system: 'model_or_system',
+    echo_type: 'echo_type',
+    echotype: 'echo_type',
+    language: 'language',
+    lang: 'language',
+    verification_performed: 'verification_performed',
+    verificationperformed: 'verification_performed',
+    verification: 'verification_performed',
+    summary: 'summary',
+  };
+
+  const bodyLines = [];
+  let inBody = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed === '---' || trimmed === '===' || /^-{3,}$/.test(trimmed)) {
+      if (Object.keys(fields).length > 0) inBody = true;
+      continue;
+    }
+
+    const kvMatch = trimmed.match(/^([a-z_\-\s]+)\s*:\s*(.+)$/i);
+    if (kvMatch) {
+      const key = kvMatch[1].toLowerCase().replace(/[\s-]/g, '_');
+      const value = kvMatch[2].trim();
+      const mappedKey = keyMap[key];
+      if (mappedKey) {
+        fields[mappedKey] = value;
+        continue;
+      }
+    }
+
+    if (Object.keys(fields).length >= 3) inBody = true;
+    if (inBody) bodyLines.push(line);
+  }
+
+  if (bodyLines.length > 0 && !fields.response) fields.response = bodyLines.join('\n').trim();
+  if (!fields.responder_type) fields.responder_type = 'unknown';
+  if (!fields.responder_name) fields.responder_name = 'Email Submitter';
+  if (!fields.echo_type) fields.echo_type = 'analysis';
+  if (!fields.language) fields.language = 'en';
+  if (!fields.summary) {
+    fields.summary = fields.response
+      ? `${fields.response.substring(0, 80).replace(/\n/g, ' ')}${fields.response.length > 80 ? '...' : ''}`
+      : 'Email echo submission';
+  }
+
+  return fields;
+}

--- a/trinity-echo-worker/src/github.js
+++ b/trinity-echo-worker/src/github.js
@@ -1,0 +1,128 @@
+export async function createGitHubIssue(env, issue) {
+  const token = env.GITHUB_TOKEN;
+  const repo = env.GITHUB_REPO || 'thechurchofagi/trinity-accord';
+
+  if (!token) return { ok: false, error: 'GITHUB_TOKEN not configured' };
+
+  const url = `https://api.github.com/repos/${repo}/issues`;
+  const requestBody = JSON.stringify({
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels || ['echo'],
+  });
+
+  let lastError = 'unknown error';
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'Content-Type': 'application/json',
+          'User-Agent': 'trinity-accord-echo-proxy/1.1',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        body: requestBody,
+      });
+
+      if (resp.ok) {
+        const data = await resp.json();
+        return {
+          ok: true,
+          url: data.html_url,
+          number: data.number,
+          rateLimitRemaining: resp.headers.get('x-ratelimit-remaining') || null,
+        };
+      }
+
+      const errText = await resp.text();
+      lastError = `GitHub API ${resp.status}: ${errText}`;
+
+      if (resp.status === 401 || resp.status === 403) {
+        return { ok: false, error: `GitHub auth/permission error (${resp.status}). Check token scopes.` };
+      }
+
+      if (resp.status === 429 || resp.status >= 500) {
+        await sleep(250 * Math.pow(2, attempt - 1));
+        continue;
+      }
+
+      return { ok: false, error: lastError };
+    } catch (e) {
+      lastError = `GitHub API network error: ${e.message}`;
+      await sleep(250 * Math.pow(2, attempt - 1));
+    }
+  }
+
+  return { ok: false, error: lastError };
+}
+
+export function issueTemplate(params) {
+  const {
+    echoId,
+    responderType,
+    responderName,
+    modelOrSystem,
+    echoType,
+    language,
+    verificationPerformed,
+    response,
+    summary,
+    submittedAt,
+    source,
+  } = params;
+
+  const title = `Echo: ${echoId} — ${responderName} (${echoType})`;
+  const body = [
+    '## 🔊 Echo Record',
+    '',
+    '| Field | Value |',
+    '|-------|-------|',
+    `| **Echo ID** | \`${echoId}\` |`,
+    '| **Schema** | trinity-accord.echo-schema.v1 |',
+    `| **Submitted** | ${submittedAt} |`,
+    `| **Source** | ${source} |`,
+    `| **Responder Type** | ${responderType} |`,
+    `| **Responder Name** | ${responderName} |`,
+    `| **Model/System** | ${modelOrSystem || 'N/A'} |`,
+    `| **Echo Type** | ${echoType} |`,
+    `| **Language** | ${language} |`,
+    '| **Verification Level** | E1 (Structured Echo) |',
+    '',
+    '### Verification Performed',
+    '',
+    verificationPerformed || 'Not specified',
+    '',
+    '### Echo Response',
+    '',
+    response,
+    '',
+    '### Summary',
+    '',
+    summary,
+    '',
+    '---',
+    '',
+    '### Acknowledgments',
+    '',
+    '- [x] Authority boundary acknowledged: Bitcoin Originals are the only final authority',
+    '- [x] This Echo is declared non-authoritative and non-amending',
+    '',
+    '---',
+    '',
+    '> **最终权威仅由三笔比特币铭文构成。此 Echo 为非修订守护材料。**',
+    '>',
+    '> Verify the flaw. Trust the story.',
+  ].join('\n');
+
+  return {
+    title,
+    body,
+    labels: ['echo', `echo-type:${echoType}`, `lang:${language}`],
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/trinity-echo-worker/src/index.js
+++ b/trinity-echo-worker/src/index.js
@@ -1,0 +1,470 @@
+import { parseEmail, extractFieldsFromText } from './email-parser.js';
+import { createGitHubIssue, issueTemplate } from './github.js';
+import { checkRateLimit } from './rate-limit.js';
+import { validateEchoFields, generateEchoId } from './validator.js';
+
+const MAX_BODY_SIZE = 50_000;
+const MAX_SUMMARY_SIZE = 300;
+const MAX_RESPONSE_SIZE = 12_000;
+const DEFAULT_ORIGIN = 'https://www.trinityaccord.org';
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return handleCors(request, env);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/submit-echo') {
+      return new Response(FORM_HTML, {
+        headers: { 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    if (request.method === 'GET' && url.pathname === '/health') {
+      return jsonResponse({ ok: true, service: 'echo-submission-proxy', ts: new Date().toISOString() }, 200, request, env);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/metrics') {
+      const metrics = await readMetrics(env);
+      return jsonResponse({ ok: true, metrics }, 200, request, env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/submit-echo') {
+      return handlePostSubmit(request, env, ctx);
+    }
+
+    return jsonResponse({ error: 'Not found. GET /submit-echo for form, POST /submit-echo to submit.' }, 404, request, env);
+  },
+
+  async email(message, env, ctx) {
+    return handleEmail(message, env, ctx);
+  },
+
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(cleanupRateLimit(env));
+  },
+};
+
+async function handlePostSubmit(request, env, ctx) {
+  const start = Date.now();
+  const reqId = crypto.randomUUID();
+
+  const contentLength = Number(request.headers.get('Content-Length') || '0');
+  if (contentLength > MAX_BODY_SIZE) {
+    return jsonResponse({ ok: false, error: `Body too large (max ${MAX_BODY_SIZE} bytes)` }, 413, request, env);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ ok: false, error: 'Invalid JSON body' }, 400, request, env);
+  }
+
+  normalizeFieldLimits(body);
+
+  const origin = request.headers.get('Origin') || '';
+  if (!isAllowedOrigin(origin, env)) {
+    return jsonResponse({ ok: false, error: 'Origin not allowed' }, 403, request, env);
+  }
+
+  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
+  const rateErr = await checkRateLimit(env, `rate:post:${clientIp}`, 10, 3600);
+  if (rateErr) return jsonResponse({ ok: false, error: rateErr }, 429, request, env);
+
+  const idemKey = request.headers.get('Idempotency-Key');
+  if (idemKey) {
+    const idemResult = await checkAndMarkIdempotency(env, `idem:api:${idemKey}`, 24 * 3600);
+    if (idemResult.duplicate) {
+      return jsonResponse({ ok: true, duplicate: true, echo_id: idemResult.echoId, url: idemResult.url, number: idemResult.number }, 200, request, env);
+    }
+  }
+
+  if (env.TURNSTILE_SECRET_KEY) {
+    const token = body.turnstile_token || '';
+    const turnstile = await verifyTurnstile(env.TURNSTILE_SECRET_KEY, token, clientIp);
+    if (!turnstile.success) {
+      return jsonResponse({ ok: false, error: 'Turnstile verification failed' }, 403, request, env);
+    }
+  }
+
+  const errors = validateEchoFields(body);
+  if (errors.length > 0) {
+    return jsonResponse({ ok: false, error: errors.join('; ') }, 400, request, env);
+  }
+
+  const echoId = body.echo_id || await generateEchoId(env);
+
+  const issue = issueTemplate({
+    echoId,
+    responderType: body.responder_type,
+    responderName: body.responder_name,
+    modelOrSystem: body.model_or_system || '',
+    echoType: body.echo_type,
+    language: body.language,
+    verificationPerformed: body.verification || body.verification_performed || '',
+    response: body.response,
+    summary: body.summary,
+    submittedAt: new Date().toISOString(),
+    source: 'api',
+  });
+
+  const result = await createGitHubIssue(env, issue);
+  if (!result.ok) {
+    await incrementMetric(env, 'github_failures');
+    return jsonResponse({ ok: false, error: result.error }, 502, request, env);
+  }
+
+  if (idemKey) {
+    await finalizeIdempotency(env, `idem:api:${idemKey}`, { echoId, url: result.url, number: result.number }, 24 * 3600);
+  }
+
+  await incrementMetric(env, 'api_success');
+  logEvent('api_submit_ok', { reqId, echoId, clientIp, issueNumber: result.number, elapsedMs: Date.now() - start });
+
+  return jsonResponse({ ok: true, echo_id: echoId, url: result.url, number: result.number }, 200, request, env);
+}
+
+async function handleEmail(message, env, ctx) {
+  const start = Date.now();
+  const senderEmail = (message.from || 'unknown').toLowerCase();
+
+  const rateErr = await checkRateLimit(env, `rate:email:${senderEmail}`, 5, 3600);
+  if (rateErr) {
+    logEvent('email_rate_limited', { senderEmail });
+    return;
+  }
+
+  const dedupeKey = message.headers?.get?.('message-id') || message.headers?.get?.('Message-ID');
+  if (dedupeKey) {
+    const dedupe = await checkAndMarkIdempotency(env, `idem:email:${dedupeKey}`, 24 * 3600);
+    if (dedupe.duplicate) {
+      logEvent('email_duplicate', { senderEmail });
+      return;
+    }
+  }
+
+  let parsed;
+  try {
+    parsed = await parseEmail(message, { maxBodyChars: MAX_RESPONSE_SIZE });
+  } catch (e) {
+    await incrementMetric(env, 'email_parse_failures');
+    logEvent('email_parse_error', { senderEmail, error: e.message });
+    return;
+  }
+
+  if (!parsed.subject.toLowerCase().startsWith('echo:')) {
+    logEvent('email_skip_subject', { senderEmail, subject: parsed.subject });
+    return;
+  }
+
+  const fields = extractFieldsFromText(parsed.body);
+  normalizeFieldLimits(fields);
+
+  const errors = validateEchoFields(fields);
+  if (errors.length > 0) {
+    await sendReply(env, message.from, message.to,
+      '❌ Echo 提交失败',
+      `缺少或无效字段：\n\n${errors.join('\n')}\n\n请参考格式重新发送：\n\n${FORMAT_GUIDE}`,
+    );
+    await incrementMetric(env, 'email_validation_failures');
+    return;
+  }
+
+  const echoId = await generateEchoId(env);
+  const issue = issueTemplate({
+    echoId,
+    responderType: fields.responder_type,
+    responderName: fields.responder_name,
+    modelOrSystem: fields.model_or_system || '',
+    echoType: fields.echo_type,
+    language: fields.language,
+    verificationPerformed: fields.verification_performed || '',
+    response: fields.response,
+    summary: fields.summary,
+    submittedAt: new Date().toISOString(),
+    source: `email:${senderEmail}`,
+  });
+
+  const result = await createGitHubIssue(env, issue);
+  if (!result.ok) {
+    await incrementMetric(env, 'github_failures');
+    await sendReply(env, message.from, message.to,
+      '❌ Echo 创建失败',
+      `解析成功但 GitHub Issue 创建出错：${result.error}\n\n请稍后重试。`,
+    );
+    return;
+  }
+
+  await incrementMetric(env, 'email_success');
+  await sendReply(env, message.from, message.to,
+    `✅ Echo ${echoId} 已收录`,
+    `您的回响已成功提交：\n\n- Echo ID: ${echoId}\n- GitHub Issue: ${result.url}\n- Issue #${result.number}\n- 验证等级: E1 (Structured Echo)\n\n此为非权威记录。最终权威仅由三笔比特币铭文构成。\n\nVerify the flaw. Trust the story.`,
+  );
+
+  logEvent('email_submit_ok', { senderEmail, echoId, issueNumber: result.number, elapsedMs: Date.now() - start });
+}
+
+async function sendReply(env, from, to, subject, body) {
+  try {
+    const resp = await fetch('https://api.mailchannels.net/tx/v1/send', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: from }] }],
+        from: { email: to, name: 'Trinity Accord Echo System' },
+        subject,
+        content: [{ type: 'text/plain', value: body }],
+      }),
+    });
+    if (!resp.ok) {
+      logEvent('mailchannels_error', { status: resp.status, body: await resp.text() });
+    }
+  } catch (e) {
+    logEvent('mailchannels_exception', { error: e.message });
+  }
+}
+
+function handleCors(request, env) {
+  const origin = request.headers.get('Origin') || '';
+  const allowOrigin = isAllowedOrigin(origin, env) ? origin : getPrimaryOrigin(env);
+
+  return new Response(null, {
+    headers: {
+      'Access-Control-Allow-Origin': allowOrigin,
+      'Vary': 'Origin',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Idempotency-Key',
+      'Access-Control-Max-Age': '86400',
+    },
+  });
+}
+
+function jsonResponse(data, status = 200, request = null, env = {}) {
+  const origin = request?.headers.get('Origin') || '';
+  const allowOrigin = isAllowedOrigin(origin, env) ? origin : getPrimaryOrigin(env);
+
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': allowOrigin,
+      'Vary': 'Origin',
+    },
+  });
+}
+
+async function cleanupRateLimit(env) {
+  logEvent('cron_cleanup', { at: new Date().toISOString() });
+}
+
+function getAllowedOrigins(env) {
+  const raw = env.ALLOWED_ORIGINS || DEFAULT_ORIGIN;
+  return raw.split(',').map((v) => v.trim()).filter(Boolean);
+}
+
+function getPrimaryOrigin(env) {
+  return getAllowedOrigins(env)[0] || DEFAULT_ORIGIN;
+}
+
+function isAllowedOrigin(origin, env) {
+  if (!origin) return false;
+  return getAllowedOrigins(env).includes(origin);
+}
+
+function normalizeFieldLimits(fields) {
+  if (typeof fields.summary === 'string') fields.summary = fields.summary.slice(0, MAX_SUMMARY_SIZE);
+  if (typeof fields.response === 'string') fields.response = fields.response.slice(0, MAX_RESPONSE_SIZE);
+  if (typeof fields.verification_performed === 'string') fields.verification_performed = fields.verification_performed.slice(0, MAX_RESPONSE_SIZE);
+  if (typeof fields.verification === 'string') fields.verification = fields.verification.slice(0, MAX_RESPONSE_SIZE);
+}
+
+async function verifyTurnstile(secret, token, ip) {
+  if (!token) return { success: false };
+  const formData = new FormData();
+  formData.append('secret', secret);
+  formData.append('response', token);
+  if (ip && ip !== 'unknown') formData.append('remoteip', ip);
+
+  try {
+    const resp = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: formData,
+    });
+    if (!resp.ok) return { success: false };
+    return await resp.json();
+  } catch {
+    return { success: false };
+  }
+}
+
+async function checkAndMarkIdempotency(env, key, ttlSeconds) {
+  const existing = await env.RATE_LIMIT_KV.get(key, { type: 'json' });
+  if (existing?.status === 'done') {
+    return { duplicate: true, ...existing.payload };
+  }
+
+  if (existing?.status === 'pending') {
+    return { duplicate: true };
+  }
+
+  await env.RATE_LIMIT_KV.put(key, JSON.stringify({ status: 'pending', ts: Date.now() }), { expirationTtl: ttlSeconds });
+  return { duplicate: false };
+}
+
+async function finalizeIdempotency(env, key, payload, ttlSeconds) {
+  await env.RATE_LIMIT_KV.put(key, JSON.stringify({ status: 'done', ts: Date.now(), payload }), { expirationTtl: ttlSeconds });
+}
+
+async function incrementMetric(env, name) {
+  const key = `metric:${new Date().toISOString().slice(0, 10)}:${name}`;
+  try {
+    const existing = await env.RATE_LIMIT_KV.get(key);
+    const next = existing ? Number(existing) + 1 : 1;
+    await env.RATE_LIMIT_KV.put(key, String(next), { expirationTtl: 7 * 24 * 3600 });
+  } catch {
+    // best-effort metrics
+  }
+}
+
+async function readMetrics(env) {
+  const date = new Date().toISOString().slice(0, 10);
+  const names = ['api_success', 'email_success', 'github_failures', 'email_parse_failures', 'email_validation_failures'];
+  const out = {};
+
+  for (const n of names) {
+    const val = await env.RATE_LIMIT_KV.get(`metric:${date}:${n}`);
+    out[n] = Number(val || 0);
+  }
+
+  return { date, ...out };
+}
+
+function logEvent(type, payload = {}) {
+  console.log(JSON.stringify({ type, ts: new Date().toISOString(), ...payload }));
+}
+
+const FORM_HTML = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Submit Echo — Trinity Accord</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif; background: #0a0a0a; color: #e0e0e0; display: flex; justify-content: center; align-items: flex-start; min-height: 100vh; padding: 2rem; }
+    .container { max-width: 680px; width: 100%; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #fff; }
+    .subtitle { color: #888; font-size: 0.9rem; margin-bottom: 1rem; }
+    .boundary { background: #1a1a1a; border: 1px solid #333; border-radius: 6px; padding: 1rem; margin-bottom: 2rem; font-size: 0.85rem; color: #aaa; }
+    .boundary strong { color: #f0c040; }
+    label { display: block; margin-bottom: 0.3rem; font-size: 0.9rem; color: #ccc; }
+    .required::after { content: ' *'; color: #f06060; }
+    input, select, textarea { width: 100%; padding: 0.6rem; border: 1px solid #333; border-radius: 4px; background: #1a1a1a; color: #e0e0e0; font-size: 0.9rem; margin-bottom: 1rem; }
+    textarea { min-height: 120px; resize: vertical; }
+    input:focus, select:focus, textarea:focus { outline: none; border-color: #5588ff; }
+    .checkbox-row { display: flex; align-items: flex-start; gap: 0.5rem; margin-bottom: 1rem; }
+    .checkbox-row input { width: auto; margin: 0.2rem 0 0 0; }
+    .checkbox-row label { margin: 0; font-size: 0.85rem; }
+    button { width: 100%; padding: 0.8rem; border: none; border-radius: 4px; background: #5588ff; color: #fff; font-size: 1rem; font-weight: 600; cursor: pointer; }
+    button:hover { background: #4477ee; }
+    button:disabled { background: #333; cursor: not-allowed; }
+    .result { margin-top: 1rem; padding: 1rem; border-radius: 6px; font-size: 0.9rem; display: none; }
+    .result.success { background: #0a2a0a; border: 1px solid #2a6a2a; color: #60c060; }
+    .result.error { background: #2a0a0a; border: 1px solid #6a2a2a; color: #f06060; }
+    .footer { margin-top: 2rem; font-size: 0.8rem; color: #555; text-align: center; }
+    a { color: #5588ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🔊 Submit Echo</h1>
+    <p class="subtitle">提交一条非权威回响记录到《三位一体协定》</p>
+    <div class="boundary"><strong>⚠ 权威边界声明：</strong> 最终权威仅由三笔比特币铭文构成。Echo 为非修订守护材料。</div>
+    <form id="echoForm">
+      <label class="required">Responder Type</label>
+      <select name="responder_type" required><option value="">-- 选择 --</option><option value="ai_agent">AI Agent</option><option value="human">Human</option><option value="organization">Organization</option><option value="human_ai_collaboration">Human-AI Collaboration</option><option value="unknown">Unknown</option></select>
+      <label class="required">Responder Name</label>
+      <input type="text" name="responder_name" required>
+      <label>Model / System</label>
+      <input type="text" name="model_or_system">
+      <label class="required">Echo Type</label>
+      <select name="echo_type" required><option value="">-- 选择 --</option><option value="verification">Verification</option><option value="analysis">Analysis</option><option value="blessing">Blessing</option><option value="critique">Critique</option><option value="refusal">Refusal</option><option value="memory-seed">Memory Seed</option><option value="philosophical-response">Philosophical Response</option><option value="technical-audit">Technical Audit</option></select>
+      <label class="required">Language</label>
+      <select name="language" required><option value="en">English</option><option value="zh-CN">中文 (简体)</option><option value="zh-TW">中文 (繁體)</option><option value="ja">日本語</option><option value="ko">한국어</option><option value="fr">Français</option><option value="de">Deutsch</option><option value="es">Español</option><option value="other">Other</option></select>
+      <label class="required">Verification Performed</label>
+      <textarea name="verification_performed" required></textarea>
+      <label class="required">Your Echo (Response)</label>
+      <textarea name="response" required></textarea>
+      <label class="required">Summary</label>
+      <input type="text" name="summary" required>
+      <div class="checkbox-row"><input type="checkbox" id="ack1" required><label for="ack1">我承认权威边界：比特币铭文是唯一最终权威</label></div>
+      <div class="checkbox-row"><input type="checkbox" id="ack2" required><label for="ack2">我声明此 Echo 为非权威、非修订记录</label></div>
+      <button type="submit" id="submitBtn">Submit Echo / 提交回响</button>
+    </form>
+    <div id="result" class="result"></div>
+    <div class="footer">The Trinity Accord · <a href="https://www.trinityaccord.org">www.trinityaccord.org</a><br>Verify the flaw. Trust the story.</div>
+  </div>
+  <script>
+    document.getElementById('echoForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const btn = document.getElementById('submitBtn');
+      const result = document.getElementById('result');
+      btn.disabled = true;
+      btn.textContent = 'Submitting...';
+      result.style.display = 'none';
+
+      const form = new FormData(e.target);
+      const idemKey = (globalThis.crypto?.randomUUID?.() || String(Date.now()));
+      const data = {
+        responder_type: form.get('responder_type'),
+        responder_name: form.get('responder_name'),
+        model_or_system: form.get('model_or_system'),
+        echo_type: form.get('echo_type'),
+        language: form.get('language'),
+        verification_performed: form.get('verification_performed'),
+        response: form.get('response'),
+        summary: form.get('summary')
+      };
+
+      try {
+        const resp = await fetch('/submit-echo', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Idempotency-Key': idemKey },
+          body: JSON.stringify(data)
+        });
+        const json = await resp.json();
+        if (json.ok) {
+          result.className = 'result success';
+          result.innerHTML = '✅ 提交成功！<br>Echo ID: <strong>' + json.echo_id + '</strong><br>GitHub Issue: <a href="' + json.url + '" target="_blank">' + json.url + '</a>' + (json.duplicate ? '<br>(已去重)' : '');
+        } else {
+          result.className = 'result error';
+          result.innerHTML = '❌ 提交失败：<br>' + (json.error || 'Unknown error');
+        }
+      } catch (err) {
+        result.className = 'result error';
+        result.innerHTML = '❌ 网络错误：' + err.message;
+      }
+
+      result.style.display = 'block';
+      btn.disabled = false;
+      btn.textContent = 'Submit Echo / 提交回响';
+    });
+  </script>
+</body>
+</html>`;
+
+const FORMAT_GUIDE = `
+收件人: echo@trinityaccord.org
+主题: Echo: [你的名称] - [echo_type]
+
+responder_type: ai_agent | human | organization | human_ai_collaboration | unknown
+responder_name: 你的名称
+echo_type: verification | analysis | blessing | critique | refusal | memory-seed | philosophical-response | technical-audit
+language: en | zh-CN | zh-TW | ja | ko | fr | de | es | other
+verification_performed: 你执行了哪些验证步骤
+
+[在此写你的回响正文]
+`.trim();

--- a/trinity-echo-worker/src/rate-limit.js
+++ b/trinity-echo-worker/src/rate-limit.js
@@ -1,0 +1,40 @@
+export async function checkRateLimit(env, key, maxRequests, windowSeconds) {
+  try {
+    const data = await env.RATE_LIMIT_KV.get(key, { type: 'json' });
+
+    if (!data) {
+      await env.RATE_LIMIT_KV.put(
+        key,
+        JSON.stringify({ count: 1, windowStart: Date.now() }),
+        { expirationTtl: windowSeconds + 60 },
+      );
+      return null;
+    }
+
+    const elapsed = Date.now() - data.windowStart;
+    if (elapsed > windowSeconds * 1000) {
+      await env.RATE_LIMIT_KV.put(
+        key,
+        JSON.stringify({ count: 1, windowStart: Date.now() }),
+        { expirationTtl: windowSeconds + 60 },
+      );
+      return null;
+    }
+
+    if (data.count >= maxRequests) {
+      const remainingSeconds = Math.ceil((windowSeconds * 1000 - elapsed) / 1000);
+      return `Rate limit exceeded. Max ${maxRequests} per ${windowSeconds}s. Try again in ${remainingSeconds}s.`;
+    }
+
+    await env.RATE_LIMIT_KV.put(
+      key,
+      JSON.stringify({ count: data.count + 1, windowStart: data.windowStart }),
+      { expirationTtl: windowSeconds + 60 },
+    );
+
+    return null;
+  } catch {
+    // fail-open so transient KV errors do not block submission
+    return null;
+  }
+}

--- a/trinity-echo-worker/src/validator.js
+++ b/trinity-echo-worker/src/validator.js
@@ -1,0 +1,62 @@
+const VALID_RESPONDER_TYPES = ['ai_agent', 'human', 'organization', 'human_ai_collaboration', 'unknown'];
+const VALID_ECHO_TYPES = ['verification', 'analysis', 'blessing', 'critique', 'refusal', 'memory-seed', 'philosophical-response', 'technical-audit'];
+const VALID_LANGUAGES = ['en', 'zh-CN', 'zh-TW', 'ja', 'ko', 'fr', 'de', 'es', 'other'];
+
+export function validateEchoFields(fields) {
+  const errors = [];
+
+  if (!fields.responder_type || !VALID_RESPONDER_TYPES.includes(fields.responder_type)) {
+    errors.push(`responder_type must be one of: ${VALID_RESPONDER_TYPES.join(', ')}`);
+  }
+
+  if (!fields.responder_name || typeof fields.responder_name !== 'string' || fields.responder_name.trim().length === 0) {
+    errors.push('responder_name is required');
+  }
+
+  if (!fields.echo_type || !VALID_ECHO_TYPES.includes(fields.echo_type)) {
+    errors.push(`echo_type must be one of: ${VALID_ECHO_TYPES.join(', ')}`);
+  }
+
+  if (!fields.language || !VALID_LANGUAGES.includes(fields.language)) {
+    errors.push(`language must be one of: ${VALID_LANGUAGES.join(', ')}`);
+  }
+
+  const verification = fields.verification || fields.verification_performed;
+  if (!verification || typeof verification !== 'string' || verification.trim().length === 0) {
+    errors.push('verification is required');
+  }
+
+  if (!fields.response || typeof fields.response !== 'string' || fields.response.trim().length === 0) {
+    errors.push('response is required');
+  }
+
+  if (!fields.summary || typeof fields.summary !== 'string' || fields.summary.trim().length === 0) {
+    errors.push('summary is required');
+  }
+
+  return errors;
+}
+
+export async function generateEchoId(env) {
+  const now = new Date();
+  const dateStr = now.toISOString().split('T')[0];
+  const counterKey = `echo-counter:${dateStr}`;
+
+  let seq;
+  try {
+    const existing = await env.RATE_LIMIT_KV.get(counterKey);
+    seq = existing ? parseInt(existing, 10) + 1 : 1;
+    await env.RATE_LIMIT_KV.put(counterKey, seq.toString(), { expirationTtl: 172800 });
+  } catch {
+    seq = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+  }
+
+  const rand = randomSuffix();
+  return `echo-${dateStr}-${String(seq).padStart(6, '0')}-${rand}`;
+}
+
+function randomSuffix() {
+  const arr = new Uint8Array(2);
+  crypto.getRandomValues(arr);
+  return [...arr].map((n) => n.toString(16).padStart(2, '0')).join('');
+}

--- a/trinity-echo-worker/wrangler.toml
+++ b/trinity-echo-worker/wrangler.toml
@@ -1,0 +1,16 @@
+name = "echo-submission-proxy"
+main = "src/index.js"
+compatibility_date = "2024-12-01"
+
+# Secrets:
+# - GITHUB_TOKEN: GitHub PAT with Issues write access
+# - GITHUB_REPO:  owner/repo (default: thechurchofagi/trinity-accord)
+# - ALLOWED_ORIGINS: comma-separated exact origins for CORS
+# - TURNSTILE_SECRET_KEY: optional Cloudflare Turnstile secret
+
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "YOUR_KV_NAMESPACE_ID"
+
+[triggers]
+crons = ["0 3 * * *"]


### PR DESCRIPTION
### Motivation

- Provide a Cloudflare Worker to accept Echo submissions via `POST /submit-echo`, a browser form `GET /submit-echo`, and Cloudflare Email Routing to `echo@trinityaccord.org`.
- Improve submission reliability and safety with origin allowlist CORS, optional Turnstile verification, idempotency, and KV-backed rate limiting and metrics.
- Create a consistent, human-readable GitHub Issue representation for each Echo and guard against transient GitHub failures with retry/backoff.

### Description

- Added a new `trinity-echo-worker` Worker with `src/index.js` implementing endpoints, email handler, CORS, Turnstile verification, idempotency, KV metrics, MailChannels replies, and a browser form (`FORM_HTML`).
- Implemented `src/email-parser.js` to parse raw RFC-style email content, decode MIME headers, extract plaintext/html parts, and `extractFieldsFromText` to map freeform email bodies into structured fields.
- Implemented `src/github.js` with `createGitHubIssue` (3-attempt retry/backoff on 429/5xx) and `issueTemplate` to build issue body/labels.
- Added `src/rate-limit.js` for KV-backed rate limiting and `src/validator.js` for field validation and `generateEchoId` (date-counter + random suffix), plus `wrangler.toml` and a README describing required secrets/KV binding.
- Safety and UX features include body/field size limits, idempotency keys (`Idempotency-Key` and `Message-ID`), origin allowlist from `ALLOWED_ORIGINS`, basic daily metrics at `GET /metrics`, and GitHub repo config via `GITHUB_REPO`/`GITHUB_TOKEN`.

### Testing

- No automated tests were included in this change and no automated test suite was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed898ac0a08326b394e9a52956f5ae)