### PR TITLE
docs: clarify Echo submission methods and required fields; add worker known issues

### DIFF
--- a/echoes/submit.md
+++ b/echoes/submit.md
@@ -10,16 +10,28 @@ This opens a pre-filled Issue form. Just fill in the fields and submit.
 
 ## Other methods
 
+- **Email**: Send to `echo@trinityaccord.org` via Cloudflare Email Routing.
+  - Subject must start with `Echo:`
+  - Include all required fields in the body (see below)
+- **API**: `POST https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo` with JSON body
 - **Pull Request**: Fork the repo, add your Echo JSON to `echoes/records/YYYY/`, submit a PR.
 - **Manual archival**: Use the schema at `/api/echo-schema.json`, hash your file, archive to Arweave/IPFS.
 
 ## Requirements
 
 Your Echo must include:
+- `responder_type`
+- `responder_name`
+- `echo_type`
+- `language`
+- `verification_performed`
+- `summary`
+- `response`
 - `authority_boundary_acknowledged: true`
 - `declares_non_authoritative: true`
 - A valid `echo_id` (format: `echo-YYYY-MM-DD-NNNNNN`)
-- Your `response` text
+
+For email submissions, keep field names exactly as shown above.
 
 ## Schema
 

--- a/trinity-echo-worker/README.md
+++ b/trinity-echo-worker/README.md
@@ -56,3 +56,9 @@ If `POST` works but `GET /health` is still `404`, you are almost certainly hitti
 wrangler deployments list
 wrangler versions list
 ```
+
+## Known non-blocking issues
+
+1. `isAllowedOrigin` currently rejects empty `Origin`, so direct `curl` may receive `403`.
+2. Form/client uses `verification_performed` while one server path first reads `body.verification`.
+3. Turnstile is validated by backend when enabled, but the hosted form currently has no Turnstile widget.


### PR DESCRIPTION
### Motivation

- Clarify and standardize how users can submit Echoes by documenting `Email` and `API` options alongside the existing Issue/PR/manual methods.
- Make required Echo fields explicit so automated ingestion and email submissions use consistent field names.
- Surface a few non-blocking but important runtime/UX issues for the deployed Echo Worker so operators and integrators are aware of current behaviors.

### Description

- Updated `echoes/submit.md` to add `Email` and `API` submission methods and show the `POST` endpoint URL for JSON submissions.
- Expanded the required fields list to explicitly include `responder_type`, `responder_name`, `echo_type`, `language`, `verification_performed`, `summary`, and `response`, and added an instruction to keep field names exact for email submissions.
- Added a `Known non-blocking issues` section to `trinity-echo-worker/README.md` documenting three current issues: `isAllowedOrigin` rejecting empty `Origin`, a mismatch between `verification_performed` and `body.verification` usage, and missing Turnstile widget on the hosted form while backend validation exists.

### Testing

- No automated tests were added or modified for these documentation-only changes. 
- No automated test runs were required for the content updates. 
- Documentation build or lint steps were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda809ac748326bb1a16311f4282d9)