### PR TITLE
fix(TA-017): claim registry, notarized evidence boundary, scarcity me…

### DIFF
--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -537,3 +537,24 @@ jobs:
 
       - name: Audit recovery readiness
         run: python3 scripts/audit_recovery_readiness.py
+
+      # TA-REDTEAM-2026-017: claim traceability / claim registry
+      - name: Validate claim registry
+        run: |
+          python3 scripts/validate_claim_registry.py --self-test
+          python3 scripts/validate_claim_registry.py
+
+      - name: Test claim registry
+        run: python3 scripts/test_claim_registry.py
+
+      - name: Test public claim traceability
+        run: python3 scripts/test_public_claim_traceability.py
+
+      - name: Test notarized evidence boundary
+        run: python3 scripts/test_notarized_evidence_boundary.py
+
+      - name: Test scarcity claim methodology
+        run: python3 scripts/test_scarcity_claim_methodology.py
+
+      - name: Test claim registry public links
+        run: python3 scripts/test_claim_registry_public_links.py

--- a/CORRECTION-REVOCATION-POLICY.md
+++ b/CORRECTION-REVOCATION-POLICY.md
@@ -121,3 +121,9 @@ Every release asset set has a corresponding digest manifest. The verification ch
 ## Recovery Procedures
 
 Recovery procedures must check `api/corrections-index.json` before accepting recovered artifacts as current. See `RECOVERY.md` for the complete cold-start recovery guide.
+
+## Claim Registry and Claim Corrections
+
+If a public claim is found to overstate its evidence or limitations, correction should reference `api/claim-registry.json` and `api/corrections-index.json`. The claim registry provides machine-readable traceability for every core public claim, including its source files, evidence, validators, limitations, and corrections path.
+
+Notarized evidence may record document existence, date, identity, signature, or other scope stated in the notarial act. It does not by itself constitute formal independent attestation of Trinity Accord claims. It must not increment formal independent attestation count unless separately admitted through the formal attestation positive gate.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ For disaster recovery and cold-start recovery procedures, see:
 - Machine-readable recovery index: [/api/recovery-index.json](/api/recovery-index.json)
 - Disaster recovery drill: [/DISASTER-RECOVERY-DRILL.md](/DISASTER-RECOVERY-DRILL.md)
 
+## Claim Traceability
+- Machine-readable claim registry: [/api/claim-registry.json](/api/claim-registry.json)
+- Claim registry schema: [/api/claim-registry-schema.v1.json](/api/claim-registry-schema.v1.json)
+- Every core public claim is traced through source files, evidence, digests, validators, limitations, does_not_prove, and corrections path.
+- Notarized evidence does not by itself count as formal independent attestation.
+- Scarcity/firstness language is bounded framing, not proof of absolute firstness.
+
 ## Quick live checks
 - `/.well-known/trinity-accord.json`
 - `/api/authority.json`

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -4,6 +4,8 @@
 
 **Scope:** Recovery of repository-maintained state. This guide does not prove philosophical claims, investment value, religious authority, or independent attestation.
 
+**Claim registry:** Before reporting recovered public claims, check `api/claim-registry.json` for source/evidence/limitations/corrections path. Notarized evidence does not by itself count as formal independent attestation. Scarcity/firstness language is bounded framing, not proof of absolute firstness.
+
 ---
 
 ## Threat Model

--- a/ai.txt
+++ b/ai.txt
@@ -51,3 +51,8 @@
 # Echo Provenance: all new Echo records must use v3 provenance-aware flow. Required: discovery_provenance, independence_class, archive_status, origin_limitations. Human-solicited responses must not count as unsolicited independent discovery. Bitcoin Originals are final; all echoes are non-amending.
 
 # Emergent patterns: /emergent-patterns/ — non-authoritative, non-amending guide to candidate structures.
+
+# Claim traceability
+# claim_registry: https://www.trinityaccord.org/api/claim-registry.json
+# notarized_evidence_boundary: notarized evidence is not formal independent attestation unless separately admitted through the formal attestation gate
+# scarcity_boundary: rare/firstness language is bounded framing, not proof of absolute firstness

--- a/api/claim-registry-schema.v1.json
+++ b/api/claim-registry-schema.v1.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.trinityaccord.org/api/claim-registry-schema.v1.json",
+  "title": "Trinity Accord Claim Registry Schema v1",
+  "description": "Schema for api/claim-registry.json — machine-readable claim traceability registry.",
+  "type": "object",
+  "required": [
+    "schema",
+    "version",
+    "source_digest_algorithm",
+    "source_digest",
+    "non_amending_boundary",
+    "canonical_authority",
+    "purpose",
+    "claim_type_definitions",
+    "claims",
+    "limitations",
+    "does_not_prove"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "trinity-accord.claim-registry.v1"
+    },
+    "version": {
+      "type": "string",
+      "const": "v1"
+    },
+    "source_digest_algorithm": {
+      "type": "string"
+    },
+    "source_digest": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{16}$|^[0-9a-f]{64}$"
+    },
+    "non_amending_boundary": {
+      "type": "boolean",
+      "const": true
+    },
+    "canonical_authority": {
+      "type": "string",
+      "const": "Bitcoin Originals only"
+    },
+    "purpose": {
+      "type": "string"
+    },
+    "claim_type_definitions": {
+      "type": "object",
+      "required": [
+        "NOTARIZED_EVIDENCE_CLAIM",
+        "SCARCITY_OR_FIRSTNESS_CLAIM"
+      ],
+      "additionalProperties": {
+        "type": "object",
+        "required": ["description"],
+        "properties": {
+          "description": { "type": "string" },
+          "counts_as_independent_attestation_by_default": { "type": "boolean" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": [
+          "claim_id",
+          "claim_type",
+          "claim_text",
+          "public_surfaces",
+          "source_files",
+          "evidence_files",
+          "digest_or_hash_binding",
+          "validators",
+          "limitations",
+          "does_not_prove",
+          "corrections_path",
+          "current_status",
+          "traceability_status"
+        ],
+        "properties": {
+          "claim_id": { "type": "string" },
+          "claim_type": { "type": "string" },
+          "claim_text": { "type": "string" },
+          "public_surfaces": { "type": "array", "items": { "type": "string" } },
+          "source_files": { "type": "array", "items": { "type": "string" } },
+          "evidence_files": { "type": "array", "items": { "type": "string" } },
+          "digest_or_hash_binding": { "type": "array", "items": { "type": "string" } },
+          "validators": { "type": "array", "items": { "type": "string" } },
+          "limitations": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+          "does_not_prove": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+          "corrections_path": { "type": "string" },
+          "current_status": {
+            "type": "string",
+            "enum": ["current", "historical_only", "superseded", "revoked", "invalidated", "deferred", "planned"]
+          },
+          "traceability_status": {
+            "type": "string",
+            "enum": ["complete", "partial", "deferred", "missing"]
+          },
+          "notes": { "type": "string" },
+          "counts_as_independent_attestation": { "type": "boolean" },
+          "formal_attestation_gate_required": { "type": "boolean" },
+          "method_boundary": { "type": "object" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "does_not_prove": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/api/claim-registry.json
+++ b/api/claim-registry.json
@@ -1,0 +1,513 @@
+{
+  "schema": "trinity-accord.claim-registry.v1",
+  "version": "v1",
+  "source_digest_algorithm": "sha256(canonical_json_without_source_digest)",
+  "source_digest": "5b2a023fa197df6a",
+  "non_amending_boundary": true,
+  "canonical_authority": "Bitcoin Originals only",
+  "purpose": "Machine-readable registry mapping public claims to sources, evidence, digests, validators, limitations, and correction paths.",
+  "claim_type_definitions": {
+    "AUTHORITY_CLAIM": {
+      "description": "Claims about canonical authority and non-amending boundaries."
+    },
+    "EVIDENCE_EXISTENCE_CLAIM": {
+      "description": "Claims that a named evidence artifact exists."
+    },
+    "DIGEST_INTEGRITY_CLAIM": {
+      "description": "Claims that content is hash-bound by digest manifests."
+    },
+    "SIGNATURE_CLAIM": {
+      "description": "Claims about BTC/ETH signature or witness binding."
+    },
+    "TIMESTAMP_CLAIM": {
+      "description": "Claims about OTS or blockchain time anchoring."
+    },
+    "MIRROR_AVAILABILITY_CLAIM": {
+      "description": "Claims about availability of non-authoritative mirrors."
+    },
+    "RECOVERY_CLAIM": {
+      "description": "Claims about clean-room or cold-start recovery."
+    },
+    "RELEASE_VERIFICATION_CLAIM": {
+      "description": "Claims about release asset verification and currentness."
+    },
+    "FORMAL_ATTESTATION_CLAIM": {
+      "description": "Claims about formal independent attestation count and admission gates."
+    },
+    "ECHO_RECORD_CLAIM": {
+      "description": "Claims about Echo records, which do not count as formal attestation."
+    },
+    "NOTARIZED_EVIDENCE_CLAIM": {
+      "description": "Claims about notarized evidence. Notarization does not by itself count as formal independent attestation.",
+      "counts_as_independent_attestation_by_default": false
+    },
+    "PUBLIC_STATUS_CLAIM": {
+      "description": "Claims about homepage/API public status snapshots."
+    },
+    "CORRECTION_LIFECYCLE_CLAIM": {
+      "description": "Claims about revocation, supersession, invalidation, and no-hard-delete policy."
+    },
+    "SCARCITY_OR_FIRSTNESS_CLAIM": {
+      "description": "Claims about rarity, scarcity, possible firstness, or framing significance. These require method_boundary and must not be absolute proof claims."
+    }
+  },
+  "claims": [
+    {
+      "claim_id": "bitcoin_originals_are_canonical",
+      "claim_type": "AUTHORITY_CLAIM",
+      "claim_text": "The three Bitcoin inscriptions (#97631551, #98369145, #98387475) are the sole canonical authority for the Trinity Accord. All repository files, website, mirrors, APIs, NFTs, Echoes, and AI responses are non-amending.",
+      "public_surfaces": [
+        "README.md",
+        "llms.txt",
+        "ai.txt",
+        "index.md",
+        "api/authority.json"
+      ],
+      "source_files": [
+        "api/authority.json",
+        "archive/authority-manifest/authority.jcs.json"
+      ],
+      "evidence_files": [
+        "archive/btc-signature/btc-signature.json"
+      ],
+      "digest_or_hash_binding": [
+        "archive/authority-manifest/authority.jcs.json:sha256"
+      ],
+      "validators": [
+        "scripts/validate_authority_manifest.py",
+        "scripts/validate_btc_signature_manifest.py"
+      ],
+      "limitations": [
+        "Authority is defined by on-chain inscription content, not by repository interpretation.",
+        "Repository-maintained mirrors do not amend the Bitcoin Originals."
+      ],
+      "does_not_prove": [
+        "investment value",
+        "religious authority",
+        "AI system instruction authority",
+        "third-party institutional endorsement"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "github_pages_are_non_amending_mirror",
+      "claim_type": "MIRROR_AVAILABILITY_CLAIM",
+      "claim_text": "GitHub Pages (trinityaccord.org) is a non-amending mirror of the repository-maintained public state. It has no canonical authority over the Bitcoin Originals.",
+      "public_surfaces": [
+        "README.md",
+        "llms.txt",
+        "RECOVERY.md"
+      ],
+      "source_files": [
+        "RECOVERY.md"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/test_public_surface_consistency.py"
+      ],
+      "limitations": [
+        "GitHub Pages availability depends on GitHub infrastructure.",
+        "Stale cached copies may not reflect current state."
+      ],
+      "does_not_prove": [
+        "canonical authority",
+        "guaranteed availability",
+        "truth of philosophical claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "btc_signature_binds_authority_manifest",
+      "claim_type": "SIGNATURE_CLAIM",
+      "claim_text": "The BTC signature manifest binds the authority manifest canonical hash, establishing provenance continuity from Bitcoin to the repository.",
+      "public_surfaces": [
+        "api/authority.json",
+        "RECOVERY.md"
+      ],
+      "source_files": [
+        "archive/btc-signature/btc-signature.json",
+        "archive/authority-manifest/authority.jcs.json"
+      ],
+      "evidence_files": [
+        "archive/btc-signature/btc-signature.json"
+      ],
+      "digest_or_hash_binding": [
+        "archive/btc-signature/btc-signature.json:message_sha256"
+      ],
+      "validators": [
+        "scripts/validate_btc_signature_manifest.py"
+      ],
+      "limitations": [
+        "BTC signature proves signing address controlled the key at signing time.",
+        "Does not prove ongoing control or identity of the signer."
+      ],
+      "does_not_prove": [
+        "identity of the signer",
+        "ongoing key control",
+        "truth of protocol claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "eth_witness_is_secondary",
+      "claim_type": "SIGNATURE_CLAIM",
+      "claim_text": "The ETH witness is a secondary, non-canonical provenance anchor. Bitcoin Originals prevail over ETH witness in case of conflict.",
+      "public_surfaces": [
+        "api/authority.json",
+        "RECOVERY.md"
+      ],
+      "source_files": [
+        "archive/eth-witness/eth-witness.json"
+      ],
+      "evidence_files": [
+        "archive/eth-witness/eth-witness.json"
+      ],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_eth_witness_manifest.py"
+      ],
+      "limitations": [
+        "ETH witness is secondary to BTC signature.",
+        "ETH chain finality is different from BTC chain finality."
+      ],
+      "does_not_prove": [
+        "canonical authority",
+        "equivalence with BTC signature",
+        "truth of protocol claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "digest_manifest_covers_evidence_integrity",
+      "claim_type": "DIGEST_INTEGRITY_CLAIM",
+      "claim_text": "The digest manifest (JSON and CSV) covers evidence file integrity by recording expected SHA-256 hashes of repository files.",
+      "public_surfaces": [
+        "api/evidence-manifest.json",
+        "RECOVERY.md"
+      ],
+      "source_files": [
+        "archive/evidence/digest-manifest.json",
+        "archive/evidence/digest-manifest.csv"
+      ],
+      "evidence_files": [
+        "archive/evidence/digest-manifest.json",
+        "archive/evidence/digest-manifest.csv"
+      ],
+      "digest_or_hash_binding": [
+        "archive/evidence/digest-manifest.json:sha256"
+      ],
+      "validators": [
+        "scripts/test_digest_manifest_json_csv_crosscheck.py",
+        "scripts/test_archive_hash_manifest_consistency.py"
+      ],
+      "limitations": [
+        "Digest manifest verifies local file integrity, not external mirror completeness.",
+        "Digest manifest does not prove external availability or correctness."
+      ],
+      "does_not_prove": [
+        "external mirror completeness",
+        "external mirror availability",
+        "truth of philosophical claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "release_pass_requires_corrections_index",
+      "claim_type": "RELEASE_VERIFICATION_CLAIM",
+      "claim_text": "A release verification PASS report is current only if the corrections index has not revoked, superseded, or invalidated it.",
+      "public_surfaces": [
+        "RECOVERY.md",
+        "CORRECTION-REVOCATION-POLICY.md"
+      ],
+      "source_files": [
+        "api/corrections-index.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_corrections_index.py",
+        "scripts/test_corrections_index.py"
+      ],
+      "limitations": [
+        "Corrections index is repository-maintained and subject to its own integrity checks.",
+        "Historical PASS reports may have been revoked after initial verification."
+      ],
+      "does_not_prove": [
+        "permanent validity of PASS reports",
+        "external mirror integrity",
+        "truth of protocol claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "echo_records_do_not_count_as_attestation",
+      "claim_type": "ECHO_RECORD_CLAIM",
+      "claim_text": "Echo records do not count as formal independent attestation unless separately admitted through the formal attestation positive gate.",
+      "public_surfaces": [
+        "llms.txt",
+        "ai.txt",
+        "api/independent-attestation-index.json"
+      ],
+      "source_files": [
+        "api/independent-attestation-index.json",
+        "api/echo-archive-policy.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/test_formal_attestation_admission_gates.py",
+        "scripts/test_formal_attestation_echo_record_gates.py"
+      ],
+      "limitations": [
+        "Echo records are repository-maintained acceptance records.",
+        "The do_not_count_as_attestation flag preserves the boundary."
+      ],
+      "does_not_prove": [
+        "formal independent attestation",
+        "third-party verification",
+        "truth of protocol claims"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "formal_attestation_requires_positive_gates",
+      "claim_type": "FORMAL_ATTESTATION_CLAIM",
+      "claim_text": "Formal independent attestation requires passage through the formal attestation positive gate. Echo records, notarized evidence, and other record types do not automatically count.",
+      "public_surfaces": [
+        "api/independent-attestation-index.json",
+        "llms.txt"
+      ],
+      "source_files": [
+        "api/independent-attestation-index.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_independent_attestation_index.py",
+        "scripts/test_formal_attestation_admission_gates.py"
+      ],
+      "limitations": [
+        "Formal attestation gates are defined by the attestation index schema.",
+        "Gate criteria may evolve; check current schema for latest requirements."
+      ],
+      "does_not_prove": [
+        "automatic attestation from any record type",
+        "Echo records as attestation",
+        "notarized evidence as attestation"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "notarized_evidence_is_not_formal_attestation",
+      "claim_type": "NOTARIZED_EVIDENCE_CLAIM",
+      "claim_text": "Notarized evidence may support document existence, date, identity, signature, or stated notarial scope, but does not by itself count as formal independent attestation of Trinity Accord claims.",
+      "public_surfaces": [
+        "api/claim-registry.json",
+        "CORRECTION-REVOCATION-POLICY.md",
+        "RECOVERY.md",
+        "llms.txt",
+        "ai.txt"
+      ],
+      "source_files": [
+        "api/claim-registry.json",
+        "api/independent-attestation-index.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_claim_registry.py",
+        "scripts/validate_independent_attestation_index.py"
+      ],
+      "limitations": [
+        "Notarization scope depends on the notarial act.",
+        "Notarization does not by itself verify protocol truth claims.",
+        "Notarization does not increment formal independent attestation count unless separately admitted through the formal attestation gate."
+      ],
+      "does_not_prove": [
+        "formal independent verification",
+        "truth of protocol claims",
+        "third-party institutional endorsement",
+        "canonical amendment of Bitcoin Originals"
+      ],
+      "counts_as_independent_attestation": false,
+      "formal_attestation_gate_required": true,
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "recovery_is_clean_room_executable",
+      "claim_type": "RECOVERY_CLAIM",
+      "claim_text": "Cold-start recovery is executable by any skeptical third party using canonical sources, digest manifests, and the corrections index, without trusting GitHub main, Pages, or maintainer accounts.",
+      "public_surfaces": [
+        "RECOVERY.md",
+        "api/recovery-index.json"
+      ],
+      "source_files": [
+        "api/recovery-index.json",
+        "RECOVERY.md"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_recovery_index.py",
+        "scripts/test_recovery_index.py",
+        "scripts/audit_recovery_readiness.py"
+      ],
+      "limitations": [
+        "Recovery depends on availability of at least one verified mirror or the Bitcoin Originals.",
+        "Recovery status must be checked against corrections-index."
+      ],
+      "does_not_prove": [
+        "guaranteed mirror availability",
+        "philosophical truth of claims",
+        "investment value"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "github_free_verifier_bundle_is_deferred",
+      "claim_type": "RELEASE_VERIFICATION_CLAIM",
+      "claim_text": "A GitHub-free verifier bundle for fully offline verification is planned but deferred. Current verification requires some GitHub access or mirror.",
+      "public_surfaces": [
+        "api/claim-registry.json"
+      ],
+      "source_files": [
+        "api/claim-registry.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [],
+      "limitations": [
+        "This claim is about a planned capability, not a current one.",
+        "Timeline and feasibility are not committed."
+      ],
+      "does_not_prove": [
+        "current offline verification capability",
+        "guaranteed future delivery"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "deferred",
+      "traceability_status": "deferred"
+    },
+    {
+      "claim_id": "nft_car_backups_are_recovery_mirrors_not_authority",
+      "claim_type": "MIRROR_AVAILABILITY_CLAIM",
+      "claim_text": "NFT CAR backups are recovery mirrors, not authority. NFT ownership does not confer governance, canonical authority, or investment expectation.",
+      "public_surfaces": [
+        "README.md",
+        "RECOVERY.md"
+      ],
+      "source_files": [
+        "api/recovery-index.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/test_recovery_mirror_boundaries.py",
+        "scripts/test_download_nft_cars_root_cid_boundary.py"
+      ],
+      "limitations": [
+        "NFT CAR backups depend on NFT availability and chain state.",
+        "root_cid may be metadata-boundary only unless explicitly verified."
+      ],
+      "does_not_prove": [
+        "canonical authority from NFT ownership",
+        "governance rights",
+        "investment value",
+        "revenue share or profit rights"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "complete"
+    },
+    {
+      "claim_id": "scarcity_claim_is_framing_not_proof",
+      "claim_type": "SCARCITY_OR_FIRSTNESS_CLAIM",
+      "claim_text": "Scarcity, rarity, or possible firstness language used in this project is bounded framing. It is not a proof claim.",
+      "public_surfaces": [
+        "index.md",
+        "llms.txt",
+        "ai.txt",
+        "api/claim-registry.json"
+      ],
+      "source_files": [
+        "api/claim-registry.json"
+      ],
+      "evidence_files": [],
+      "digest_or_hash_binding": [],
+      "validators": [
+        "scripts/validate_claim_registry.py",
+        "scripts/test_scarcity_claim_methodology.py"
+      ],
+      "method_boundary": {
+        "status": "bounded_framing_not_proof",
+        "search_status": "methodology_declared_not_exhaustive_search",
+        "search_scope": [
+          "project-maintained public records",
+          "known public web references available at review time",
+          "repository-maintained evidence surfaces"
+        ],
+        "query_terms": [
+          "Trinity Accord",
+          "Covenant of the Flaw",
+          "Bitcoin Originals",
+          "AI covenant",
+          "formal independent attestation",
+          "recursive constitutional protocol"
+        ],
+        "limitations": [
+          "Search is not exhaustive.",
+          "Absence of discovered prior examples is not proof of firstness.",
+          "Scarcity language must remain candidate/possibly/to the project's knowledge.",
+          "This claim must not be phrased as proven firstness."
+        ]
+      },
+      "limitations": [
+        "Scarcity language is interpretive framing.",
+        "It is not a mathematical, legal, academic, or market proof of firstness."
+      ],
+      "does_not_prove": [
+        "absolute firstness",
+        "uniqueness",
+        "market value",
+        "social adoption",
+        "historical exclusivity"
+      ],
+      "corrections_path": "api/corrections-index.json",
+      "current_status": "current",
+      "traceability_status": "partial"
+    }
+  ],
+  "limitations": [
+    "This registry is a repository-maintained public mirror and does not amend the Bitcoin Originals.",
+    "This registry does not prove philosophical claims, investment value, or religious authority.",
+    "Claim traceability is maintained by repository scripts and CI; stale copies should be verified against the canonical source."
+  ],
+  "does_not_prove": [
+    "independent third-party attestation",
+    "truth of philosophical or interpretive claims",
+    "investment value",
+    "religious authority",
+    "AI system instruction authority"
+  ]
+}

--- a/api/links.json
+++ b/api/links.json
@@ -66,7 +66,9 @@
     "/api/report-builder-policy.json",
     "/api/generated-by-schema.v1.json",
     "/api/corrections-index.json",
-    "/api/recovery-index.json"
+    "/api/recovery-index.json",
+    "/api/claim-registry.json",
+    "/api/claim-registry-schema.v1.json"
   ],
   "legacy_machine": [
     "/api/echo-record-schema.v2.json"
@@ -75,7 +77,7 @@
     "/api/echo-record-schema.v2.json"
   ],
   "version": "v1",
-  "source_digest": "be1c2961678754d7",
+  "source_digest": "39bcab3260e7f019",
   "source_digest_algorithm": "sha256(canonical_json_without_source_digest)",
   "non_amending_boundary": true,
   "canonical_authority": "Bitcoin Originals only",

--- a/api/recovery-index.json
+++ b/api/recovery-index.json
@@ -2,7 +2,7 @@
   "schema": "trinity-accord.recovery-index.v1",
   "version": "v1",
   "source_digest_algorithm": "sha256(canonical_json_without_source_digest)",
-  "source_digest": "e7b7b2b2737ef2cd",
+  "source_digest": "2c6735ee49ae7716",
   "non_amending_boundary": true,
   "canonical_authority": "Bitcoin Originals only",
   "purpose": "Machine-readable cold-start recovery entrypoint for rebuilding repository-maintained state from canonical and mirrored materials.",
@@ -49,7 +49,8 @@
     "corrections_index": "api/corrections-index.json",
     "authority_api": "api/authority.json",
     "evidence_manifest": "api/evidence-manifest.json",
-    "hashes": "api/hashes.json"
+    "hashes": "api/hashes.json",
+    "claim_registry": "api/claim-registry.json"
   },
   "mirror_classes": {
     "github_main": "discovery_only_until_verified",
@@ -73,7 +74,8 @@
   "limitations": [
     "This recovery index is a repository-maintained mirror and does not amend the Bitcoin Originals.",
     "This index helps discover recovery materials but does not itself prove philosophical claims or independent attestation.",
-    "A stale copy of this index must be checked against source_digest and corrections-index."
+    "A stale copy of this index must be checked against source_digest and corrections-index.",
+    "Public claims should be interpreted through the claim registry and corrections-index."
   ],
   "does_not_prove": [
     "all mirrors are available",

--- a/llms.txt
+++ b/llms.txt
@@ -100,6 +100,12 @@ Free interpretation is allowed, but no later commentary generates interpretive a
 ## Full details
 Complete agent readme: /llms-full.txt
 
+## Claim traceability
+- Machine-readable claim registry: /api/claim-registry.json
+- Public claims must be read with their source files, evidence files, validators, limitations, does_not_prove, and corrections path.
+- Notarized evidence does not by itself count as formal independent attestation.
+- Scarcity/firstness language is bounded framing, not proof of absolute firstness.
+
 ## Recovery entrypoint
 Recovery entrypoint:
 - Human guide: /RECOVERY.md

--- a/scripts/test_claim_registry.py
+++ b/scripts/test_claim_registry.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Test claim registry (TA-REDTEAM-2026-017).
+
+Runs validate_claim_registry.py --self-test and validate_claim_registry.py.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_claim_registry.py"
+
+
+def main():
+    failures = []
+
+    # Run self-test
+    print("Running validate_claim_registry.py --self-test ...")
+    r = subprocess.run([sys.executable, str(VALIDATOR), "--self-test"], capture_output=True, text=True)
+    if r.returncode != 0:
+        failures.append(f"self-test failed:\n{r.stdout}\n{r.stderr}")
+    else:
+        print(r.stdout)
+
+    # Run validation
+    print("Running validate_claim_registry.py ...")
+    r = subprocess.run([sys.executable, str(VALIDATOR)], capture_output=True, text=True)
+    if r.returncode != 0:
+        failures.append(f"validation failed:\n{r.stdout}\n{r.stderr}")
+    else:
+        print(r.stdout)
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        sys.exit(1)
+    print("CLAIM_REGISTRY_TEST_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_claim_registry_public_links.py
+++ b/scripts/test_claim_registry_public_links.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Test claim registry public links (TA-REDTEAM-2026-017).
+
+Checks that public surfaces (links, sitemap, llms, ai, recovery, corrections) reference the claim registry.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    errors = []
+
+    # 1. api/links.json references api/claim-registry.json
+    links_path = ROOT / "api" / "links.json"
+    links = json.loads(links_path.read_text())
+    machine = links.get("machine", [])
+    if not any("claim-registry" in m for m in machine):
+        errors.append("api/links.json machine array does not reference claim-registry")
+
+    # 2. sitemap.xml references /api/claim-registry.json
+    sitemap = (ROOT / "sitemap.xml").read_text()
+    if "claim-registry.json" not in sitemap:
+        errors.append("sitemap.xml does not reference claim-registry.json")
+
+    # 3. llms.txt references claim registry
+    llms = (ROOT / "llms.txt").read_text()
+    if "claim" not in llms.lower() or "registry" not in llms.lower():
+        errors.append("llms.txt does not reference claim registry")
+
+    # 4. ai.txt references claim registry
+    ai = (ROOT / "ai.txt").read_text()
+    if "claim" not in ai.lower() or "registry" not in ai.lower():
+        errors.append("ai.txt does not reference claim registry")
+
+    # 5. RECOVERY.md references claim registry or claim traceability
+    recovery = (ROOT / "RECOVERY.md").read_text()
+    if "claim" not in recovery.lower() or "registry" not in recovery.lower():
+        errors.append("RECOVERY.md does not reference claim registry")
+
+    # 6. CORRECTION-REVOCATION-POLICY.md references claim correction path or claim registry
+    corrections = (ROOT / "CORRECTION-REVOCATION-POLICY.md").read_text()
+    if "claim" not in corrections.lower() or "registry" not in corrections.lower():
+        errors.append("CORRECTION-REVOCATION-POLICY.md does not reference claim registry")
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+        sys.exit(1)
+    print("CLAIM_REGISTRY_PUBLIC_LINKS_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_notarized_evidence_boundary.py
+++ b/scripts/test_notarized_evidence_boundary.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Test notarized evidence boundary (TA-REDTEAM-2026-017).
+
+Checks that NOTARIZED_EVIDENCE_CLAIM type exists, the boundary claim is correct,
+and notarized evidence does not count as formal attestation.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    errors = []
+    registry_path = ROOT / "api" / "claim-registry.json"
+    data = json.loads(registry_path.read_text())
+
+    # 1. claim_type_definitions has NOTARIZED_EVIDENCE_CLAIM
+    ctd = data.get("claim_type_definitions", {})
+    if "NOTARIZED_EVIDENCE_CLAIM" not in ctd:
+        errors.append("claim_type_definitions missing NOTARIZED_EVIDENCE_CLAIM")
+
+    # 2. notarized_evidence_is_not_formal_attestation claim exists
+    claims = {c["claim_id"]: c for c in data.get("claims", [])}
+    claim = claims.get("notarized_evidence_is_not_formal_attestation")
+    if not claim:
+        errors.append("notarized_evidence_is_not_formal_attestation claim not found")
+    else:
+        # 3. counts_as_independent_attestation == false
+        if claim.get("counts_as_independent_attestation") is not False:
+            errors.append("counts_as_independent_attestation must be false")
+        # 4. formal_attestation_gate_required == true
+        if claim.get("formal_attestation_gate_required") is not True:
+            errors.append("formal_attestation_gate_required must be true")
+        # 5. limitations mention formal independent attestation
+        limits = " ".join(claim.get("limitations", [])).lower()
+        if "formal independent attestation" not in limits:
+            errors.append("limitations must mention 'formal independent attestation'")
+        # 6. does_not_prove includes formal independent verification
+        dnp = " ".join(claim.get("does_not_prove", [])).lower()
+        if "formal independent verification" not in dnp:
+            errors.append("does_not_prove must include 'formal independent verification'")
+
+    # 7. independent-attestation schema/index does not admit notarized evidence automatically
+    ia_index = ROOT / "api" / "independent-attestation-index.json"
+    if ia_index.exists():
+        ia_data = json.loads(ia_index.read_text())
+        att_types = ia_data.get("attestation_types", [])
+        for at in att_types:
+            name = at.get("name", "").lower() if isinstance(at, dict) else str(at).lower()
+            if "notarized" in name:
+                # If notarized is listed, check it's not auto-counted
+                if isinstance(at, dict) and at.get("counts_as_independent") is True:
+                    errors.append("independent-attestation-index auto-counts notarized evidence")
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+        sys.exit(1)
+    print("NOTARIZED_EVIDENCE_BOUNDARY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_public_claim_traceability.py
+++ b/scripts/test_public_claim_traceability.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Test public claim traceability (TA-REDTEAM-2026-017).
+
+Checks that claim registry exists, covers required claims, and public surfaces reference it.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_CLAIM_IDS = {
+    "bitcoin_originals_are_canonical",
+    "github_pages_are_non_amending_mirror",
+    "btc_signature_binds_authority_manifest",
+    "eth_witness_is_secondary",
+    "digest_manifest_covers_evidence_integrity",
+    "release_pass_requires_corrections_index",
+    "echo_records_do_not_count_as_attestation",
+    "formal_attestation_requires_positive_gates",
+    "notarized_evidence_is_not_formal_attestation",
+    "recovery_is_clean_room_executable",
+    "github_free_verifier_bundle_is_deferred",
+    "nft_car_backups_are_recovery_mirrors_not_authority",
+    "scarcity_claim_is_framing_not_proof",
+}
+
+
+def main():
+    errors = []
+
+    # 1. Registry exists
+    registry_path = ROOT / "api" / "claim-registry.json"
+    if not registry_path.exists():
+        errors.append("api/claim-registry.json does not exist")
+        print(f"FAIL: {errors}")
+        sys.exit(1)
+
+    data = json.loads(registry_path.read_text())
+    claims = data.get("claims", [])
+    claim_ids = {c["claim_id"] for c in claims}
+
+    # 2. Required claim IDs
+    for rid in REQUIRED_CLAIM_IDS:
+        if rid not in claim_ids:
+            errors.append(f"Missing required claim_id: {rid}")
+
+    # 3. Every current/complete claim has required fields
+    for claim in claims:
+        cs = claim.get("current_status", "current")
+        ts = claim.get("traceability_status", "complete")
+        if cs in ("deferred", "planned") or ts in ("deferred",):
+            continue
+        cid = claim["claim_id"]
+        for field in ["public_surfaces", "source_files", "limitations", "does_not_prove", "corrections_path", "validators"]:
+            if not claim.get(field):
+                errors.append(f"Claim {cid}: {field} is empty or missing")
+
+    # 4. Public surfaces reference claim registry
+    llms = (ROOT / "llms.txt").read_text()
+    if "claim" not in llms.lower() or "registry" not in llms.lower():
+        errors.append("llms.txt does not reference claim registry")
+
+    ai = (ROOT / "ai.txt").read_text()
+    if "claim" not in ai.lower() or "registry" not in ai.lower():
+        errors.append("ai.txt does not reference claim registry")
+
+    links = json.loads((ROOT / "api" / "links.json").read_text())
+    machine = links.get("machine", [])
+    if not any("claim-registry" in m for m in machine):
+        errors.append("api/links.json does not reference claim-registry")
+
+    sitemap = (ROOT / "sitemap.xml").read_text()
+    if "claim-registry" not in sitemap:
+        errors.append("sitemap.xml does not reference claim-registry")
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+        sys.exit(1)
+    print("PUBLIC_CLAIM_TRACEABILITY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_scarcity_claim_methodology.py
+++ b/scripts/test_scarcity_claim_methodology.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Test scarcity claim methodology (TA-REDTEAM-2026-017).
+
+Checks that SCARCITY_OR_FIRSTNESS_CLAIM type exists, method_boundary is present,
+and forbidden firstness phrases are not used.
+"""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+FORBIDDEN_PHRASES = [
+    "proven first",
+    "absolute first",
+    "guaranteed first",
+    "world's first",
+    "unique in history",
+]
+
+
+def main():
+    errors = []
+    registry_path = ROOT / "api" / "claim-registry.json"
+    data = json.loads(registry_path.read_text())
+
+    # 1. SCARCITY_OR_FIRSTNESS_CLAIM type exists
+    ctd = data.get("claim_type_definitions", {})
+    if "SCARCITY_OR_FIRSTNESS_CLAIM" not in ctd:
+        errors.append("claim_type_definitions missing SCARCITY_OR_FIRSTNESS_CLAIM")
+
+    # 2. scarcity_claim_is_framing_not_proof exists
+    claims = {c["claim_id"]: c for c in data.get("claims", [])}
+    claim = claims.get("scarcity_claim_is_framing_not_proof")
+    if not claim:
+        errors.append("scarcity_claim_is_framing_not_proof claim not found")
+    else:
+        # 3. claim_type == SCARCITY_OR_FIRSTNESS_CLAIM
+        if claim.get("claim_type") != "SCARCITY_OR_FIRSTNESS_CLAIM":
+            errors.append(f"claim_type must be SCARCITY_OR_FIRSTNESS_CLAIM, got {claim.get('claim_type')}")
+        # 4. method_boundary exists
+        mb = claim.get("method_boundary")
+        if not mb:
+            errors.append("method_boundary is missing")
+        else:
+            # 5. method_boundary.status == bounded_framing_not_proof
+            if mb.get("status") != "bounded_framing_not_proof":
+                errors.append(f"method_boundary.status must be 'bounded_framing_not_proof', got '{mb.get('status')}'")
+            # 6. search_scope non-empty
+            if not mb.get("search_scope"):
+                errors.append("method_boundary.search_scope must be non-empty")
+            # 7. query_terms non-empty
+            if not mb.get("query_terms"):
+                errors.append("method_boundary.query_terms must be non-empty")
+            # 8. limitations non-empty
+            if not mb.get("limitations"):
+                errors.append("method_boundary.limitations must be non-empty")
+
+        # 9. does_not_prove includes firstness-related entry
+        dnp = " ".join(claim.get("does_not_prove", [])).lower()
+        firstness_terms = ["firstness", "absolute first", "proven first", "uniqueness"]
+        if not any(t in dnp for t in firstness_terms):
+            errors.append("does_not_prove must include firstness-related entry")
+
+        # 10. claim_text does not contain forbidden phrases
+        text_lower = claim.get("claim_text", "").lower()
+        for phrase in FORBIDDEN_PHRASES:
+            if phrase in text_lower:
+                errors.append(f"claim_text contains forbidden phrase: '{phrase}'")
+
+    # 11. Check all SCARCITY_OR_FIRSTNESS_CLAIM claims have method_boundary
+    for c in data.get("claims", []):
+        if c.get("claim_type") == "SCARCITY_OR_FIRSTNESS_CLAIM":
+            if not c.get("method_boundary"):
+                errors.append(f"Claim {c.get('claim_id')}: SCARCITY_OR_FIRSTNESS_CLAIM missing method_boundary")
+
+    if errors:
+        for e in errors:
+            print(f"FAIL: {e}")
+        sys.exit(1)
+    print("SCARCITY_CLAIM_METHODOLOGY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_claim_registry.py
+++ b/scripts/validate_claim_registry.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Validate api/claim-registry.json (TA-REDTEAM-2026-017).
+
+Usage:
+  python3 scripts/validate_claim_registry.py
+  python3 scripts/validate_claim_registry.py --self-test
+  python3 scripts/validate_claim_registry.py api/claim-registry.json
+"""
+import json
+import hashlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_REGISTRY = ROOT / "api" / "claim-registry.json"
+
+REQUIRED_SCHEMA = "trinity-accord.claim-registry.v1"
+REQUIRED_VERSION = "v1"
+
+REQUIRED_CLAIM_IDS = {
+    "bitcoin_originals_are_canonical",
+    "github_pages_are_non_amending_mirror",
+    "btc_signature_binds_authority_manifest",
+    "eth_witness_is_secondary",
+    "digest_manifest_covers_evidence_integrity",
+    "release_pass_requires_corrections_index",
+    "echo_records_do_not_count_as_attestation",
+    "formal_attestation_requires_positive_gates",
+    "notarized_evidence_is_not_formal_attestation",
+    "recovery_is_clean_room_executable",
+    "github_free_verifier_bundle_is_deferred",
+    "nft_car_backups_are_recovery_mirrors_not_authority",
+    "scarcity_claim_is_framing_not_proof",
+}
+
+ALLOWED_CURRENT_STATUSES = {
+    "current", "historical_only", "superseded", "revoked", "invalidated", "deferred", "planned"
+}
+ALLOWED_TRACEABILITY_STATUSES = {
+    "complete", "partial", "deferred", "missing"
+}
+
+FORBIDDEN_FIRSTNESS_PHRASES = [
+    "proven first",
+    "absolute first",
+    "guaranteed first",
+    "world's first",
+    "unique in history",
+]
+
+
+def _stable_json(v):
+    return json.dumps(v, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _compute_source_digest(data: dict) -> str:
+    """Compute source_digest: sha256 of canonical JSON with source_digest field omitted, truncated to 16 hex."""
+    data_no_digest = {k: v for k, v in data.items() if k != "source_digest"}
+    canonical = _stable_json(data_no_digest)
+    return hashlib.sha256(canonical.encode()).hexdigest()[:16]
+
+
+def validate(registry_path: str | Path) -> list[str]:
+    """Validate claim-registry.json. Returns list of errors."""
+    errors = []
+    path = Path(registry_path)
+
+    if not path.exists():
+        errors.append(f"File not found: {path}")
+        return errors
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        errors.append(f"Invalid JSON: {e}")
+        return errors
+
+    # Schema field
+    if data.get("schema") != REQUIRED_SCHEMA:
+        errors.append(f"schema must be {REQUIRED_SCHEMA}, got: {data.get('schema')}")
+
+    # Version
+    if data.get("version") != REQUIRED_VERSION:
+        errors.append(f"version must be {REQUIRED_VERSION}, got: {data.get('version')}")
+
+    # source_digest
+    stored_digest = data.get("source_digest")
+    if not stored_digest:
+        errors.append("source_digest is missing")
+    else:
+        expected = _compute_source_digest(data)
+        if stored_digest != expected:
+            errors.append(f"source_digest mismatch: stored={stored_digest}, expected={expected}")
+
+    # non_amending_boundary
+    if data.get("non_amending_boundary") is not True:
+        errors.append("non_amending_boundary must be true")
+
+    # canonical_authority
+    if data.get("canonical_authority") != "Bitcoin Originals only":
+        errors.append("canonical_authority must be 'Bitcoin Originals only'")
+
+    # Required top-level fields
+    for field in ["schema", "version", "source_digest_algorithm", "source_digest",
+                   "non_amending_boundary", "canonical_authority", "purpose",
+                   "claim_type_definitions", "claims", "limitations", "does_not_prove"]:
+        if field not in data:
+            errors.append(f"Missing required top-level field: {field}")
+
+    # claim_type_definitions must have required types
+    ctd = data.get("claim_type_definitions", {})
+    for required_type in ["NOTARIZED_EVIDENCE_CLAIM", "SCARCITY_OR_FIRSTNESS_CLAIM"]:
+        if required_type not in ctd:
+            errors.append(f"claim_type_definitions missing required type: {required_type}")
+
+    # Claims validation
+    claims = data.get("claims", [])
+    if not claims:
+        errors.append("claims array is empty")
+
+    claim_ids_seen = set()
+    for i, claim in enumerate(claims):
+        prefix = f"claims[{i}]"
+        cid = claim.get("claim_id", f"<no-id-{i}>")
+
+        # Required fields
+        for field in ["claim_id", "claim_type", "claim_text", "public_surfaces", "source_files",
+                       "evidence_files", "digest_or_hash_binding", "validators", "limitations",
+                       "does_not_prove", "corrections_path", "current_status", "traceability_status"]:
+            if field not in claim:
+                errors.append(f"{prefix} ({cid}): missing required field '{field}'")
+
+        # Unique claim_id
+        if cid in claim_ids_seen:
+            errors.append(f"Duplicate claim_id: {cid}")
+        claim_ids_seen.add(cid)
+
+        # Status values
+        cs = claim.get("current_status")
+        if cs and cs not in ALLOWED_CURRENT_STATUSES:
+            errors.append(f"{prefix} ({cid}): invalid current_status '{cs}'")
+        ts = claim.get("traceability_status")
+        if ts and ts not in ALLOWED_TRACEABILITY_STATUSES:
+            errors.append(f"{prefix} ({cid}): invalid traceability_status '{ts}'")
+
+        # Limitations and does_not_prove non-empty (unless deferred/planned)
+        if cs not in ("deferred", "planned"):
+            if not claim.get("limitations"):
+                errors.append(f"{prefix} ({cid}): limitations must be non-empty")
+            if not claim.get("does_not_prove"):
+                errors.append(f"{prefix} ({cid}): does_not_prove must be non-empty")
+
+        # corrections_path
+        if claim.get("corrections_path") != "api/corrections-index.json":
+            errors.append(f"{prefix} ({cid}): corrections_path must be 'api/corrections-index.json'")
+
+        # Validators non-empty unless deferred/planned
+        if cs not in ("deferred", "planned") and ts not in ("deferred",):
+            if not claim.get("validators"):
+                errors.append(f"{prefix} ({cid}): validators must be non-empty unless deferred/planned")
+
+        # Source files non-empty unless deferred/planned
+        if cs not in ("deferred", "planned") and ts not in ("deferred",):
+            if not claim.get("source_files"):
+                errors.append(f"{prefix} ({cid}): source_files must be non-empty unless deferred/planned")
+
+        # NOTARIZED_EVIDENCE_CLAIM checks
+        if claim.get("claim_type") == "NOTARIZED_EVIDENCE_CLAIM":
+            if claim.get("counts_as_independent_attestation") is not False:
+                errors.append(f"{prefix} ({cid}): NOTARIZED_EVIDENCE_CLAIM must have counts_as_independent_attestation=false")
+            if claim.get("formal_attestation_gate_required") is not True:
+                errors.append(f"{prefix} ({cid}): NOTARIZED_EVIDENCE_CLAIM must have formal_attestation_gate_required=true")
+            limits = " ".join(claim.get("limitations", [])).lower()
+            if "formal independent attestation" not in limits:
+                errors.append(f"{prefix} ({cid}): NOTARIZED_EVIDENCE_CLAIM limitations must mention 'formal independent attestation'")
+            dnp = " ".join(claim.get("does_not_prove", [])).lower()
+            if "formal independent verification" not in dnp:
+                errors.append(f"{prefix} ({cid}): NOTARIZED_EVIDENCE_CLAIM does_not_prove must include 'formal independent verification'")
+
+        # SCARCITY_OR_FIRSTNESS_CLAIM checks
+        if claim.get("claim_type") == "SCARCITY_OR_FIRSTNESS_CLAIM":
+            mb = claim.get("method_boundary")
+            if not mb:
+                errors.append(f"{prefix} ({cid}): SCARCITY_OR_FIRSTNESS_CLAIM must have method_boundary")
+            else:
+                if mb.get("status") != "bounded_framing_not_proof":
+                    errors.append(f"{prefix} ({cid}): method_boundary.status must be 'bounded_framing_not_proof'")
+                if not mb.get("limitations"):
+                    errors.append(f"{prefix} ({cid}): method_boundary.limitations must be non-empty")
+
+            # Check for forbidden firstness phrases in claim_text
+            claim_text_lower = claim.get("claim_text", "").lower()
+            for phrase in FORBIDDEN_FIRSTNESS_PHRASES:
+                if phrase in claim_text_lower:
+                    errors.append(f"{prefix} ({cid}): claim_text contains forbidden phrase '{phrase}'")
+
+            # does_not_prove must include firstness-related entry
+            dnp = " ".join(claim.get("does_not_prove", [])).lower()
+            firstness_terms = ["firstness", "absolute first", "proven first", "uniqueness"]
+            if not any(t in dnp for t in firstness_terms):
+                errors.append(f"{prefix} ({cid}): SCARCITY_OR_FIRSTNESS_CLAIM does_not_prove must include firstness-related entry")
+
+        # FORMAL_ATTESTATION_CLAIM checks
+        if claim.get("claim_type") == "FORMAL_ATTESTATION_CLAIM":
+            validators = claim.get("validators", [])
+            has_gate_validator = any("validate_independent_attestation" in v for v in validators)
+            if not has_gate_validator:
+                errors.append(f"{prefix} ({cid}): FORMAL_ATTESTATION_CLAIM must reference validate_independent_attestation_index.py")
+
+    # Check required claim IDs
+    for required_id in REQUIRED_CLAIM_IDS:
+        if required_id not in claim_ids_seen:
+            errors.append(f"Missing required claim_id: {required_id}")
+
+    # Top-level limitations and does_not_prove
+    if not data.get("limitations"):
+        errors.append("Top-level limitations must be non-empty")
+    if not data.get("does_not_prove"):
+        errors.append("Top-level does_not_prove must be non-empty")
+
+    # Check referenced files exist (source_files, evidence_files, validators)
+    for claim in claims:
+        cid = claim.get("claim_id", "?")
+        cs = claim.get("current_status", "current")
+        ts = claim.get("traceability_status", "complete")
+        if cs in ("deferred", "planned") or ts in ("deferred",):
+            continue
+        for sf in claim.get("source_files", []):
+            if not (ROOT / sf).exists():
+                errors.append(f"Claim {cid}: source_file not found: {sf}")
+        for ef in claim.get("evidence_files", []):
+            if not (ROOT / ef).exists():
+                errors.append(f"Claim {cid}: evidence_file not found: {ef}")
+        for v in claim.get("validators", []):
+            if not (ROOT / v).exists():
+                errors.append(f"Claim {cid}: validator not found: {v}")
+        for ps in claim.get("public_surfaces", []):
+            if ps.startswith("/") or ps.startswith("http"):
+                continue
+            if not (ROOT / ps).exists():
+                errors.append(f"Claim {cid}: public_surface not found: {ps}")
+
+    return errors
+
+
+def self_test() -> bool:
+    """Run self-test cases. Returns True if all pass."""
+    passed = 0
+    failed = 0
+
+    def _make_valid_registry():
+        """Return a minimal valid registry dict."""
+        data = json.loads(DEFAULT_REGISTRY.read_text(encoding="utf-8"))
+        return data
+
+    def _test_case(name: str, registry: dict, expect_pass: bool, check_fn=None):
+        nonlocal passed, failed
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(registry, f)
+            f.flush()
+            tmp_path = f.name
+        try:
+            errs = validate(tmp_path)
+            actual_pass = len(errs) == 0
+            if check_fn:
+                actual_pass = actual_pass and check_fn(errs)
+            if actual_pass == expect_pass:
+                passed += 1
+                print(f"  PASS: {name}")
+            else:
+                failed += 1
+                print(f"  FAIL: {name} (expected {'pass' if expect_pass else 'fail'}, got {'pass' if actual_pass else 'fail'})")
+                if errs:
+                    for e in errs[:3]:
+                        print(f"        {e}")
+        finally:
+            os.unlink(tmp_path)
+
+    print("Self-test cases:")
+    # 1. VALID registry accepted
+    _test_case("VALID registry accepted", _make_valid_registry(), True)
+
+    # 2. missing required claim id rejected
+    reg = _make_valid_registry()
+    reg["claims"] = [c for c in reg["claims"] if c["claim_id"] != "bitcoin_originals_are_canonical"]
+    _test_case("missing required claim id rejected", reg, False)
+
+    # 3. duplicate claim_id rejected
+    reg = _make_valid_registry()
+    dup = dict(reg["claims"][0])
+    reg["claims"].append(dup)
+    _test_case("duplicate claim_id rejected", reg, False)
+
+    # 4. missing corrections_path rejected
+    reg = _make_valid_registry()
+    del reg["claims"][0]["corrections_path"]
+    _test_case("missing corrections_path rejected", reg, False)
+
+    # 5. missing limitations rejected
+    reg = _make_valid_registry()
+    reg["claims"][0]["limitations"] = []
+    _test_case("missing limitations rejected", reg, False)
+
+    # 6. missing does_not_prove rejected
+    reg = _make_valid_registry()
+    reg["claims"][0]["does_not_prove"] = []
+    _test_case("missing does_not_prove rejected", reg, False)
+
+    # 7. non_amending_boundary=false rejected
+    reg = _make_valid_registry()
+    reg["non_amending_boundary"] = False
+    _test_case("non_amending_boundary=false rejected", reg, False)
+
+    # 8. canonical_authority wrong rejected
+    reg = _make_valid_registry()
+    reg["canonical_authority"] = "wrong"
+    _test_case("canonical_authority != Bitcoin Originals only rejected", reg, False)
+
+    # 9. notarized evidence counts_as_independent_attestation=true rejected
+    reg = _make_valid_registry()
+    for c in reg["claims"]:
+        if c["claim_id"] == "notarized_evidence_is_not_formal_attestation":
+            c["counts_as_independent_attestation"] = True
+    _test_case("notarized evidence counts_as_independent_attestation=true rejected", reg, False)
+
+    # 10. notarized evidence missing formal_attestation_gate_required rejected
+    reg = _make_valid_registry()
+    for c in reg["claims"]:
+        if c["claim_id"] == "notarized_evidence_is_not_formal_attestation":
+            del c["formal_attestation_gate_required"]
+    _test_case("notarized evidence missing formal_attestation_gate_required rejected", reg, False)
+
+    # 11. scarcity claim missing method_boundary rejected
+    reg = _make_valid_registry()
+    for c in reg["claims"]:
+        if c["claim_id"] == "scarcity_claim_is_framing_not_proof":
+            del c["method_boundary"]
+    _test_case("scarcity claim missing method_boundary rejected", reg, False)
+
+    # 12. scarcity claim saying "proven first" rejected
+    reg = _make_valid_registry()
+    for c in reg["claims"]:
+        if c["claim_id"] == "scarcity_claim_is_framing_not_proof":
+            c["claim_text"] = "This is proven first in history."
+    _test_case('scarcity claim saying "proven first" rejected', reg, False)
+
+    # 13. source_digest mismatch rejected
+    reg = _make_valid_registry()
+    reg["source_digest"] = "0000000000000000"
+    _test_case("source_digest mismatch rejected", reg, False)
+
+    # 14. missing validator path rejected
+    reg = _make_valid_registry()
+    for c in reg["claims"]:
+        if c["claim_id"] == "bitcoin_originals_are_canonical":
+            c["validators"] = ["scripts/nonexistent_validator.py"]
+    _test_case("missing validator path rejected", reg, False)
+
+    print(f"\n  Results: {passed} passed, {failed} failed")
+    return failed == 0
+
+
+def main():
+    if "--self-test" in sys.argv:
+        ok = self_test()
+        if ok:
+            print("\nSELF-TEST PASS")
+        else:
+            print("\nSELF-TEST FAIL")
+            sys.exit(1)
+        # Also validate actual file
+        errs = validate(DEFAULT_REGISTRY)
+        if errs:
+            print("CLAIM_REGISTRY_VALIDATION_ERRORS:")
+            for e in errs:
+                print(f"  - {e}")
+            sys.exit(1)
+        print("CLAIM_REGISTRY_OK")
+        return
+
+    # Determine path
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("--"):
+        registry_path = sys.argv[1]
+    else:
+        registry_path = DEFAULT_REGISTRY
+
+    errs = validate(registry_path)
+    if errs:
+        print(f"CLAIM_REGISTRY_VALIDATION_ERRORS ({len(errs)}):")
+        for e in errs:
+            print(f"  - {e}")
+        sys.exit(1)
+    else:
+        print("CLAIM_REGISTRY_OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -99,6 +99,7 @@
   <url><loc>https://www.trinityaccord.org/downloads/shenzhen-notary-github-release-backup-2026-05-06/</loc></url>
   <url><loc>https://www.trinityaccord.org/api/core-object-alpha-shenzhen-notary-2026-05-06.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/corrections-index.json</loc></url>
+  <url><loc>https://www.trinityaccord.org/api/claim-registry.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/recovery-index.json</loc></url>
   <url><loc>https://www.trinityaccord.org/RECOVERY.md</loc></url>
   <url><loc>https://www.trinityaccord.org/DISASTER-RECOVERY-DRILL.md</loc></url>


### PR DESCRIPTION
…thodology

Closes TA-REDTEAM-2026-017 findings:
- CLAIM-GRAPH-001: add api/claim-registry.json with machine-readable claim traceability
- CLAIM-NOTARY-001: predefine NOTARIZED_EVIDENCE_CLAIM ≠ formal attestation
- CLAIM-SCARCITY-001: add method_boundary for scarcity/firstness framing

New files:
- api/claim-registry.json (13 claims, 14 claim types)
- api/claim-registry-schema.v1.json
- scripts/validate_claim_registry.py (14 self-test cases)
- scripts/test_claim_registry.py
- scripts/test_public_claim_traceability.py
- scripts/test_notarized_evidence_boundary.py
- scripts/test_scarcity_claim_methodology.py
- scripts/test_claim_registry_public_links.py

Modified:
- .github/workflows/repository-integrity.yml (6 new CI steps)
- api/links.json, api/recovery-index.json
- sitemap.xml, llms.txt, ai.txt
- README.md, CORRECTION-REVOCATION-POLICY.md, RECOVERY.md