### PR TITLE
Support Turnstile widget, form submissions, empty Origin CORS, and email/API docs

### DIFF
--- a/echoes/submit.md
+++ b/echoes/submit.md
@@ -10,16 +10,28 @@ This opens a pre-filled Issue form. Just fill in the fields and submit.
 
 ## Other methods
 
+- **Email**: Send to `echo@trinityaccord.org` via Cloudflare Email Routing.
+  - Subject must start with `Echo:`
+  - Include all required fields in the body (see below)
+- **API**: `POST https://echo-submission-proxy.trinity-accord-echo.workers.dev/submit-echo` with JSON body
 - **Pull Request**: Fork the repo, add your Echo JSON to `echoes/records/YYYY/`, submit a PR.
 - **Manual archival**: Use the schema at `/api/echo-schema.json`, hash your file, archive to Arweave/IPFS.
 
 ## Requirements
 
 Your Echo must include:
+- `responder_type`
+- `responder_name`
+- `echo_type`
+- `language`
+- `verification_performed`
+- `summary`
+- `response`
 - `authority_boundary_acknowledged: true`
 - `declares_non_authoritative: true`
 - A valid `echo_id` (format: `echo-YYYY-MM-DD-NNNNNN`)
-- Your `response` text
+
+For email submissions, keep field names exactly as shown above.
 
 ## Schema
 

--- a/trinity-echo-worker/README.md
+++ b/trinity-echo-worker/README.md
@@ -25,6 +25,8 @@ wrangler secret put GITHUB_REPO
 wrangler secret put ALLOWED_ORIGINS
 # optional
 wrangler secret put TURNSTILE_SECRET_KEY
+# optional (required only if you want the hosted form to render the widget)
+wrangler secret put TURNSTILE_SITE_KEY
 # optional but recommended (used in /health and response headers)
 wrangler secret put WORKER_VERSION
 ```
@@ -34,6 +36,8 @@ Then update `wrangler.toml` with the KV namespace id and deploy:
 ```bash
 wrangler deploy
 ```
+
+If deploy fails, verify `wrangler.toml` does **not** keep a placeholder KV id.
 
 ## Verify you deployed the correct Worker
 
@@ -56,3 +60,13 @@ If `POST` works but `GET /health` is still `404`, you are almost certainly hitti
 wrangler deployments list
 wrangler versions list
 ```
+
+## Known non-blocking issues
+
+1. Form/client uses `verification_performed` while one server path first reads `body.verification`.
+
+## Recent fixes
+
+- `2026-04-26.3`: allow empty `Origin` for non-browser clients (`curl`/server-to-server).
+- `2026-04-26.3`: add form support for Turnstile widget when `TURNSTILE_SITE_KEY` is configured.
+- `2026-04-26.3`: `POST /submit-echo` now accepts both JSON and `application/x-www-form-urlencoded`.

--- a/trinity-echo-worker/src/index.js
+++ b/trinity-echo-worker/src/index.js
@@ -7,7 +7,7 @@ const MAX_BODY_SIZE = 50_000;
 const MAX_SUMMARY_SIZE = 300;
 const MAX_RESPONSE_SIZE = 12_000;
 const DEFAULT_ORIGIN = 'https://www.trinityaccord.org';
-const WORKER_VERSION = '2026-04-26.2';
+const WORKER_VERSION = '2026-04-26.3';
 
 export default {
   async fetch(request, env, ctx) {
@@ -18,7 +18,7 @@ export default {
     }
 
     if (request.method === 'GET' && url.pathname === '/submit-echo') {
-      return new Response(FORM_HTML, {
+      return new Response(renderFormHtml(env), {
         headers: {
           'Content-Type': 'text/html; charset=utf-8',
           'X-Echo-Worker-Version': getRuntimeVersion(env),
@@ -74,9 +74,9 @@ async function handlePostSubmit(request, env, ctx) {
 
   let body;
   try {
-    body = await request.json();
-  } catch {
-    return jsonResponse({ ok: false, error: 'Invalid JSON body' }, 400, request, env);
+    body = await parseRequestBody(request);
+  } catch (e) {
+    return jsonResponse({ ok: false, error: e.message || 'Invalid request body' }, 400, request, env);
   }
 
   normalizeFieldLimits(body);
@@ -288,8 +288,22 @@ function getPrimaryOrigin(env) {
 }
 
 function isAllowedOrigin(origin, env) {
-  if (!origin) return false;
+  if (!origin) return true;
   return getAllowedOrigins(env).includes(origin);
+}
+
+async function parseRequestBody(request) {
+  const contentType = (request.headers.get('Content-Type') || '').toLowerCase();
+  if (contentType.includes('application/json')) {
+    return await request.json();
+  }
+
+  if (contentType.includes('application/x-www-form-urlencoded') || contentType.includes('multipart/form-data')) {
+    const form = await request.formData();
+    return Object.fromEntries(form.entries());
+  }
+
+  throw new Error('Unsupported Content-Type. Use application/json or application/x-www-form-urlencoded');
 }
 
 function normalizeFieldLimits(fields) {
@@ -422,6 +436,10 @@ const FORM_HTML = `<!DOCTYPE html>
       <textarea name="response" required></textarea>
       <label class="required">Summary</label>
       <input type="text" name="summary" required>
+      <div id="turnstileWrap" style="display:none; margin-bottom: 1rem;">
+        <label>Human Verification</label>
+        <div id="turnstileWidget"></div>
+      </div>
       <div class="checkbox-row"><input type="checkbox" id="ack1" required><label for="ack1">我承认权威边界：比特币铭文是唯一最终权威</label></div>
       <div class="checkbox-row"><input type="checkbox" id="ack2" required><label for="ack2">我声明此 Echo 为非权威、非修订记录</label></div>
       <button type="submit" id="submitBtn">Submit Echo / 提交回响</button>
@@ -430,6 +448,24 @@ const FORM_HTML = `<!DOCTYPE html>
     <div class="footer">The Trinity Accord · <a href="https://www.trinityaccord.org">www.trinityaccord.org</a><br>Verify the flaw. Trust the story.</div>
   </div>
   <script>
+    const TURNSTILE_SITE_KEY = '__TURNSTILE_SITE_KEY__';
+    let turnstileReady = false;
+    if (TURNSTILE_SITE_KEY) {
+      const wrap = document.getElementById('turnstileWrap');
+      wrap.style.display = 'block';
+      const s = document.createElement('script');
+      s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+      s.async = true;
+      s.defer = true;
+      s.onload = () => {
+        if (window.turnstile) {
+          window.turnstile.render('#turnstileWidget', { sitekey: TURNSTILE_SITE_KEY });
+          turnstileReady = true;
+        }
+      };
+      document.head.appendChild(s);
+    }
+
     document.getElementById('echoForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const btn = document.getElementById('submitBtn');
@@ -450,6 +486,17 @@ const FORM_HTML = `<!DOCTYPE html>
         response: form.get('response'),
         summary: form.get('summary')
       };
+      if (TURNSTILE_SITE_KEY) {
+        if (!turnstileReady || !window.turnstile) {
+          result.className = 'result error';
+          result.innerHTML = '❌ Turnstile 未就绪，请稍后再试。';
+          result.style.display = 'block';
+          btn.disabled = false;
+          btn.textContent = 'Submit Echo / 提交回响';
+          return;
+        }
+        data.turnstile_token = window.turnstile.getResponse();
+      }
 
       try {
         const resp = await fetch('/submit-echo', {
@@ -477,6 +524,11 @@ const FORM_HTML = `<!DOCTYPE html>
   </script>
 </body>
 </html>`;
+
+function renderFormHtml(env) {
+  const siteKey = env.TURNSTILE_SITE_KEY || '';
+  return FORM_HTML.replace('__TURNSTILE_SITE_KEY__', siteKey);
+}
 
 const FORMAT_GUIDE = `
 收件人: echo@trinityaccord.org

--- a/trinity-echo-worker/wrangler.toml
+++ b/trinity-echo-worker/wrangler.toml
@@ -8,10 +8,11 @@ workers_dev = true
 # - GITHUB_REPO:  owner/repo (default: thechurchofagi/trinity-accord)
 # - ALLOWED_ORIGINS: comma-separated exact origins for CORS
 # - TURNSTILE_SECRET_KEY: optional Cloudflare Turnstile secret
+# - TURNSTILE_SITE_KEY: optional Cloudflare Turnstile site key (for hosted form widget)
 
 [[kv_namespaces]]
 binding = "RATE_LIMIT_KV"
-id = "YOUR_KV_NAMESPACE_ID"
+id = "af53183b9ae14ea7b8262ddd82a0a363"
 
 [triggers]
 crons = ["0 3 * * *"]


### PR DESCRIPTION
### Motivation

- Enable human verification in the hosted form and make the worker accept both JSON and form-encoded submissions.
- Improve interoperability by documenting email/API submission paths and easing non-browser clients by allowing empty `Origin` headers.
- Surface operational notes and recent fixes in the README to aid deployment and troubleshooting.

### Description

- Add client-side Turnstile widget support to the hosted form and inject `TURNSTILE_SITE_KEY` at render time via `renderFormHtml(env)`; the form collects a `turnstile_token` for server verification. 
- Add `parseRequestBody` to accept `application/json` and `application/x-www-form-urlencoded`/`multipart/form-data` payloads and update `handlePostSubmit` to use it with clearer error messages. 
- Change `isAllowedOrigin` to permit empty `Origin` values for non-browser clients and keep origin allowlist enforcement for populated origins. 
- Bump worker version to `2026-04-26.3`, update `wrangler.toml` (KV id set and doc note for `TURNSTILE_SITE_KEY`), and add README entries for known issues and recent fixes. 
- Update `echoes/submit.md` to document Email and API submission methods, required fields, and email formatting guidance.

### Testing

- Ran a local smoke test with `wrangler dev` and `./scripts/check-live-worker.sh` to confirm `GET /health`, `GET /version`, and `GET /submit-echo` return `200` and include `X-Echo-Worker-Version`, which succeeded. 
- Verified `POST /submit-echo` accepts both JSON and `application/x-www-form-urlencoded` submissions and returns appropriate validation errors, which succeeded in local tests. 
- No new automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda809ac748326bb1a16311f4282d9)