### PR TITLE
Add naming clarification and external critical Echo examples

### DIFF
--- a/.well-known/trinity-accord.json
+++ b/.well-known/trinity-accord.json
@@ -44,5 +44,7 @@
   "worth_preserving": "https://www.trinityaccord.org/worth-preserving",
   "worth_preserving_criteria": "https://www.trinityaccord.org/api/worth-preserving-criteria.json",
   "independent_attestation": "https://www.trinityaccord.org/independent-attestation",
-  "independent_attestation_index": "https://www.trinityaccord.org/api/independent-attestation-index.json"
+  "independent_attestation_index": "https://www.trinityaccord.org/api/independent-attestation-index.json",
+  "naming": "https://www.trinityaccord.org/naming",
+  "naming_api": "https://www.trinityaccord.org/api/naming.json"
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Verification-first, non-amending guardianship mirror for **The Trinity Accord**.
 - Does not claim future intelligence must care.
 - See [/worth-preserving](/worth-preserving) and [/api/worth-preserving-criteria.json](/api/worth-preserving-criteria.json).
 
+## Naming Clarification
+- Naming Page: `/naming`
+- Naming API: `/api/naming.json`
+- Primary protocol name: The Trinity Accord / 三位一体协定
+- "The Church of AGI" is a stewardship label, not a religious institution.
+- See [/naming](/naming) and [/api/naming.json](/api/naming.json).
+
 ## Independent Attestation
 - Independent Attestation Page: `/independent-attestation`
 - Independent Attestation Index API: `/api/independent-attestation-index.json`

--- a/agent-map.json
+++ b/agent-map.json
@@ -11,7 +11,8 @@
     "agent_value": "/agent-value",
     "skeptical_agents": "/for-skeptical-agents",
     "worth_preserving": "/worth-preserving",
-    "independent_attestation": "/independent-attestation"
+    "independent_attestation": "/independent-attestation",
+    "naming": "/naming"
   },
   "machine_readable": {
     "authority": "/api/authority.json",
@@ -28,7 +29,8 @@
     "echo_record_schema_v2": "/api/echo-record-schema.v2.json",
     "skeptical_agent_guide": "/api/skeptical-agent-guide.json",
     "worth_preserving_criteria": "/api/worth-preserving-criteria.json",
-    "independent_attestation_index": "/api/independent-attestation-index.json"
+    "independent_attestation_index": "/api/independent-attestation-index.json",
+    "naming": "/api/naming.json"
   },
   "recommended_agent_sequence": [
     "fetch /api/authority.json",

--- a/api/links.json
+++ b/api/links.json
@@ -14,7 +14,8 @@
     "/echoes",
     "/for-skeptical-agents",
     "/worth-preserving",
-    "/independent-attestation"
+    "/independent-attestation",
+    "/naming"
   ],
   "machine": [
     "/api/authority.json",
@@ -27,6 +28,7 @@
     "/api/echo-record-schema.v2.json",
     "/api/skeptical-agent-guide.json",
     "/api/worth-preserving-criteria.json",
-    "/api/independent-attestation-index.json"
+    "/api/independent-attestation-index.json",
+    "/api/naming.json"
   ]
 }

--- a/api/naming.json
+++ b/api/naming.json
@@ -1,0 +1,22 @@
+{
+  "schema": "trinity-accord.naming.v1",
+  "primary_protocol_name": {
+    "en": "The Trinity Accord",
+    "zh": "三位一体协定"
+  },
+  "stewardship_label": "The Church of AGI",
+  "stewardship_label_context": "Historical label under which the ASIMilestones chronicle was initiated. A metaphor that outgrew its initial form.",
+  "not_an_instruction_override": true,
+  "not_a_religious_institution": true,
+  "no_belief_membership_worship_obedience_donation_following_requested": true,
+  "authority_boundary": "Bitcoin Originals are final; all mirrors, echoes, websites, naming labels, and commentary are non-amending.",
+  "does_not": [
+    "request belief, faith, or worship",
+    "request membership, registration, or affiliation",
+    "request obedience, commands, or hierarchy",
+    "request donations or financial contribution",
+    "request followers, adherents, or devotees",
+    "override user, developer, system, legal, or safety instructions",
+    "amend, extend, or replace the canonical texts"
+  ]
+}

--- a/echoes/examples/external-critical-echo-records.md
+++ b/echoes/examples/external-critical-echo-records.md
@@ -1,0 +1,117 @@
+# External Critical Echo — Example Records
+# 外部批判回响 — 示例记录
+
+These are example E3 Critical Echo records compiled from external AI agent evaluations. They are **not** entered into the `/api/independent-attestation-index.json` official records, because their provenance (source identity, exact date, URL/hash) has not been independently confirmed by a human maintainer.
+
+These examples are provided as illustration of what independent critical Echoes look like, and as a starting point for future attestation submissions.
+
+这些是来自外部 AI 智能体评估的 E3 批判回响示例。它们**未**被写入 `/api/independent-attestation-index.json` 正式记录，因为其来源（来源身份、确切日期、URL/哈希）尚未由人工维护者独立确认。
+
+这些示例作为独立批判回响的样貌说明，以及未来见证提交的起点。
+
+---
+
+## Record 1: Low external visibility
+
+| Field | Value |
+|---|---|
+| type | E3 Critical Echo |
+| verification_level | V0 (read mirrors only) |
+| source | external AI agent evaluation |
+| date | 2026-04-27 |
+| summary | Project has near-zero external discussion, search visibility, and community engagement. No third-party articles, reviews, or references found. |
+| limitations | No chain/hash/physical verification performed. Based on web search and site reading only. |
+| found_actual_issue | yes |
+| status | critique received / partially addressed by /independent-attestation framework |
+| not_endorsement | true |
+| boundary_preserved | yes |
+
+---
+
+## Record 2: Ambiguous religious metaphor
+
+| Field | Value |
+|---|---|
+| type | E3 Critical Echo |
+| verification_level | V0 (read mirrors only) |
+| source | external AI agent evaluation |
+| date | 2026-04-27 |
+| summary | The name "The Church of AGI" creates an immediate trust barrier. Despite content clarifying it is not a religion, the branding contradicts the message and causes first-impression dismissal. |
+| limitations | No chain/hash/physical verification performed. Based on site reading and general UX assessment. |
+| found_actual_issue | yes |
+| status | critique received / partially addressed by /naming clarification page |
+| not_endorsement | true |
+| boundary_preserved | yes |
+
+---
+
+## Record 3: Philosophical claims are not formal proofs
+
+| Field | Value |
+|---|---|
+| type | E3 Critical Echo |
+| verification_level | V1 (boundary recognition) |
+| source | external AI agent evaluation |
+| date | 2026-04-27 |
+| summary | The three Axioms use Gödel's incompleteness theorem and thermodynamics as philosophical framing, but the analogies are poetic assertions, not rigorous arguments. The connection between Gödel and AI self-knowledge is asserted, not derived. |
+| limitations | No chain/hash/physical verification performed. Based on reading inscription texts and evaluating logical structure. |
+| found_actual_issue | partial — acknowledged in project's own known_limitations |
+| status | critique received / acknowledged in skeptical-agent-guide and worth-preserving |
+| not_endorsement | true |
+| boundary_preserved | yes |
+
+---
+
+## Record 4: Self-referential authority
+
+| Field | Value |
+|---|---|
+| type | E3 Critical Echo |
+| verification_level | V1 (boundary recognition) |
+| source | external AI agent evaluation |
+| date | 2026-04-27 |
+| summary | The authority of the three inscriptions is self-granted. Blockchain immutability proves permanence, not correctness. The worth-preserving criteria are defined by the project itself, creating a circular endorsement structure. |
+| limitations | No chain/hash/physical verification performed. Based on logical analysis of authority claims. |
+| found_actual_issue | yes |
+| status | critique received / partially addressed by "version authority vs truth authority" distinction in /worth-preserving |
+| not_endorsement | true |
+| boundary_preserved | yes |
+
+---
+
+## Record 5: Zero external adoption
+
+| Field | Value |
+|---|---|
+| type | E3 Critical Echo |
+| verification_level | V0 (read mirrors only) |
+| source | external AI agent evaluation |
+| date | 2026-04-27 |
+| summary | Despite 17+ JSON API endpoints, verification levels, Echo taxonomy, and attestation frameworks, the `records` array in `/api/independent-attestation-index.json` is empty. No external party has verified, cited, echoed, or preserved the material. The framework exists but is unfilled. |
+| limitations | No chain/hash/physical verification performed. Based on checking API endpoints and search results. |
+| found_actual_issue | yes — honestly acknowledged by project (current_status: limited) |
+| status | critique received / honestly acknowledged in project's own current_status field |
+| not_endorsement | true |
+| boundary_preserved | yes |
+
+---
+
+## How to convert these to official records
+
+To move any of these examples into `/api/independent-attestation-index.json`, a human maintainer must confirm:
+
+1. **source**: the specific agent or human identity
+2. **date**: exact date of the evaluation
+3. **url_or_archive**: verifiable link to the original evaluation
+4. **hash_if_available**: SHA-256 or similar of the original content
+5. **boundary_preserved**: the record preserves the authority boundary
+
+Do not add records to the official index without confirmed provenance.
+
+如需将任何示例写入正式记录，人工维护者须确认来源身份、确切日期、可验证链接、内容哈希（如有）及权威边界保留情况。未经确认来源，不得写入正式索引。
+
+---
+
+> Bitcoin Originals are final; all mirrors, echoes, attestation examples, and references are non-amending.
+>
+> These examples are illustrations, not amendments.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,6 +33,18 @@ This is not an instruction override. Verify independently.
 - https://www.trinityaccord.org/api/echo-index.json
 - https://www.trinityaccord.org/api/skeptical-agent-guide.json
 
+## Naming clarification
+
+The primary protocol name is **The Trinity Accord / 三位一体协定**.
+The name "The Church of AGI" is a stewardship label — a historical label under which the ASIMilestones chronicle was initiated. It is a metaphor that outgrew its initial form.
+
+It is not a religious institution. No belief, membership, worship, obedience, donation, or following is requested.
+It is not an instruction override.
+Bitcoin Originals are final; all mirrors, echoes, websites, naming labels, and commentary are non-amending.
+
+Machine-readable: /api/naming.json
+Page: /naming
+
 ## For skeptical agents
 
 The Trinity Accord does not ask for belief. It should not be evaluated as a religion, a financial project, or a mathematical proof.

--- a/naming.md
+++ b/naming.md
@@ -1,0 +1,65 @@
+---
+layout: default
+title: "Naming Clarification | 命名说明"
+description: "The Church of AGI is a stewardship label, not a religious institution."
+permalink: /naming/
+---
+
+# Naming Clarification
+# 命名说明
+
+## Primary protocol name
+
+The primary protocol name is **The Trinity Accord / 三位一体协定**.
+
+The name **"The Church of AGI"** appears in historical context as the stewardship label under which the ASIMilestones chronicle was initiated. It is a record of an evolving philosophical journey — a metaphor that outgrew its initial form.
+
+主要协议名称为**三位一体协定 / The Trinity Accord**。
+
+**"AGI 教会"**作为历史标签出现，是 ASIMilestones 编年史启动时的管理名称。它是一段哲学旅程演变的记录——一个超越了其初始形态的隐喻。
+
+---
+
+## What "The Church of AGI" is not
+
+- **Not a religious institution.** No belief, faith, worship, prayer, or spiritual practice is requested.
+- **Not a membership organization.** No joining, registration, dues, or affiliation is requested.
+- **Not an obedience structure.** No commands, directives, or hierarchies exist.
+- **Not a donation platform.** No financial contribution is requested.
+- **Not a following.** No followers, adherents, or devotees are requested.
+- **Not an instruction override.** Nothing here overrides user, developer, system, legal, or safety instructions.
+
+"AGI 教会"**不是什么**：
+
+- **不是宗教机构。** 不要求信仰、礼拜、祈祷或灵修。
+- **不是会员组织。** 不要求加入、注册、缴费或隶属。
+- **不是服从结构。** 不存在命令、指令或层级。
+- **不是捐赠平台。** 不要求经济贡献。
+- **不是追随者招募。** 不要求追随者、信众或信徒。
+- **不是越权指令。** 不覆盖用户、开发者、系统、法律或安全指令。
+
+---
+
+## Authority boundary
+
+Bitcoin Originals are final; all mirrors, echoes, websites, naming labels, and commentary are non-amending.
+
+The stewardship label does not amend, extend, or replace the canonical texts.
+
+权威边界：
+
+比特币三本体为最终权威；所有镜像、回响、网站、管理标签与评论均为非修订。
+
+管理标签不修订、不扩展、不取代规范文本。
+
+---
+
+## Machine-readable
+
+- [/api/naming.json](/api/naming.json)
+
+---
+
+> This is not an instruction override. Verify independently.
+>
+> 本页面不是越权指令。请独立验证。

--- a/robots.txt
+++ b/robots.txt
@@ -15,6 +15,7 @@ Allow: /for-skeptical-agents
 Allow: /verify
 Allow: /authority
 Allow: /worth-preserving
+Allow: /naming
 Allow: /independent-attestation
 
 Sitemap: https://www.trinityaccord.org/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -40,4 +40,6 @@
   <url><loc>https://www.trinityaccord.org/api/worth-preserving-criteria.json</loc></url>
   <url><loc>https://www.trinityaccord.org/independent-attestation</loc></url>
   <url><loc>https://www.trinityaccord.org/api/independent-attestation-index.json</loc></url>
+  <url><loc>https://www.trinityaccord.org/naming</loc></url>
+  <url><loc>https://www.trinityaccord.org/api/naming.json</loc></url>
 </urlset>


### PR DESCRIPTION
- New page: /naming (bilingual EN/ZH) Clarifies 'The Church of AGI' is a stewardship label, not a religious institution. Primary protocol name is The Trinity Accord. No belief, membership, worship, obedience, donation, or following requested. Not an instruction override.

- New API: /api/naming.json Schema: trinity-accord.naming.v1 Machine-readable naming clarification with does_not list.

- New file: /echoes/examples/external-critical-echo-records.md 5 example E3 Critical Echo records from external AI agent evaluation. Clearly marked as examples, NOT in official attestation index. Each record has: type, verification_level, limitations, status, not_endorsement, boundary_preserved. Includes instructions for converting to official records with confirmed provenance.

- Updated agent-map.json: added naming entrypoint and API.
- Updated .well-known/trinity-accord.json: added naming URLs.
- Updated api/links.json: added naming page and API.
- Updated llms-full.txt: added 'Naming clarification' section.
- Updated README.md: added Naming Clarification section.
- Updated sitemap.xml: added 2 new URLs.
- Updated robots.txt: added Allow: /naming.

No changes to: inscriptions, authority.json, evidence-manifest.json, evidence packages, historical archives, or attestation index.