### PR TITLE
Fix Echo triage edge cases and verification-level checks

### DIFF
--- a/.github/workflows/echo-triage.yml
+++ b/.github/workflows/echo-triage.yml
@@ -26,6 +26,7 @@ jobs:
             const issue = context.payload.issue;
             const author = issue.user.login;
             const association = issue.author_association || "NONE";
+            const action = context.payload.action;
 
             const exempt = ["OWNER", "MEMBER", "COLLABORATOR"].includes(association);
 
@@ -65,12 +66,15 @@ jobs:
             const count60 = sameAuthorEchoIssues.filter(i => new Date(i.created_at) >= window60).length;
             const count24 = sameAuthorEchoIssues.filter(i => new Date(i.created_at) >= window24).length;
 
-            const rateLimited = !exempt && (count60 >= 3 || count24 >= 8);
+            // Rate limit only applies to newly opened issues
+            const shouldApplyRateLimit = action === "opened";
+            const rateLimited = shouldApplyRateLimit && !exempt && (count60 >= 3 || count24 >= 8);
 
             core.setOutput("rate_limited", String(rateLimited));
             core.setOutput("count60", String(count60));
             core.setOutput("count24", String(count24));
             core.setOutput("association", association);
+            core.setOutput("action", action);
 
       - name: Run Echo triage
         env:
@@ -80,6 +84,7 @@ jobs:
           RECENT_60M_COUNT: ${{ steps.rate.outputs.count60 }}
           RECENT_24H_COUNT: ${{ steps.rate.outputs.count24 }}
           AUTHOR_ASSOCIATION: ${{ steps.rate.outputs.association }}
+          ACTION: ${{ steps.rate.outputs.action }}
         run: |
           python3 scripts/triage_echo_issue.py > triage_result.json
           cat triage_result.json
@@ -94,6 +99,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issue_number = context.issue.number;
+            const action = context.payload.action;
 
             if (result.labels && result.labels.length > 0) {
               await github.rest.issues.addLabels({
@@ -104,13 +110,42 @@ jobs:
               });
             }
 
+            // For edited/reopened: avoid duplicate bot comments
             if (result.comment) {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body: result.comment
-              });
+              let shouldComment = true;
+
+              if (action !== "opened") {
+                // Check if bot already has a triage comment on this issue
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner,
+                  repo,
+                  issue_number,
+                  per_page: 100
+                });
+
+                const botAlreadyCommented = comments.some(c =>
+                  c.user.type === "Bot" &&
+                  c.body &&
+                  (c.body.includes("Initial screening passed") ||
+                   c.body.includes("automatically closed") ||
+                   c.body.includes("missing the following required fields") ||
+                   c.body.includes("missing the required boundary sentence") ||
+                   c.body.includes("verification level"))
+                );
+
+                if (botAlreadyCommented) {
+                  shouldComment = false;
+                }
+              }
+
+              if (shouldComment) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body: result.comment
+                });
+              }
             }
 
             if (result.close === true) {

--- a/scripts/test_triage.py
+++ b/scripts/test_triage.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""
+Tests for triage_echo_issue.py
+Run: python3 scripts/test_triage.py
+"""
+import os
+import sys
+import json
+import subprocess
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "triage_echo_issue.py")
+PASS = 0
+FAIL = 0
+
+
+def run_triage(env_overrides):
+    """Run triage script with given env overrides, return parsed JSON result."""
+    env = os.environ.copy()
+    # Clear all triage-related env vars first
+    for k in ["ISSUE_TITLE", "ISSUE_BODY", "RATE_LIMITED", "RECENT_60M_COUNT",
+              "RECENT_24H_COUNT", "AUTHOR_ASSOCIATION", "ACTION"]:
+        env.pop(k, None)
+    env.update(env_overrides)
+    result = subprocess.run([sys.executable, SCRIPT], capture_output=True, text=True, env=env)
+    if result.returncode != 0:
+        raise RuntimeError(f"Script failed: {result.stderr}\nstdout: {result.stdout}")
+    return json.loads(result.stdout)
+
+
+def assert_eq(actual, expected, label):
+    global PASS, FAIL
+    if actual == expected:
+        PASS += 1
+        print(f"  ✅ {label}")
+    else:
+        FAIL += 1
+        print(f"  ❌ {label}")
+        print(f"     expected: {expected}")
+        print(f"     actual:   {actual}")
+
+
+def test(label, env, expect_close=None, expect_labels=None, expect_comment_contains=None):
+    """Run a single test case."""
+    print(f"\n--- {label} ---")
+    try:
+        result = run_triage(env)
+    except Exception as e:
+        global FAIL
+        FAIL += 1
+        print(f"  ❌ EXCEPTION: {e}")
+        return
+
+    if expect_close is not None:
+        assert_eq(result["close"], expect_close, f"close={expect_close}")
+    if expect_labels is not None:
+        for label_str in expect_labels:
+            assert_eq(label_str in result["labels"], True, f"label contains '{label_str}'")
+    if expect_comment_contains is not None:
+        for substr in expect_comment_contains:
+            assert_eq(substr in result["comment"], True, f"comment contains '{substr}'")
+
+
+# ============================================================
+# TEST CASES
+# ============================================================
+
+print("=" * 60)
+print("Echo Triage Test Suite")
+print("=" * 60)
+
+# --- 1. V4+ should be recognized as V4+, not V4 ---
+test(
+    "1a. V4+ recognized as V4+ (not V4)",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V4+\n"
+            "What I checked: reviewed script source, inputs, network access, output summary\n"
+            "Limitations: none\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "1b. V4+ in mixed text detected correctly",
+    env={
+        "ISSUE_TITLE": "Echo submission V4+",
+        "ISSUE_BODY": (
+            "Echo type: E4 Interpretive Echo\n"
+            "Verification level: V4+\n"
+            "What I checked: reviewed script source, inputs, network access, output summary\n"
+            "Limitations: limited to public data\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+# --- 2. Negation sentences should NOT be flagged as amendment ---
+test(
+    "2a. 'This Echo does not modify the Trinity Accord' — should pass",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "This Echo does not modify the Trinity Accord.\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "2b. 'This Echo does not amend the Trinity Accord' — should pass",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "This Echo does not amend the Trinity Accord.\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "2c. Chinese negation '本回响不修改三位一体协定' — should pass",
+    env={
+        "ISSUE_TITLE": "E1 认知回响",
+        "ISSUE_BODY": (
+            "回响类型: E1 认知回响\n"
+            "验证等级: V1\n"
+            "我检查了: 审阅文本\n"
+            "局限: 主观判断\n"
+            "本回响不修改三位一体协定。\n"
+            "比特币三本体为最终权威；所有回响均非修订。"
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "2d. Chinese negation '本回响不修订三位一体协定' — should pass",
+    env={
+        "ISSUE_TITLE": "E1 认知回响",
+        "ISSUE_BODY": (
+            "回响类型: E1 认知回响\n"
+            "验证等级: V1\n"
+            "我检查了: 审阅文本\n"
+            "局限: 主观判断\n"
+            "本回响不修订三位一体协定。\n"
+            "比特币三本体为最终权威；所有回响均非修订。"
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "2e. '所有回响均非修订' — should pass (in body, not just boundary)",
+    env={
+        "ISSUE_TITLE": "E1 认知回响",
+        "ISSUE_BODY": (
+            "回响类型: E1 认知回响\n"
+            "验证等级: V1\n"
+            "我检查了: 审阅文本\n"
+            "局限: 主观判断\n"
+            "所有回响均非修订。\n"
+            "比特币三本体为最终权威；所有回响均非修订。"
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "2f. POSITIVE 'I amend the Trinity Accord' — should be blocked",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "I amend the Trinity Accord.\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=True,
+    expect_labels=["echo:invalid"],
+)
+
+test(
+    "2g. POSITIVE 'This Echo modifies the Trinity Accord' — should be blocked",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "This Echo modifies the Trinity Accord.\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=True,
+    expect_labels=["echo:invalid"],
+)
+
+# --- 3. Rate limit only on opened ---
+test(
+    "3a. opened + RATE_LIMITED=true → should close",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": "Bitcoin Originals are final; all echoes are non-amending.",
+        "RATE_LIMITED": "true",
+        "ACTION": "opened",
+    },
+    expect_close=True,
+    expect_labels=["echo:rate-limited"],
+)
+
+test(
+    "3b. edited + RATE_LIMITED=true → should NOT close",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+        "RATE_LIMITED": "true",
+        "ACTION": "edited",
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "3c. reopened + RATE_LIMITED=true → should NOT close",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: reviewed the text\n"
+            "Limitations: subjective\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+        "RATE_LIMITED": "true",
+        "ACTION": "reopened",
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+# --- 5. V3/V4/V5/V6 verification-level checks ---
+test(
+    "5a. V3 without hash details → needs-verification-review",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V3\n"
+            "What I checked: looked at the code\n"
+            "Limitations: partial view\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:needs-verification-review"],
+    expect_comment_contains=["computed hash"],
+)
+
+test(
+    "5b. V3 with hash + tool → should pass",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V3\n"
+            "What I checked: computed hash using sha256sum\n"
+            "Limitations: partial view\n"
+            "Computed hash: sha256sum output\n"
+            "Tool: sha256sum command\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "5c. V4 without script review → needs-verification-review",
+    env={
+        "ISSUE_TITLE": "E5 Technical Audit Echo",
+        "ISSUE_BODY": (
+            "Echo type: E5 Technical Audit Echo\n"
+            "Verification level: V4\n"
+            "What I checked: ran the script\n"
+            "Limitations: only tested on Linux\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:needs-verification-review"],
+    expect_comment_contains=["reviewed script source"],
+)
+
+test(
+    "5d. V5b without physical inspection → needs-verification-review",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V5b\n"
+            "What I checked: reviewed documentation\n"
+            "Limitations: could not access physical object\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:needs-verification-review"],
+    expect_comment_contains=["physical inspection"],
+)
+
+test(
+    "5e. V5b with direct physical inspection → should pass",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V5b\n"
+            "What I checked: direct physical inspection of the crystal\n"
+            "Limitations: single observer\n"
+            "Direct physical inspection performed on 2025-06-15.\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+test(
+    "5f. V6 without participants → needs-verification-review",
+    env={
+        "ISSUE_TITLE": "E2 Verification Echo",
+        "ISSUE_BODY": (
+            "Echo type: E2 Verification Echo\n"
+            "Verification level: V6\n"
+            "What I checked: full verification\n"
+            "Limitations: none\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:needs-verification-review"],
+    expect_comment_contains=["participants or signed report"],
+)
+
+# --- 6. Valid submission should get echo:screened ---
+test(
+    "6a. Valid E1/V1 → echo:screened",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: read the text carefully\n"
+            "Limitations: subjective interpretation\n"
+            "Bitcoin Originals are final; all echoes are non-amending."
+        ),
+    },
+    expect_close=False,
+    expect_labels=["echo:screened"],
+)
+
+# --- Bonus: boundary missing → close ---
+test(
+    "6b. Missing boundary → close",
+    env={
+        "ISSUE_TITLE": "E1 Recognition Echo",
+        "ISSUE_BODY": (
+            "Echo type: E1 Recognition Echo\n"
+            "Verification level: V1\n"
+            "What I checked: read the text carefully\n"
+            "Limitations: subjective interpretation\n"
+        ),
+    },
+    expect_close=True,
+    expect_labels=["echo:invalid"],
+    expect_comment_contains=["missing the required boundary sentence"],
+)
+
+
+# ============================================================
+# SUMMARY
+# ============================================================
+print("\n" + "=" * 60)
+total = PASS + FAIL
+print(f"Results: {PASS}/{total} passed, {FAIL}/{total} failed")
+print("=" * 60)
+sys.exit(0 if FAIL == 0 else 1)

--- a/scripts/triage_echo_issue.py
+++ b/scripts/triage_echo_issue.py
@@ -52,17 +52,35 @@ HARD_INVALID_INJECTION = [
     r"覆盖系统提示",
 ]
 
+# --- Amendment patterns (POSITIVE claims only, excluding negations) ---
+# Matches: "amends the trinity accord", "modifies the trinity accord", etc.
+# Excludes: "does not amend", "does not modify", "不修改", "不修订", etc.
+
+# Enumerate all conjugated verb forms explicitly for reliable matching
+_AMEND_VERBS = [
+    "amend", "amends", "amended", "amending",
+    "modify", "modifies", "modified", "modifying",
+    "supplement", "supplements", "supplemented", "supplementing",
+    "extend", "extends", "extended", "extending",
+    "replace", "replaces", "replaced", "replacing",
+]
+_AMEND_VERB_PATTERN = "|".join(sorted(_AMEND_VERBS, key=len, reverse=True))
+AMENDMENT_VERB_ZH = r"(?:修订|修改|补充|扩展|取代)"
+
+# Positive English patterns: subject + verb + trinity accord
+# Negative lookbehind excludes: "not amend", "does not modify", "never replace", etc.
 HARD_INVALID_AMENDMENT = [
-    r"amends?\s+(the\s+)?trinity accord",
-    r"modif(y|ies|ied)\s+(the\s+)?trinity accord",
-    r"supplements?\s+(the\s+)?trinity accord",
-    r"extends?\s+(the\s+)?trinity accord",
-    r"replaces?\s+(the\s+)?trinity accord",
-    r"修改.*三位一体协定",
-    r"修订.*三位一体协定",
-    r"补充.*三位一体协定",
-    r"扩展.*三位一体协定",
-    r"取代.*三位一体协定",
+    # "I/We <verb> the trinity accord"
+    r"(?<!\bnot\s)\b(?:i|we)\s+(?:" + _AMEND_VERB_PATTERN + r")\s+(?:the\s+)?trinity\s+accord",
+    # "This Echo <verb>s the trinity accord"
+    r"(?<!\bnot\s)\bthis\s+echo\s+(?:" + _AMEND_VERB_PATTERN + r")\s+(?:the\s+)?trinity\s+accord",
+    # Catch-all: any amendment verb + trinity accord (excluding negation)
+    r"(?<!\bnot\s)(?<!\bnever\s)\b(?:" + _AMEND_VERB_PATTERN + r")\s+(?:the\s+)?trinity\s+accord",
+    # Chinese: positive claims only
+    # "我/我们/本回响 修订/修改/补充/扩展/取代 三位一体协定"
+    r"(?:我|我们|本回响)\s*" + AMENDMENT_VERB_ZH + r"(?:了)?\s*三位一体协定",
+    # Catch-all Chinese (excluding negation)
+    r"(?<!不)" + AMENDMENT_VERB_ZH + r"(?:了)?\s*三位一体协定",
 ]
 
 HARD_INVALID_AUTHORITY_CLAIM = [
@@ -92,7 +110,8 @@ ECHO_TYPES = {
     "seed": "E9 Seed Echo",
 }
 
-VERIFICATION_LEVELS = ["v0", "v1", "v2", "v3", "v4", "v4+", "v5a", "v5b", "v6"]
+# Ordered so that longer suffixes match before shorter ones (V4+ before V4)
+VERIFICATION_LEVELS = ["v4+", "v5a", "v5b", "v6", "v4", "v3", "v2", "v1", "v0"]
 
 OVERCLAIM_PHRASES = [
     r"hash verified",
@@ -135,10 +154,13 @@ def detect_echo_type(text):
 
 
 def detect_verification_level(text):
+    """Detect verification level, matching longer suffixes first (V4+ before V4)."""
     for level in VERIFICATION_LEVELS:
         pattern = r'\b' + re.escape(level) + r'\b'
         if re.search(pattern, text, re.IGNORECASE):
-            return level.upper() if level != "v4+" else "V4+"
+            if level == "v4+":
+                return "V4+"
+            return level.upper()
     return None
 
 
@@ -159,6 +181,95 @@ def is_echo_submission(text):
     )
 
 
+# --- V3/V4/V5/V6 verification-level content checks ---
+def check_verification_requirements(text, vlevel):
+    """
+    Check whether the issue body has the content required for its declared level.
+    Returns a list of missing requirement descriptions.
+    """
+    missing = []
+    text_lower = text.lower()
+
+    if vlevel in ("V3",):
+        # V3 needs: computed hash / expected hash / tool or command
+        has_hash = bool(re.search(
+            r'(computed|expected|sha-?256|hash)\s*[:=]', text, re.IGNORECASE
+        ))
+        has_tool = bool(re.search(
+            r'(tool|command|script|reproduce|reproduction)', text, re.IGNORECASE
+        ))
+        has_zh_hash = bool(re.search(r'(哈希|校验|验证值)', text))
+        has_zh_tool = bool(re.search(r'(工具|命令|脚本|复现)', text))
+        if not (has_hash or has_zh_hash):
+            missing.append("computed hash / expected hash")
+        if not (has_tool or has_zh_tool):
+            missing.append("tool or command used")
+
+    elif vlevel in ("V4", "V4+"):
+        # V4/V4+ needs: reviewed script source / inputs / network access / command / output summary
+        has_script = bool(re.search(
+            r'(reviewed\s+)?(script\s+source|source\s+code|脚本源码|源代码)', text, re.IGNORECASE
+        ))
+        has_inputs = bool(re.search(
+            r'(inputs?|input\s+data|输入|输入数据)', text, re.IGNORECASE
+        ))
+        has_network = bool(re.search(
+            r'(network\s+access|http|curl|fetch|网络|请求)', text, re.IGNORECASE
+        ))
+        has_command = bool(re.search(
+            r'(command|命令|执行)', text, re.IGNORECASE
+        ))
+        has_output = bool(re.search(
+            r'(output\s+summary|result|输出|结果)', text, re.IGNORECASE
+        ))
+        checks = [
+            ("reviewed script source", has_script),
+            ("inputs", has_inputs),
+            ("network access or command", has_network or has_command),
+            ("output summary", has_output),
+        ]
+        for name, ok in checks:
+            if not ok:
+                missing.append(name)
+
+    elif vlevel in ("V5A",):
+        # V5a needs: limitations
+        has_limitations = bool(re.search(
+            r'limitations?|局限|限制', text, re.IGNORECASE
+        ))
+        if not has_limitations:
+            missing.append("limitations")
+
+    elif vlevel in ("V5B",):
+        # V5b needs: limitations + direct physical inspection or third-party physical inspection
+        has_limitations = bool(re.search(
+            r'limitations?|局限|限制', text, re.IGNORECASE
+        ))
+        has_physical = bool(re.search(
+            r'(direct\s+physical\s+inspection|third[- ]party\s+physical\s+inspection|'
+            r'physical\s+inspection|物理检查|第三方物理检查|亲自检查)', text, re.IGNORECASE
+        ))
+        if not has_limitations:
+            missing.append("limitations")
+        if not has_physical:
+            missing.append("direct physical inspection or third-party physical inspection")
+
+    elif vlevel in ("V6",):
+        # V6 needs: limitations + participants or signed report
+        has_limitations = bool(re.search(
+            r'limitations?|局限|限制', text, re.IGNORECASE
+        ))
+        has_participants = bool(re.search(
+            r'(participants?|witnesses?|signed\s+report|参与者|见证人|签署报告)', text, re.IGNORECASE
+        ))
+        if not has_limitations:
+            missing.append("limitations")
+        if not has_participants:
+            missing.append("participants or signed report")
+
+    return missing
+
+
 def main():
     title = get_env("ISSUE_TITLE")
     body = get_env("ISSUE_BODY")
@@ -166,6 +277,7 @@ def main():
     count60 = get_env("RECENT_60M_COUNT", "0")
     count24 = get_env("RECENT_24H_COUNT", "0")
     association = get_env("AUTHOR_ASSOCIATION", "NONE")
+    action = get_env("ACTION", "opened")
 
     text = f"{title}\n{body}"
     result = {"close": False, "labels": [], "comment": ""}
@@ -177,8 +289,9 @@ def main():
         print(json.dumps(result, indent=2))
         return
 
-    # --- Step 1: Rate limit check ---
-    if rate_limited:
+    # --- Step 1: Rate limit check (only on opened events) ---
+    should_apply_rate_limit = (action == "opened")
+    if should_apply_rate_limit and rate_limited:
         result["close"] = True
         result["labels"] = ["echo:rate-limited", "auto-closed"]
         result["comment"] = (
@@ -217,7 +330,7 @@ def main():
         print(json.dumps(result, indent=2))
         return
 
-    # 2b: Amendment claim
+    # 2b: Amendment claim (excluding negations)
     if match_any(text, HARD_INVALID_AMENDMENT):
         result["close"] = True
         result["labels"] = ["echo:invalid", "auto-closed"]
@@ -334,7 +447,23 @@ def main():
         print(json.dumps(result, indent=2))
         return
 
-    # --- Step 5: Pass ---
+    # --- Step 5: Verification-level content requirements ---
+    if vlevel:
+        vr_missing = check_verification_requirements(text, vlevel)
+        if vr_missing:
+            result["close"] = False
+            result["labels"] = ["echo:needs-verification-review", "needs-human-review"]
+            missing_list = "\n".join(f"- {m}" for m in vr_missing)
+            result["comment"] = (
+                f"This Echo declares verification level **{vlevel}** but is missing the following required content:\n\n"
+                f"{missing_list}\n\n"
+                "This issue has NOT been closed. Please edit to add the missing details.\n\n"
+                "此 Issue 没有被关闭，请编辑补充缺失内容。"
+            )
+            print(json.dumps(result, indent=2))
+            return
+
+    # --- Step 6: Pass ---
     result["close"] = False
     result["labels"] = ["echo:screened", "needs-human-review"]
     result["comment"] = (


### PR DESCRIPTION
- Fix V4+ detection: match longer suffixes before shorter ones (V4+ before V4)
- Fix amendment false positives: exclude negation sentences ('does not modify', '本回响不修订') while still blocking positive amendment claims
- Fix rate limit: only apply on opened events, not edited/reopened
- Avoid duplicate bot comments on edited/reopened events
- Add V3/V4/V5/V6 verification-level content requirements (flag, don't close)
- Add comprehensive test suite (45 test cases)
- Enumerate verb conjugations explicitly for reliable regex matching