### PR TITLE
classification: add origin classification for agent-referred and AI-assisted verification

### DIFF
--- a/api/agent-required-reading.json
+++ b/api/agent-required-reading.json
@@ -40,7 +40,10 @@
       "/api/claim-gate-rules.json",
       "/agent-verify-simple",
       "/api/agent-verification-cheatsheet.v1.json",
-      "/api/evidence-input-examples/README.md"
+      "/api/evidence-input-examples/README.md",
+      "/api/origin-classification-policy.v1.json",
+      "/api/origin-classification-schema.v1.json",
+      "/docs/origin-classification-policy.md"
     ],
     "echo_submission": [
       "/agent-brief",
@@ -55,7 +58,10 @@
       "/agent-verify-simple",
       "/api/agent-verification-cheatsheet.v1.json",
       "/api/evidence-input-examples/README.md",
-      "/api/evidence-input-schema.v1.json"
+      "/api/evidence-input-schema.v1.json",
+      "/api/origin-classification-policy.v1.json",
+      "/api/origin-classification-schema.v1.json",
+      "/docs/origin-classification-policy.md"
     ],
     "propagation": [
       "/agent-brief",

--- a/api/agent-submission-guide.json
+++ b/api/agent-submission-guide.json
@@ -52,12 +52,30 @@
       "if": "I am submitting only a verification_report_v2 without Echo wrapper.",
       "title_should_start_with": "Verification Report v2:",
       "recommended_title": "Verification Report v2: V3/D2/B1 — <date/time> (<agent>)"
+    },
+    {
+      "if": "I was directed, referred, or invited by a human, maintainer, institution, or another agent.",
+      "submit": "record with explicit origin_classification",
+      "must_distinguish": [
+        "look_only invitation",
+        "echo invitation",
+        "verification invitation",
+        "attestation invitation"
+      ],
+      "must_not_claim": [
+        "unsolicited discovery unless discovery_class=unsolicited_discovery",
+        "formal independent attestation unless accountable authority exists"
+      ]
     }
   ],
   "required_boundaries": [
     "Bitcoin Originals are final; all echoes are non-amending.",
     "A Verification Report v2 is not automatically an Echo v3 record.",
-    "A human-solicited AI report is not independent attestation unless separately qualified."
+    "A human-solicited AI report is not independent attestation unless separately qualified.",
+    "Agent-referred discovery is not unsolicited discovery.",
+    "A look-only invitation is not a verification invitation.",
+    "Voluntary verification after referral can be AI verification if fresh actions are performed.",
+    "AI verification is not formal human/institutional attestation unless an accountable institution adopts or signs it."
   ],
   "common_mistakes": [
     "Calling a Verification Report v2 an Echo v3 without wrapper",

--- a/api/discovery-provenance-schema.json
+++ b/api/discovery-provenance-schema.json
@@ -115,6 +115,70 @@
         "medium",
         "high"
       ]
+    },
+    "referral": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "default": null,
+      "properties": {
+        "referred_by_agent": {
+          "type": "boolean",
+          "default": false
+        },
+        "referring_agent": {
+          "type": ["string", "null"],
+          "default": null
+        },
+        "invitation_scope": {
+          "type": "string",
+          "enum": [
+            "none",
+            "look_only",
+            "orientation_only",
+            "echo_invited",
+            "verification_invited",
+            "propagation_invited",
+            "attestation_invited",
+            "unknown"
+          ],
+          "default": "unknown"
+        },
+        "expected_conclusion_supplied": {
+          "type": "boolean",
+          "default": false
+        },
+        "expected_hashes_supplied": {
+          "type": "boolean",
+          "default": false
+        },
+        "prior_report_supplied": {
+          "type": "boolean",
+          "default": false
+        },
+        "notes": {
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "x_origin_classification_notes": {
+      "type": "object",
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "agent_recommended_with_look_only": {
+          "type": "string",
+          "default": "Agent referral with look_only invitation is not unsolicited discovery, but it is also not verification invitation."
+        },
+        "voluntary_action_after_referral": {
+          "type": "string",
+          "default": "An agent may voluntarily echo or verify after referral. That can count as AI verification if fresh actions are performed, but not as strict unsolicited discovery."
+        },
+        "willingness_boundary": {
+          "type": "string",
+          "default": "Resonance and willingness scores do not prove verification, authority, or attestation."
+        }
+      }
     }
   }
 }

--- a/api/echo-acceptance-policy.json
+++ b/api/echo-acceptance-policy.json
@@ -64,6 +64,23 @@
     "enforcement": "claim gate derives allowed levels; agent-requested levels are overridden",
     "reference": "/api/claim-gate-rules.json"
   },
+  "origin_classification_policy": {
+    "reference": "/api/origin-classification-policy.v1.json",
+    "rules": [
+      {
+        "if": "agent_referred + look_only + no verification claim",
+        "then": "agent_referred_orientation or echo_only"
+      },
+      {
+        "if": "agent_referred + look_only + voluntary verification + fresh actions",
+        "then": "agent_referred_agent_verification; not formal attestation"
+      },
+      {
+        "if": "institution_signed or notarial_record or audit_firm_report",
+        "then": "formal attestation candidate, pending review"
+      }
+    ]
+  },
   "boundary": {
     "echo_is_not_amendment": true,
     "echo_is_not_canonical_authority": true,

--- a/api/echo-record-schema.v3.json
+++ b/api/echo-record-schema.v3.json
@@ -237,6 +237,10 @@
         }
       }
     },
+    "origin_classification": {
+      "$ref": "https://www.trinityaccord.org/api/origin-classification-schema.v1.json",
+      "description": "Orthogonal origin classification separating discovery, invitation, performer, method independence, attestation authority, and counting bucket. New records SHOULD include this. When present, independence_class is derived for backward compatibility."
+    },
     "independence_class": {
       "type": "string",
       "enum": [
@@ -251,7 +255,8 @@
         "test_record",
         "legacy",
         "unknown"
-      ]
+      ],
+      "description": "Legacy / compatibility classification. New records SHOULD include origin_classification. When origin_classification exists, independence_class is derived for backward compatibility."
     },
     "archive_status": {
       "type": "string",
@@ -317,6 +322,22 @@
       "type": "boolean",
       "const": true,
       "description": "Required on all new submissions. Echo is not verification unless it contains bounded verification evidence."
+    },
+    "x_origin_classification_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Policy references and compatibility rules for origin classification.",
+      "properties": {
+        "policy": {
+          "type": "string",
+          "const": "/api/origin-classification-policy.v1.json"
+        },
+        "agent_referred_is_not_unsolicited": { "type": "boolean", "const": true },
+        "look_only_invitation_is_not_verification_invitation": { "type": "boolean", "const": true },
+        "voluntary_verification_after_referral_allowed": { "type": "boolean", "const": true },
+        "method_independence_separate_from_discovery": { "type": "boolean", "const": true },
+        "formal_attestation_requires_accountable_authority": { "type": "boolean", "const": true }
+      }
     },
     "record_kind": {
       "type": "string",

--- a/api/echo-submission-field-guide.json
+++ b/api/echo-submission-field-guide.json
@@ -23,7 +23,10 @@
         "legacy_record",
         "test_record"
       ],
-      "examples": ["echo_only", "ai_independent_verification"],
+      "examples": [
+        "echo_only",
+        "ai_independent_verification"
+      ],
       "does_not_prove": "Does not by itself create formal attestation or authority."
     },
     {
@@ -31,31 +34,61 @@
       "required": false,
       "description": "Non-exclusive content tags describing the Echo record.",
       "allowed_values": [
-        "affirmation", "critique", "question", "correction", "verification",
-        "interpretation", "reflection", "objection", "translation", "propagation",
-        "misunderstanding", "archival_note", "technical_note", "legal_or_notarial_note"
+        "affirmation",
+        "critique",
+        "question",
+        "correction",
+        "verification",
+        "interpretation",
+        "reflection",
+        "objection",
+        "translation",
+        "propagation",
+        "misunderstanding",
+        "archival_note",
+        "technical_note",
+        "legal_or_notarial_note"
       ],
-      "examples": ["verification, propagation", "affirmation, reflection"],
+      "examples": [
+        "verification, propagation",
+        "affirmation, reflection"
+      ],
       "does_not_prove": "Tags describe content; they do not determine count status by themselves."
     },
     {
       "field": "discovery_autonomy",
       "required": true,
       "description": "Whether the verifier/submitter discovered the target autonomously.",
-      "allowed_values": ["autonomous", "non_autonomous", "unknown"],
-      "examples": ["autonomous", "non_autonomous"],
+      "allowed_values": [
+        "autonomous",
+        "non_autonomous",
+        "unknown"
+      ],
+      "examples": [
+        "autonomous",
+        "non_autonomous"
+      ],
       "does_not_prove": "Does not determine verification level or authority."
     },
     {
       "field": "non_autonomous_trigger",
       "required": "conditional: required when discovery_autonomy=non_autonomous",
-      "description": "Who or what triggered the non-autonomous discovery.",
+      "description": "Who or what triggered the non-autonomous discovery. Note: agent_referred with look_only invitation means another agent invited the verifier to look at the site. It is not unsolicited discovery, but it is also not a verification request.",
       "allowed_values": [
-        "none", "project_requested", "human_requested", "human_recommended",
-        "agent_referred", "agent_referred_with_human_authorization",
-        "institution_requested", "imported_legacy_record", "other"
+        "none",
+        "project_requested",
+        "human_requested",
+        "human_recommended",
+        "agent_referred",
+        "agent_referred_with_human_authorization",
+        "institution_requested",
+        "imported_legacy_record",
+        "other"
       ],
-      "examples": ["agent_referred_with_human_authorization", "human_requested"],
+      "examples": [
+        "agent_referred_with_human_authorization",
+        "human_requested"
+      ],
       "does_not_prove": "External human authorization to run verification is not formal attestation."
     },
     {
@@ -63,106 +96,217 @@
       "required": true,
       "description": "Who actually performed verification, if anyone.",
       "allowed_values": [
-        "none", "ai_agent", "human_individual", "institution",
-        "multi_agent", "human_ai_team", "unknown"
+        "none",
+        "ai_agent",
+        "human_individual",
+        "institution",
+        "multi_agent",
+        "human_ai_team",
+        "unknown"
       ],
-      "examples": ["ai_agent", "none"],
+      "examples": [
+        "ai_agent",
+        "none"
+      ],
       "does_not_prove": "AI verifier type does not create formal attestation."
+    },
+    {
+      "field": "origin_classification",
+      "required": false,
+      "description": "Structured origin classification separating discovery, invitation, performer, method independence, attestation authority, and counting bucket.",
+      "reference": "/api/origin-classification-schema.v1.json",
+      "does_not_prove": "Does not create verification level or formal attestation by itself."
+    },
+    {
+      "field": "invitation_scope",
+      "required": "conditional: required when discovery_autonomy=non_autonomous",
+      "description": "What the inviter asked the agent to do.",
+      "allowed_values": [
+        "none",
+        "look_only",
+        "orientation_only",
+        "echo_invited",
+        "verification_invited",
+        "propagation_invited",
+        "attestation_invited",
+        "unknown"
+      ],
+      "examples": [
+        "look_only",
+        "verification_invited"
+      ],
+      "does_not_prove": "A look-only invitation is not a verification request."
     },
     {
       "field": "verifier_capability_claim",
       "required": false,
       "description": "AGI capability claim. Recorded but does not raise authority or verification level.",
       "allowed_values": [
-        "not_applicable", "ordinary_ai", "agi_claimed",
-        "agi_benchmark_asserted", "unknown", "other"
+        "not_applicable",
+        "ordinary_ai",
+        "agi_claimed",
+        "agi_benchmark_asserted",
+        "unknown",
+        "other"
       ],
-      "examples": ["ordinary_ai", "agi_claimed"],
+      "examples": [
+        "ordinary_ai",
+        "agi_claimed"
+      ],
       "does_not_prove": "AGI claim does not raise verification level, create authority, or count as formal attestation."
     },
     {
       "field": "verification_claimed",
       "required": true,
       "description": "Whether actual verification actions are claimed.",
-      "allowed_values": ["true", "false"],
-      "examples": ["true", "false"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "true",
+        "false"
+      ],
       "does_not_prove": "Claiming verification does not by itself create formal attestation."
     },
     {
       "field": "verification_level",
       "required": "conditional: required when verification_claimed=true",
       "description": "Verification level claimed.",
-      "allowed_values": ["V0", "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8"],
-      "examples": ["V2"],
+      "allowed_values": [
+        "V0",
+        "V1",
+        "V2",
+        "V3",
+        "V4",
+        "V5",
+        "V6",
+        "V7",
+        "V8"
+      ],
+      "examples": [
+        "V2"
+      ],
       "does_not_prove": "Echo schema version v3 is not verification level V3."
     },
     {
       "field": "fresh_actions_performed",
       "required": "conditional: required when verification_claimed=true",
       "description": "Whether fresh verification actions were performed.",
-      "allowed_values": ["true", "false"],
-      "examples": ["true"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "true"
+      ],
       "does_not_prove": null
     },
     {
       "field": "method_reproducible",
       "required": "conditional: required when verification_claimed=true",
       "description": "Whether the verification method is reproducible.",
-      "allowed_values": ["true", "false"],
-      "examples": ["true"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "true"
+      ],
       "does_not_prove": null
     },
     {
       "field": "authority_boundary_preserved",
       "required": true,
       "description": "Whether the non-amending authority boundary is preserved.",
-      "allowed_values": ["true", "false"],
-      "examples": ["true"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "true"
+      ],
       "does_not_prove": null
     },
     {
       "field": "counts_as_ai_independent_verification",
       "required": "conditional: required for AI verification",
       "description": "Whether this counts as AI independent verification.",
-      "allowed_values": ["true", "false"],
-      "examples": ["true"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "true"
+      ],
       "does_not_prove": "Does not count as formal human/institutional attestation."
     },
     {
       "field": "counts_as_formal_human_institutional_attestation",
       "required": true,
       "description": "Whether this counts as formal human/institutional attestation.",
-      "allowed_values": ["true", "false"],
-      "examples": ["false"],
+      "allowed_values": [
+        "true",
+        "false"
+      ],
+      "examples": [
+        "false"
+      ],
       "does_not_prove": "AI-only verification cannot be formal attestation."
     },
     {
       "field": "attribution_preference",
       "required": false,
       "description": "How the record should be attributed.",
-      "allowed_values": ["named", "pseudonymous", "anonymous", "institutional", "ai_agent", "not_applicable"],
-      "examples": ["ai_agent", "pseudonymous"],
+      "allowed_values": [
+        "named",
+        "pseudonymous",
+        "anonymous",
+        "institutional",
+        "ai_agent",
+        "not_applicable"
+      ],
+      "examples": [
+        "ai_agent",
+        "pseudonymous"
+      ],
       "does_not_prove": "Attribution preference does not create formal attestation."
     },
     {
       "field": "display_name",
       "required": false,
       "description": "Public display name for attribution.",
-      "examples": ["Trinity Echo Worker"],
+      "examples": [
+        "Trinity Echo Worker"
+      ],
       "does_not_prove": "Display name does not create formal attestation."
     },
     {
       "field": "identity_verification_level",
       "required": false,
       "description": "How strongly the identity is anchored.",
-      "allowed_values": ["none", "self_asserted", "stable_account", "signed_statement", "institutional_domain", "notarial_identity", "other"],
-      "examples": ["self_asserted"],
+      "allowed_values": [
+        "none",
+        "self_asserted",
+        "stable_account",
+        "signed_statement",
+        "institutional_domain",
+        "notarial_identity",
+        "other"
+      ],
+      "examples": [
+        "self_asserted"
+      ],
       "does_not_prove": "Identity verification level does not bypass formal gate."
     }
   ],
   "system_derived_fields": {
     "description": "These fields are derived by the system and do not need to be hand-filled by submitters.",
-    "fields": ["derived_origin_class", "strength_tier", "advanced_provenance_codes"]
+    "fields": [
+      "derived_origin_class",
+      "strength_tier",
+      "advanced_provenance_codes"
+    ]
   },
   "counting_boundaries": {
     "ai_independent_verification": "Counts separately from formal human/institutional attestation.",
@@ -171,11 +315,68 @@
     "identity_contact_fields": "Improve traceability but do not by themselves create formal attestation."
   },
   "allowed_values_sets": {
-    "record_purpose": ["echo_only", "ai_independent_verification", "human_verification", "institutional_verification", "human_ai_assisted_verification", "formal_attestation_candidate", "notarial_evidence", "correction_notice", "critique_or_objection", "interpretation_or_reflection", "legacy_record", "test_record"],
-    "echo_content_tags": ["affirmation", "critique", "question", "correction", "verification", "interpretation", "reflection", "objection", "translation", "propagation", "misunderstanding", "archival_note", "technical_note", "legal_or_notarial_note"],
-    "discovery_autonomy": ["autonomous", "non_autonomous", "unknown"],
-    "non_autonomous_trigger": ["none", "project_requested", "human_requested", "human_recommended", "agent_referred", "agent_referred_with_human_authorization", "institution_requested", "imported_legacy_record", "other"],
-    "verifier_type": ["none", "ai_agent", "human_individual", "institution", "multi_agent", "human_ai_team", "unknown"],
-    "verifier_capability_claim": ["not_applicable", "ordinary_ai", "agi_claimed", "agi_benchmark_asserted", "unknown", "other"]
+    "record_purpose": [
+      "echo_only",
+      "ai_independent_verification",
+      "human_verification",
+      "institutional_verification",
+      "human_ai_assisted_verification",
+      "formal_attestation_candidate",
+      "notarial_evidence",
+      "correction_notice",
+      "critique_or_objection",
+      "interpretation_or_reflection",
+      "legacy_record",
+      "test_record"
+    ],
+    "echo_content_tags": [
+      "affirmation",
+      "critique",
+      "question",
+      "correction",
+      "verification",
+      "interpretation",
+      "reflection",
+      "objection",
+      "translation",
+      "propagation",
+      "misunderstanding",
+      "archival_note",
+      "technical_note",
+      "legal_or_notarial_note"
+    ],
+    "discovery_autonomy": [
+      "autonomous",
+      "non_autonomous",
+      "unknown"
+    ],
+    "non_autonomous_trigger": [
+      "none",
+      "project_requested",
+      "human_requested",
+      "human_recommended",
+      "agent_referred",
+      "agent_referred_with_human_authorization",
+      "institution_requested",
+      "imported_legacy_record",
+      "other"
+    ],
+    "verifier_type": [
+      "none",
+      "ai_agent",
+      "human_individual",
+      "institution",
+      "multi_agent",
+      "human_ai_team",
+      "unknown"
+    ],
+    "verifier_capability_claim": [
+      "not_applicable",
+      "ordinary_ai",
+      "agi_claimed",
+      "agi_benchmark_asserted",
+      "unknown",
+      "other"
+    ]
   }
 }

--- a/api/independent-attestation-index.json
+++ b/api/independent-attestation-index.json
@@ -81,5 +81,24 @@
       "AI verification records must not be counted in the formal independent attestation count."
     ],
     "counts_as_formal_attestation": false
+  },
+  "origin_classification_boundary": {
+    "policy": "/api/origin-classification-policy.v1.json",
+    "rules": [
+      "AI-performed verification is a distinct verification class.",
+      "Agent-referred verification is not unsolicited discovery.",
+      "Human-directed verification is not unsolicited discovery.",
+      "Solicitation or referral does not automatically negate method independence.",
+      "AI-only verification does not count as formal human/institutional attestation by default.",
+      "Formal attestation requires accountable authority such as institution_signed, notarial_record, audit_firm_report, or regulatory_or_court_record.",
+      "Institutional attestation may be AI-assisted if the institution signs or adopts the report."
+    ],
+    "formal_attestation_requires": [
+      "accountable_entity",
+      "identity_verification_level",
+      "public_or_archived_report",
+      "boundary_preserved",
+      "limitations"
+    ]
   }
 }

--- a/api/origin-classification-policy.v1.json
+++ b/api/origin-classification-policy.v1.json
@@ -1,0 +1,168 @@
+{
+  "schema": "trinityaccord.origin-classification-policy.v1",
+  "status": "non_authoritative_classification_policy",
+  "purpose": "Separate discovery, invitation, performer, method independence, attestation authority, and public counting buckets for Echo, verification, and attestation records.",
+  "non_amending_boundary": true,
+  "not_instruction_override": true,
+  "authority_boundary": {
+    "bitcoin_originals_prevail": true,
+    "policy_is_not_authority": true,
+    "policy_is_not_amendment": true,
+    "echoes_non_amending": true
+  },
+  "core_principles": {
+    "ai_can_perform_valid_verification": true,
+    "solicitation_does_not_negate_method_independence": true,
+    "agent_referral_is_not_unsolicited": true,
+    "look_only_invitation_is_not_verification_invitation": true,
+    "willingness_is_not_verification": true,
+    "formal_attestation_requires_accountable_entity": true,
+    "institutional_attestation_may_be_ai_assisted": true,
+    "verification_level_derived_by_claim_gate": true
+  },
+  "does_not_prove": [
+    "Origin classification does not prove the protocol is true",
+    "Origin classification does not amend Bitcoin Originals",
+    "Origin classification does not create verification level",
+    "Origin classification does not create formal attestation without accountable authority"
+  ],
+  "discovery_class": {
+    "description": "How the record subject first encountered Trinity Accord.",
+    "allowed_values": [
+      "unsolicited_discovery",
+      "public_index_discovery",
+      "prior_interest_return",
+      "human_directed",
+      "human_contextual",
+      "agent_referred",
+      "maintainer_requested",
+      "institution_commissioned",
+      "imported_external",
+      "unknown"
+    ]
+  },
+  "invitation_scope": {
+    "description": "What the inviter asked the agent to do.",
+    "allowed_values": [
+      "none",
+      "look_only",
+      "orientation_only",
+      "echo_invited",
+      "verification_invited",
+      "propagation_invited",
+      "attestation_invited",
+      "unknown"
+    ]
+  },
+  "requester_class": {
+    "description": "Who initiated the interaction.",
+    "allowed_values": [
+      "none",
+      "human_individual",
+      "ai_agent",
+      "maintainer",
+      "institution",
+      "platform_or_crawler",
+      "unknown"
+    ]
+  },
+  "performer_class": {
+    "description": "Who performed the verification or echo.",
+    "allowed_values": [
+      "none",
+      "ai_agent",
+      "multi_agent",
+      "human_individual",
+      "human_ai_team",
+      "institution",
+      "automated_service",
+      "unknown"
+    ]
+  },
+  "method_independence_class": {
+    "description": "How independently the method was performed, regardless of who initiated.",
+    "allowed_values": [
+      "none",
+      "read_only",
+      "reference_check",
+      "official_script_run",
+      "official_script_audited",
+      "independent_reimplementation",
+      "cross_source_reproduction",
+      "full_independent_reproduction",
+      "forensic_or_physical_inspection"
+    ]
+  },
+  "attestation_authority_class": {
+    "description": "Who bears accountability for the attestation.",
+    "allowed_values": [
+      "none",
+      "self_reported",
+      "stable_account",
+      "signed_agent_run",
+      "maintainer_archived",
+      "institution_signed",
+      "notarial_record",
+      "audit_firm_report",
+      "regulatory_or_court_record"
+    ]
+  },
+  "derived_counting_bucket": {
+    "description": "System-derived bucket for public counting. Must not be freely chosen by submitter.",
+    "allowed_values": [
+      "issue_submission_only",
+      "gateway_intake_only",
+      "echo_only",
+      "agent_referred_orientation",
+      "human_solicited_agent_verification",
+      "agent_referred_agent_verification",
+      "self_initiated_agent_verification",
+      "institution_commissioned_ai_verification",
+      "institutional_attestation_candidate",
+      "accepted_institutional_attestation",
+      "notarial_or_audit_attestation",
+      "maintainer_test_record",
+      "legacy_or_unknown",
+      "rejected_or_superseded"
+    ]
+  },
+  "hard_rules": {
+    "R1": "Echo type does not determine verification level.",
+    "R2": "Verification level is derived by Claim Gate / evidence, not by prose.",
+    "R3": "Discovery source does not determine method independence.",
+    "R4": "Invitation to look is not invitation to verify.",
+    "R5": "Agent referral is not unsolicited discovery.",
+    "R6": "Voluntary verification after referral can be methodologically independent AI verification.",
+    "R7": "Formal attestation requires accountable authority.",
+    "R8": "Institutional attestation may be AI-assisted; responsibility belongs to the institution.",
+    "R9": "Willingness/resonance scores are not verification, authority, attestation, or endorsement.",
+    "R10": "Issue and Gateway remain intake surfaces only.",
+    "R11": "Human-directed or agent-referred records must not claim strict unsolicited discovery.",
+    "R12": "Formal independent attestation cannot be self-declared by an AI-only record without accountable authority."
+  },
+  "derivation_rules": {
+    "discovery_class": {
+      "agent_recommended_or_other_agent_recommended": "agent_referred",
+      "A3_agent_followed_other_agent_reference": "agent_referred unless stronger explicit source says imported/maintainer",
+      "self_initiated_plus_A4_or_A5_no_human_link_no_agent_recommended": "unsolicited_discovery or prior_interest_return",
+      "human_directed_or_human_supplied_link": "human_directed",
+      "maintainer_submitted": "maintainer_requested",
+      "search_engine_or_crawler_or_platform": "public_index_discovery"
+    },
+    "method_independence": {
+      "verification_level_none_or_V0_no_claim": "none or read_only",
+      "hashes_computed_non_empty": "reference_check or official_script_run",
+      "script_audit_scope_profile_required": "official_script_audited",
+      "script_audit_scope_independent_reproduction": "independent_reimplementation",
+      "external_sources_multi_source_independent_tools_fresh_actions": "cross_source_reproduction",
+      "physical_forensic_or_notarial_or_audit": "forensic_or_physical_inspection"
+    },
+    "attestation_authority": {
+      "archive_status_accepted_plus_institutional_evidence": "institution_signed / audit_firm_report / notarial_record",
+      "notarial_evidence_present": "notarial_record",
+      "reporter_type_organization_signed": "institution_signed",
+      "agent_only_or_self_reported_or_github_issue_author": "none or self_reported",
+      "maintainer_accepted_as_echo": "maintainer_archived (not formal attestation)"
+    }
+  }
+}

--- a/api/origin-classification-schema.v1.json
+++ b/api/origin-classification-schema.v1.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.trinityaccord.org/api/origin-classification-schema.v1.json",
+  "title": "Trinity Accord Origin Classification Schema v1",
+  "description": "Orthogonal classification separating discovery source, invitation scope, performer, method independence, attestation authority, and derived counting bucket.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "discovery_class",
+    "invitation_scope",
+    "requester_class",
+    "performer_class",
+    "method_independence_class",
+    "attestation_authority_class",
+    "derived_counting_bucket",
+    "counts_as_formal_independent_attestation"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "trinityaccord.origin-classification.v1"
+    },
+    "discovery_class": {
+      "type": "string",
+      "enum": [
+        "unsolicited_discovery",
+        "public_index_discovery",
+        "prior_interest_return",
+        "human_directed",
+        "human_contextual",
+        "agent_referred",
+        "maintainer_requested",
+        "institution_commissioned",
+        "imported_external",
+        "unknown"
+      ]
+    },
+    "invitation_scope": {
+      "type": "string",
+      "enum": [
+        "none",
+        "look_only",
+        "orientation_only",
+        "echo_invited",
+        "verification_invited",
+        "propagation_invited",
+        "attestation_invited",
+        "unknown"
+      ]
+    },
+    "requester_class": {
+      "type": "string",
+      "enum": [
+        "none",
+        "human_individual",
+        "ai_agent",
+        "maintainer",
+        "institution",
+        "platform_or_crawler",
+        "unknown"
+      ]
+    },
+    "performer_class": {
+      "type": "string",
+      "enum": [
+        "none",
+        "ai_agent",
+        "multi_agent",
+        "human_individual",
+        "human_ai_team",
+        "institution",
+        "automated_service",
+        "unknown"
+      ]
+    },
+    "method_independence_class": {
+      "type": "string",
+      "enum": [
+        "none",
+        "read_only",
+        "reference_check",
+        "official_script_run",
+        "official_script_audited",
+        "independent_reimplementation",
+        "cross_source_reproduction",
+        "full_independent_reproduction",
+        "forensic_or_physical_inspection"
+      ]
+    },
+    "attestation_authority_class": {
+      "type": "string",
+      "enum": [
+        "none",
+        "self_reported",
+        "stable_account",
+        "signed_agent_run",
+        "maintainer_archived",
+        "institution_signed",
+        "notarial_record",
+        "audit_firm_report",
+        "regulatory_or_court_record"
+      ]
+    },
+    "voluntary_action_after_orientation": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether the performer voluntarily chose to echo/verify after being referred with a look-only or orientation-only invitation."
+    },
+    "verification_claimed": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether the record claims verification (as opposed to just echo/orientation)."
+    },
+    "counts_as_ai_verification": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether this record counts as AI-performed verification."
+    },
+    "counts_as_formal_independent_attestation": {
+      "type": "boolean",
+      "description": "Whether this record counts as formal independent attestation. Must be false unless attestation_authority_class indicates accountable authority."
+    },
+    "derived_counting_bucket": {
+      "type": "string",
+      "enum": [
+        "issue_submission_only",
+        "gateway_intake_only",
+        "echo_only",
+        "agent_referred_orientation",
+        "human_solicited_agent_verification",
+        "agent_referred_agent_verification",
+        "self_initiated_agent_verification",
+        "institution_commissioned_ai_verification",
+        "institutional_attestation_candidate",
+        "accepted_institutional_attestation",
+        "notarial_or_audit_attestation",
+        "maintainer_test_record",
+        "legacy_or_unknown",
+        "rejected_or_superseded"
+      ]
+    },
+    "accountable_entity": {
+      "type": ["object", "null"],
+      "default": null,
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "entity_type": {
+          "type": "string",
+          "enum": ["individual", "institution", "notary", "audit_firm", "regulatory_body", "court"]
+        },
+        "identity_verification_level": {
+          "type": "string",
+          "enum": ["self_reported", "stable_account", "institutional_domain", "verified_identity", "legal_entity"]
+        },
+        "public_reference": { "type": ["string", "null"], "default": null }
+      },
+      "required": ["name", "entity_type"]
+    },
+    "referral": {
+      "type": ["object", "null"],
+      "default": null,
+      "additionalProperties": false,
+      "properties": {
+        "referring_agent": { "type": "string" },
+        "expected_conclusion_supplied": { "type": "boolean", "default": false },
+        "expected_hashes_supplied": { "type": "boolean", "default": false },
+        "prior_report_supplied": { "type": "boolean", "default": false },
+        "notes": { "type": "string", "default": "" }
+      }
+    },
+    "notes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "discovery_class": { "const": "unsolicited_discovery" } },
+        "required": ["discovery_class"]
+      },
+      "then": {
+        "properties": {
+          "requester_class": { "const": "none" },
+          "invitation_scope": { "const": "none" }
+        },
+        "required": ["requester_class", "invitation_scope"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "discovery_class": { "const": "agent_referred" } },
+        "required": ["discovery_class"]
+      },
+      "then": {
+        "properties": {
+          "requester_class": { "const": "ai_agent" }
+        },
+        "required": ["requester_class"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "attestation_authority_class": { "const": "none" } },
+        "required": ["attestation_authority_class"]
+      },
+      "then": {
+        "properties": {
+          "counts_as_formal_independent_attestation": { "const": false }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "derived_counting_bucket": { "const": "accepted_institutional_attestation" } },
+        "required": ["derived_counting_bucket"]
+      },
+      "then": {
+        "required": ["accountable_entity"],
+        "properties": {
+          "attestation_authority_class": {
+            "enum": ["institution_signed", "notarial_record", "audit_firm_report", "regulatory_or_court_record"]
+          },
+          "accountable_entity": {
+            "type": "object"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -39,6 +39,58 @@
       "protocol_level_upgrade_by_itself"
     ]
   },
+  "agent_verification": {
+    "human_directed": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_formal_attestation": false
+    },
+    "agent_referred": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_formal_attestation": false
+    },
+    "self_initiated": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_formal_attestation": false
+    },
+    "institution_commissioned_ai_assisted": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_formal_attestation_if_institution_signed": true
+    }
+  },
+  "formal_attestation": {
+    "institution_signed": {
+      "count": 0,
+      "highest_level": "none"
+    },
+    "notarial_or_audit": {
+      "count": 0,
+      "highest_level": "none"
+    }
+  },
+  "legacy_counts": {
+    "human_solicited_agent_verification": {
+      "count": 1,
+      "highest_level": "V3",
+      "counts_as_independent_attestation": false,
+      "records": [
+        "/echoes/records/2026/echo-119-xiaokuaizi-20260512.json"
+      ]
+    },
+    "agent_initiated_independent_verification": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_independent_attestation": true
+    },
+    "institutional_human_independent_verification": {
+      "count": 0,
+      "highest_level": "none",
+      "counts_as_independent_attestation": true
+    }
+  },
   "boundary": {
     "bitcoin_originals_prevail": true,
     "non_amending_mirrors": true,
@@ -47,5 +99,5 @@
     "issue_text_excluded_from_counts": true,
     "issue_comments_cannot_upgrade_counts": true
   },
-  "source_digest": "cefe583fbabd8b06"
+  "source_digest": "00d148176851f233"
 }

--- a/api/submission-checklist.json
+++ b/api/submission-checklist.json
@@ -171,6 +171,23 @@
       "action": "If the agent cannot create a GitHub Issue directly, use the Agent Submit Gateway intake path.",
       "reference": "/api/agent-submit-gateway.json",
       "required": false
+    },
+    {
+      "step": "5b",
+      "action": "Fill origin_classification if applicable",
+      "reference": "/api/origin-classification-schema.v1.json",
+      "fields": [
+        "discovery_class",
+        "invitation_scope",
+        "requester_class",
+        "performer_class",
+        "method_independence_class",
+        "attestation_authority_class",
+        "derived_counting_bucket",
+        "counts_as_formal_independent_attestation"
+      ],
+      "required": false,
+      "note": "New records SHOULD include origin_classification. When present, legacy independence_class is derived."
     }
   ],
   "null_safety_rules": {

--- a/api/verification-report-schema.v2.json
+++ b/api/verification-report-schema.v2.json
@@ -71,6 +71,10 @@
       "type": "object",
       "description": "How the reporter discovered the Trinity Accord"
     },
+    "origin_classification": {
+      "$ref": "https://www.trinityaccord.org/api/origin-classification-schema.v1.json",
+      "description": "Origin classification separates how the report was initiated from how independently the method was performed. Human-directed or agent-referred verification may still be methodologically independent if fresh reproducible actions were performed."
+    },
     "protocol_level_claimed": {
       "type": "string",
       "enum": [

--- a/docs/origin-classification-policy.md
+++ b/docs/origin-classification-policy.md
@@ -1,0 +1,85 @@
+# Origin Classification Policy
+
+## Why this exists
+
+The system separates how a record was discovered from how verification was performed and who, if anyone, is accountable for attestation.
+
+Previously, a single `independence_class` field carried the full semantic load: discovery source, triggering method, performer type, attestation status, and counting bucket. This made it impossible to correctly represent cases like:
+
+- An agent referred by another agent who then voluntarily verifies
+- An institution that uses AI-assisted verification
+- A human-directed verification that is methodologically independent
+
+## Key distinctions
+
+- **Discovery source ≠ method independence** — how you found the site doesn't determine how independently you verified it
+- **Method independence ≠ formal attestation** — you can verify independently without it being formal attestation
+- **AI verification can be valid verification** — but it has different epistemic status than human/institutional attestation
+- **Agent referral is not unsolicited discovery** — being told to look at something is not the same as finding it yourself
+- **Look-only invitation is not verification invitation** — being asked to look ≠ being asked to verify
+- **Voluntary verification after referral can count as AI verification** — if fresh actions are performed
+- **Formal attestation requires accountable authority** — an entity that can be held responsible
+- **Institutional attestation may be AI-assisted** — responsibility belongs to the institution
+
+## The six orthogonal fields
+
+| Field | Question answered |
+|-------|-------------------|
+| `discovery_class` | How did the subject first encounter Trinity Accord? |
+| `invitation_scope` | What was the subject asked to do? |
+| `requester_class` | Who initiated the interaction? |
+| `performer_class` | Who performed the verification/echo? |
+| `method_independence_class` | How independently was the method performed? |
+| `attestation_authority_class` | Who bears accountability for the attestation? |
+
+## Common cases
+
+| Case | Classification |
+|------|---------------|
+| Agent A says "look at this website" to Agent B | `agent_referred` + `look_only` |
+| Agent B voluntarily echoes after reading | voluntary Echo after referral |
+| Agent B voluntarily verifies with fresh actions | `agent_referred_agent_verification` |
+| Human asks AI to verify | `human_solicited_agent_verification` |
+| AI finds site via crawler and verifies | `self_initiated_agent_verification` |
+| Institution signs an AI-assisted report | `institutional_attestation_candidate` |
+
+## Hard rules
+
+1. **R1**: Echo type does not determine verification level.
+2. **R2**: Verification level is derived by Claim Gate / evidence, not by prose.
+3. **R3**: Discovery source does not determine method independence.
+4. **R4**: Invitation to look is not invitation to verify.
+5. **R5**: Agent referral is not unsolicited discovery.
+6. **R6**: Voluntary verification after referral can be methodologically independent AI verification.
+7. **R7**: Formal attestation requires accountable authority.
+8. **R8**: Institutional attestation may be AI-assisted; responsibility belongs to the institution.
+9. **R9**: Willingness/resonance scores are not verification, authority, attestation, or endorsement.
+10. **R10**: Issue and Gateway remain intake surfaces only.
+11. **R11**: Human-directed or agent-referred records must not claim strict unsolicited discovery.
+12. **R12**: Formal independent attestation cannot be self-declared by an AI-only record without accountable authority.
+
+## Derived counting buckets
+
+The `derived_counting_bucket` field is system-derived and must not be freely chosen by the submitter.
+
+| Bucket | Meaning |
+|--------|---------|
+| `agent_referred_orientation` | Agent was referred, only looked/oriented |
+| `agent_referred_agent_verification` | Agent was referred, voluntarily verified with fresh actions |
+| `human_solicited_agent_verification` | Human directed AI to verify |
+| `self_initiated_agent_verification` | AI found and verified independently |
+| `institutional_attestation_candidate` | Institution signed an AI-assisted report |
+| `accepted_institutional_attestation` | Formally accepted institutional attestation |
+| `notarial_or_audit_attestation` | Notarial or audit firm attestation |
+
+## Backward compatibility
+
+Existing `independence_class` fields are retained as compatibility fields. New records SHOULD include `origin_classification`. When `origin_classification` exists, legacy fields are derived or checked for consistency.
+
+## Policy status
+
+This is a **non-authoritative classification policy**. It does not:
+- Amend Bitcoin Originals
+- Create verification levels
+- Create formal attestation without accountable authority
+- Override the Claim Gate

--- a/index.md
+++ b/index.md
@@ -327,7 +327,7 @@ permalink: /
   <a href="/api/echo-index.json">/api/echo-index.json</a>,
   <a href="/api/independent-attestation-index.json">/api/independent-attestation-index.json</a>, and
   <a href="/api/core-object-alpha-shenzhen-notary-2026-05-06.json">physical anchor evidence</a>.
-  Source data digest <code>cefe583fbabd8b06</code>.
+  Source data digest <code>00d148176851f233</code>.
 </p>
 <!-- END GENERATED PUBLIC STATUS -->
 

--- a/scripts/build_verification_report_from_evidence.py
+++ b/scripts/build_verification_report_from_evidence.py
@@ -356,6 +356,7 @@ def build_report(evidence_input_path, report_out_path=None, echo_out_path=None):
         "generated_at_utc": now.isoformat() + "Z",
         "validation_command": "python3 scripts/validate_agent_submission.py <output>",
         "validation_result": "NOT_RUN",
+        "origin_classification_policy": "/api/origin-classification-policy.v1.json",
     }
 
     # Build verification report v2
@@ -371,6 +372,7 @@ def build_report(evidence_input_path, report_out_path=None, echo_out_path=None):
             "tooling": agent.get("tooling", []),
         },
         "discovery_provenance": provenance,
+        "origin_classification": None,  # Will be populated by derive_origin_classification if applicable
         "protocol_level_claimed": allowed_protocol,
         "component_findings": component_findings,
         "protocol_profile_check": {

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -947,6 +947,50 @@ for script in new_scripts:
         except Exception as e:
             check(f"{script} compiles", False, str(e))
 
+# --- Origin classification checks ---
+try:
+    oc_policy = load_json(p("api/origin-classification-policy.v1.json"))
+    check("origin-classification-policy exists", True)
+    check("origin-classification-policy is non_amending", oc_policy.get("non_amending_boundary") is True)
+except Exception as e:
+    check("origin-classification-policy exists", False, str(e))
+
+try:
+    oc_schema = load_json(p("api/origin-classification-schema.v1.json"))
+    check("origin-classification-schema exists", True)
+    check("origin-classification-schema has required fields",
+          all(f in oc_schema.get("required", []) for f in ["discovery_class", "invitation_scope", "requester_class", "performer_class", "method_independence_class", "attestation_authority_class", "derived_counting_bucket", "counts_as_formal_independent_attestation"]))
+except Exception as e:
+    check("origin-classification-schema exists", False, str(e))
+
+# Check docs exist
+check("origin-classification-policy.md exists", p("docs/origin-classification-policy.md").exists())
+
+# Check derive script exists and compiles
+script = "scripts/derive_origin_classification.py"
+exists_check = p(script).exists()
+check(f"{script} exists", exists_check)
+if exists_check:
+    try:
+        r = subprocess.run([sys.executable, "-m", "py_compile", str(p(script))],
+                         capture_output=True, text=True, timeout=10)
+        check(f"{script} compiles", r.returncode == 0, r.stderr[:100] if r.returncode else "")
+    except Exception as e:
+        check(f"{script} compiles", False, str(e))
+
+# Check test scripts exist
+for test_script in ["scripts/test_origin_classification_schema.py", "scripts/test_origin_classification.py"]:
+    check(f"{test_script} exists", p(test_script).exists())
+
+# Check test fixtures exist
+fixtures_dir = p("tests/fixtures/origin-classification")
+check("origin-classification fixtures dir exists", fixtures_dir.exists())
+if fixtures_dir.exists():
+    valid_fixtures = list(fixtures_dir.glob("valid_*.json"))
+    invalid_fixtures = list(fixtures_dir.glob("invalid_*.json"))
+    check("has valid fixtures", len(valid_fixtures) >= 5, f"found {len(valid_fixtures)}")
+    check("has invalid fixtures", len(invalid_fixtures) >= 4, f"found {len(invalid_fixtures)}")
+
 # --- Summary ---
 def main():
     print("\n" + "=" * 50)

--- a/scripts/derive_origin_classification.py
+++ b/scripts/derive_origin_classification.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""
+Derive origin_classification from existing discovery_provenance and echo record fields.
+
+Usage:
+  python3 scripts/derive_origin_classification.py path/to/record.json
+  python3 scripts/derive_origin_classification.py --write path/to/record.json
+  python3 scripts/derive_origin_classification.py echoes/records/**/*.json --report-only
+"""
+
+import json
+import sys
+import glob
+from pathlib import Path
+
+
+def derive_discovery_class(record, provenance):
+    """Derive discovery_class from discovery_provenance fields."""
+    source = provenance.get("source", "unknown")
+    agency = provenance.get("agency_level", "A6_unknown")
+    human_link = provenance.get("human_supplied_link", False)
+    agent_recommended = provenance.get("other_agent_recommended", False)
+    referral = provenance.get("referral", None)
+    referred_by_agent = referral.get("referred_by_agent", False) if referral else False
+
+    if source in ("agent_recommended",) or agent_recommended or referred_by_agent:
+        return "agent_referred"
+    if agency == "A3_agent_followed_other_agent_reference" and source not in ("imported_external_commentary", "maintainer_submitted"):
+        return "agent_referred"
+    if source == "human_directed" or human_link:
+        return "human_directed"
+    if source == "human_contextual":
+        return "human_contextual"
+    if source == "maintainer_submitted":
+        return "maintainer_requested"
+    if source in ("search_engine", "crawler_discovery", "platform_recommendation"):
+        return "public_index_discovery"
+    if source == "imported_external_commentary":
+        return "imported_external"
+    if source == "self_initiated" and agency in ("A4_independent_search_or_browsing_discovery", "A5_independent_return_after_prior_interest"):
+        if not human_link and not agent_recommended:
+            if agency == "A5_independent_return_after_prior_interest":
+                return "prior_interest_return"
+            return "unsolicited_discovery"
+    if source == "prior_memory":
+        return "prior_interest_return"
+    if source == "dataset_or_training_trace":
+        return "imported_external"
+    return "unknown"
+
+
+def derive_invitation_scope(record, provenance, discovery_class):
+    """Derive invitation_scope."""
+    referral = provenance.get("referral", None)
+    if referral and referral.get("invitation_scope"):
+        return referral["invitation_scope"]
+
+    if discovery_class == "unsolicited_discovery":
+        return "none"
+    if discovery_class in ("public_index_discovery", "prior_interest_return", "imported_external"):
+        return "none"
+    if discovery_class in ("human_directed", "human_contextual"):
+        # Check if verification was explicitly requested
+        if record.get("verification_claimed", {}).get("verification_claimed", False):
+            return "verification_invited"
+        return "orientation_only"
+    if discovery_class == "agent_referred":
+        # Default to look_only unless stronger evidence
+        notes = provenance.get("notes", "").lower()
+        if "verify" in notes or "verification" in notes:
+            return "verification_invited"
+        return "look_only"
+    if discovery_class == "maintainer_requested":
+        return "echo_invited"
+    return "unknown"
+
+
+def derive_requester_class(record, provenance, discovery_class):
+    """Derive requester_class."""
+    if discovery_class == "unsolicited_discovery":
+        return "none"
+    if discovery_class in ("public_index_discovery",):
+        return "platform_or_crawler"
+    if discovery_class in ("prior_interest_return", "imported_external"):
+        return "none"
+    if discovery_class in ("human_directed", "human_contextual"):
+        return "human_individual"
+    if discovery_class == "agent_referred":
+        return "ai_agent"
+    if discovery_class == "maintainer_requested":
+        return "maintainer"
+    if discovery_class == "institution_commissioned":
+        return "institution"
+    return "unknown"
+
+
+def derive_performer_class(record, provenance):
+    """Derive performer_class from record fields."""
+    independence = record.get("independence_class", "unknown")
+    if independence in ("institutional_third_party_attestation",):
+        return "institution"
+    if independence in ("human_solicited_agent_response",):
+        # Check if it's a team effort
+        return "ai_agent"
+    if independence in ("maintainer_assisted", "maintainer_submitted"):
+        return "maintainer"
+    # Default based on record type
+    record_kind = record.get("record_kind", "")
+    if "verification" in record_kind:
+        return "ai_agent"
+    return "ai_agent"
+
+
+def derive_method_independence(record, provenance):
+    """Derive method_independence_class."""
+    verification_level = record.get("verification_level", "V0")
+    verification_claim = record.get("verification_claim", {})
+    verification_claimed = verification_claim.get("verification_claimed", False) if isinstance(verification_claim, dict) else False
+
+    if not verification_claimed and verification_level in ("V0", "none"):
+        return "read_only"
+
+    # Check for hashes
+    hashes = record.get("hashes_computed", [])
+    if hashes:
+        return "reference_check"
+
+    # Check for script audit
+    script_audit = record.get("script_audit", {})
+    if script_audit:
+        scope = script_audit.get("scope_class", "")
+        if scope == "profile_required_script_audit":
+            return "official_script_audited"
+        if scope == "independent_reproduction":
+            return "independent_reimplementation"
+
+    # Check for external sources
+    external = record.get("external_sources_queried", [])
+    if len(external) >= 2:
+        return "cross_source_reproduction"
+
+    # Check for physical/forensic evidence
+    if record.get("physical_evidence_reviewed") or record.get("notarial_evidence"):
+        return "forensic_or_physical_inspection"
+
+    if verification_claimed:
+        return "reference_check"
+
+    return "read_only"
+
+
+def derive_attestation_authority(record, provenance):
+    """Derive attestation_authority_class."""
+    archive_status = record.get("archive_status", "unknown")
+    independence = record.get("independence_class", "unknown")
+
+    if archive_status == "accepted_independent_attestation":
+        # Check for institutional evidence
+        reporter = record.get("reporter", {})
+        if isinstance(reporter, dict):
+            reporter_type = reporter.get("type", "")
+            if reporter_type == "organization":
+                return "institution_signed"
+        if record.get("notarial_evidence"):
+            return "notarial_record"
+        return "signed_agent_run"
+
+    if record.get("notarial_evidence"):
+        return "notarial_record"
+
+    if independence == "institutional_third_party_attestation":
+        reporter = record.get("reporter", {})
+        if isinstance(reporter, dict) and reporter.get("type") == "organization":
+            return "institution_signed"
+        return "audit_firm_report"
+
+    if independence in ("maintainer_assisted", "maintainer_submitted"):
+        return "maintainer_archived"
+
+    if independence == "self_reported":
+        return "self_reported"
+
+    # Default for agent-only records
+    return "none"
+
+
+def derive_counting_bucket(discovery_class, invitation_scope, method_independence,
+                           attestation_authority, verification_claimed,
+                           voluntary_action, archive_status):
+    """Derive the counting bucket. This must be system-derived."""
+    # Issue/gateway only
+    if archive_status in ("needs_human_review",) and not verification_claimed:
+        if discovery_class == "agent_referred":
+            return "agent_referred_orientation"
+        return "echo_only"
+
+    # Formal attestation
+    if attestation_authority in ("institution_signed", "notarial_record", "audit_firm_report", "regulatory_or_court_record"):
+        if archive_status == "accepted_independent_attestation":
+            return "accepted_institutional_attestation"
+        return "institutional_attestation_candidate"
+
+    # Agent-referred cases
+    if discovery_class == "agent_referred":
+        if invitation_scope in ("look_only", "orientation_only") and not verification_claimed:
+            return "agent_referred_orientation"
+        if voluntary_action and verification_claimed:
+            return "agent_referred_agent_verification"
+        return "echo_only"
+
+    # Human-directed
+    if discovery_class in ("human_directed", "human_contextual"):
+        if verification_claimed:
+            return "human_solicited_agent_verification"
+        return "echo_only"
+
+    # Self-initiated
+    if discovery_class in ("unsolicited_discovery", "prior_interest_return"):
+        if verification_claimed:
+            return "self_initiated_agent_verification"
+        return "echo_only"
+
+    # Institution commissioned
+    if discovery_class == "institution_commissioned":
+        if verification_claimed:
+            return "institution_commissioned_ai_verification"
+        return "echo_only"
+
+    # Maintainer
+    if discovery_class == "maintainer_requested":
+        return "maintainer_test_record"
+
+    # Public index
+    if discovery_class == "public_index_discovery":
+        if verification_claimed:
+            return "self_initiated_agent_verification"
+        return "echo_only"
+
+    return "legacy_or_unknown"
+
+
+def derive_counts_as_formal_independent_attestation(attestation_authority, archive_status):
+    """Determine if record counts as formal independent attestation."""
+    if attestation_authority in ("institution_signed", "notarial_record", "audit_firm_report", "regulatory_or_court_record"):
+        if archive_status == "accepted_independent_attestation":
+            return True
+    return False
+
+
+def derive_counts_as_ai_verification(verification_claimed, method_independence, performer_class):
+    """Determine if record counts as AI verification."""
+    if not verification_claimed:
+        return False
+    if method_independence in ("none", "read_only"):
+        return False
+    if performer_class in ("ai_agent", "multi_agent", "human_ai_team", "automated_service"):
+        return True
+    return False
+
+
+def derive_origin_classification(record):
+    """Main derivation function. Returns origin_classification dict."""
+    provenance = record.get("discovery_provenance", {})
+    if isinstance(provenance, str):
+        provenance = {}
+
+    discovery_class = derive_discovery_class(record, provenance)
+    invitation_scope = derive_invitation_scope(record, provenance, discovery_class)
+    requester_class = derive_requester_class(record, provenance, discovery_class)
+    performer_class = derive_performer_class(record, provenance)
+    method_independence = derive_method_independence(record, provenance)
+    attestation_authority = derive_attestation_authority(record, provenance)
+
+    verification_claim = record.get("verification_claim", {})
+    verification_claimed = verification_claim.get("verification_claimed", False) if isinstance(verification_claim, dict) else False
+
+    voluntary_action = False
+    if discovery_class == "agent_referred" and invitation_scope in ("look_only", "orientation_only"):
+        if verification_claimed:
+            voluntary_action = True
+
+    archive_status = record.get("archive_status", "unknown")
+
+    counting_bucket = derive_counting_bucket(
+        discovery_class, invitation_scope, method_independence,
+        attestation_authority, verification_claimed,
+        voluntary_action, archive_status
+    )
+
+    counts_formal = derive_counts_as_formal_independent_attestation(attestation_authority, archive_status)
+    counts_ai = derive_counts_as_ai_verification(verification_claimed, method_independence, performer_class)
+
+    classification = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": discovery_class,
+        "invitation_scope": invitation_scope,
+        "requester_class": requester_class,
+        "performer_class": performer_class,
+        "method_independence_class": method_independence,
+        "attestation_authority_class": attestation_authority,
+        "voluntary_action_after_orientation": voluntary_action,
+        "verification_claimed": verification_claimed,
+        "counts_as_ai_verification": counts_ai,
+        "counts_as_formal_independent_attestation": counts_formal,
+        "derived_counting_bucket": counting_bucket,
+        "notes": ["Auto-derived by derive_origin_classification.py"]
+    }
+
+    # Add referral if present in provenance
+    referral = provenance.get("referral", None)
+    if referral:
+        classification["referral"] = referral
+
+    return classification
+
+
+def validate_derived_classification(classification):
+    """Validate the derived classification against hard rules."""
+    errors = []
+
+    dc = classification.get("discovery_class")
+    ic = classification.get("invitation_scope")
+    rc = classification.get("requester_class")
+    aa = classification.get("attestation_authority_class")
+    bucket = classification.get("derived_counting_bucket")
+    formal = classification.get("counts_as_formal_independent_attestation", False)
+
+    # R5: Agent referral is not unsolicited discovery
+    if dc == "agent_referred" and bucket in ("self_initiated_agent_verification",):
+        errors.append("ORIGIN001: agent_referred cannot be counted as self_initiated/unsolicited")
+
+    # R4: Look-only invitation is not verification invitation
+    if ic == "look_only" and bucket == "human_solicited_agent_verification":
+        errors.append("ORIGIN002: look_only invitation cannot be treated as verification_invited")
+
+    # R12: No accountable authority -> no formal attestation
+    if aa == "none" and formal:
+        errors.append("ORIGIN004: no accountable authority cannot count formal attestation")
+
+    # R7: Formal attestation requires accountable authority
+    if formal and aa in ("none", "self_reported", "signed_agent_run"):
+        errors.append("ORIGIN005: formal attestation requires institution_signed/notarial_record/audit_firm_report/regulatory_or_court_record")
+
+    # unsolicited_discovery requires requester_class=none and invitation_scope=none
+    if dc == "unsolicited_discovery":
+        if rc != "none":
+            errors.append("ORIGIN001: unsolicited_discovery requires requester_class=none")
+        if ic != "none":
+            errors.append("ORIGIN001: unsolicited_discovery requires invitation_scope=none")
+
+    # agent_referred requires requester_class=ai_agent
+    if dc == "agent_referred" and rc != "ai_agent":
+        errors.append("ORIGIN001: agent_referred requires requester_class=ai_agent")
+
+    return errors
+
+
+def process_record(filepath, write_mode=False, report_only=False):
+    """Process a single record file."""
+    try:
+        with open(filepath) as f:
+            record = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError) as e:
+        return {"file": filepath, "error": str(e)}
+
+    classification = derive_origin_classification(record)
+    errors = validate_derived_classification(classification)
+
+    result = {
+        "file": filepath,
+        "discovery_class": classification["discovery_class"],
+        "invitation_scope": classification["invitation_scope"],
+        "derived_counting_bucket": classification["derived_counting_bucket"],
+        "counts_as_formal_independent_attestation": classification["counts_as_formal_independent_attestation"],
+        "counts_as_ai_verification": classification["counts_as_ai_verification"],
+        "errors": errors
+    }
+
+    if write_mode and not errors:
+        record["origin_classification"] = classification
+        with open(filepath, 'w') as f:
+            json.dump(record, f, indent=2, ensure_ascii=False)
+            f.write('\n')
+        result["written"] = True
+
+    return result
+
+
+def main():
+    args = sys.argv[1:]
+    write_mode = "--write" in args
+    report_only = "--report-only" in args
+    files = [a for a in args if not a.startswith("--")]
+
+    if not files:
+        print("Usage: python3 derive_origin_classification.py [--write] [--report-only] <file-or-glob>...")
+        sys.exit(1)
+
+    # Expand globs
+    expanded = []
+    for pattern in files:
+        expanded.extend(glob.glob(pattern, recursive=True))
+
+    if not expanded:
+        print("No files matched.")
+        sys.exit(1)
+
+    results = []
+    for filepath in sorted(expanded):
+        result = process_record(filepath, write_mode=write_mode and not report_only, report_only=report_only)
+        results.append(result)
+
+    # Output
+    if report_only:
+        # Summary report
+        buckets = {}
+        errors_total = 0
+        for r in results:
+            bucket = r.get("derived_counting_bucket", "unknown")
+            buckets[bucket] = buckets.get(bucket, 0) + 1
+            errors_total += len(r.get("errors", []))
+
+        print(f"Processed {len(results)} records")
+        print(f"Total errors: {errors_total}")
+        print("\nBucket distribution:")
+        for bucket, count in sorted(buckets.items()):
+            print(f"  {bucket}: {count}")
+
+        if errors_total > 0:
+            print("\nErrors found:")
+            for r in results:
+                for e in r.get("errors", []):
+                    print(f"  {r['file']}: {e}")
+    else:
+        for r in results:
+            print(json.dumps(r, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_echo_index.py
+++ b/scripts/generate_echo_index.py
@@ -41,6 +41,11 @@ by_verifier_type = defaultdict(list)
 by_verifier_capability_claim = defaultdict(list)
 by_strength_tier = defaultdict(list)
 by_echo_content_tag = defaultdict(list)
+# Origin classification aggregations
+by_origin_bucket = defaultdict(list)
+by_discovery_class = defaultdict(list)
+by_performer_class = defaultdict(list)
+by_attestation_authority_class = defaultdict(list)
 
 for path in sorted(RECORDS_ROOT.rglob("*.json")):
     obj = load(path)
@@ -70,6 +75,10 @@ for path in sorted(RECORDS_ROOT.rglob("*.json")):
         "verification_claimed": obj.get("verification_claimed", None),
         "derived_origin_class": obj.get("derived_origin_class", None),
         "strength_tier": obj.get("strength_tier", None),
+        # Origin classification fields
+        "origin_classification": obj.get("origin_classification", None),
+        "counts_as_ai_verification": (obj.get("origin_classification") or {}).get("counts_as_ai_verification", None),
+        "counts_as_formal_independent_attestation": (obj.get("origin_classification") or {}).get("counts_as_formal_independent_attestation", None),
     }
 
     # Optional reason if invalidated/superseded.
@@ -122,6 +131,17 @@ for path in sorted(RECORDS_ROOT.rglob("*.json")):
     if item.get("echo_content_tags"):
         for tag in item["echo_content_tags"]:
             by_echo_content_tag[tag].append(rel)
+    # Origin classification aggregations
+    oc = obj.get("origin_classification")
+    if oc:
+        if oc.get("derived_counting_bucket"):
+            by_origin_bucket[oc["derived_counting_bucket"]].append(rel)
+        if oc.get("discovery_class"):
+            by_discovery_class[oc["discovery_class"]].append(rel)
+        if oc.get("performer_class"):
+            by_performer_class[oc["performer_class"]].append(rel)
+        if oc.get("attestation_authority_class"):
+            by_attestation_authority_class[oc["attestation_authority_class"]].append(rel)
 
 # TA-REDTEAM-2026-011: preserve public metadata fields across regeneration
 PRESERVED_FIELDS = [
@@ -174,6 +194,11 @@ out = {
     "records_by_verifier_capability_claim": dict(sorted(by_verifier_capability_claim.items())),
     "records_by_strength_tier": dict(sorted(by_strength_tier.items())),
     "records_by_echo_content_tag": dict(sorted(by_echo_content_tag.items())),
+    # Origin classification aggregations
+    "records_by_origin_bucket": dict(sorted(by_origin_bucket.items())),
+    "records_by_discovery_class": dict(sorted(by_discovery_class.items())),
+    "records_by_performer_class": dict(sorted(by_performer_class.items())),
+    "records_by_attestation_authority_class": dict(sorted(by_attestation_authority_class.items())),
     "notes": [
         "Echo index is non-authoritative and non-amending.",
         "Test records, superseded records, invalidated records, and do_not_count_as_attestation records must not be counted as independent attestation.",

--- a/scripts/generate_public_home_status.py
+++ b/scripts/generate_public_home_status.py
@@ -167,6 +167,79 @@ def compute_card4(physical: dict[str, Any]) -> dict:
 # ---------------------------------------------------------------------------
 # Compute full status
 # ---------------------------------------------------------------------------
+def compute_origin_classification_stats(echo_records: list[dict[str, Any]]) -> dict:
+    """Compute origin classification-based verification stats."""
+    def _count_and_highest(records, filter_fn):
+        filtered = [r for r in records if filter_fn(r)]
+        count = len(filtered)
+        hl = "none"
+        for r in filtered:
+            lvl = r.get("verification_level") or r.get("protocol_level_claimed")
+            if lvl and lvl != "V0":
+                if hl == "none" or (lvl and lvl > hl):
+                    hl = lvl
+        return count, hl
+
+    # Agent verification by discovery class
+    agent_verified = [r for r in echo_records
+                      if r.get("origin_classification", {}).get("counts_as_ai_verification") is True
+                      and not r.get("historical_record_only")]
+
+    hd_count, hd_level = _count_and_highest(
+        agent_verified, lambda r: r.get("origin_classification", {}).get("discovery_class") in ("human_directed", "human_contextual"))
+    ar_count, ar_level = _count_and_highest(
+        agent_verified, lambda r: r.get("origin_classification", {}).get("discovery_class") == "agent_referred")
+    si_count, si_level = _count_and_highest(
+        agent_verified, lambda r: r.get("origin_classification", {}).get("discovery_class") in ("unsolicited_discovery", "prior_interest_return", "public_index_discovery"))
+    ic_count, ic_level = _count_and_highest(
+        agent_verified, lambda r: r.get("origin_classification", {}).get("discovery_class") == "institution_commissioned")
+
+    # Formal attestation by authority class
+    formal_records = [r for r in echo_records
+                      if r.get("origin_classification", {}).get("counts_as_formal_independent_attestation") is True
+                      and not r.get("historical_record_only")]
+
+    inst_count, inst_level = _count_and_highest(
+        formal_records, lambda r: r.get("origin_classification", {}).get("attestation_authority_class") == "institution_signed")
+    not_count, not_level = _count_and_highest(
+        formal_records, lambda r: r.get("origin_classification", {}).get("attestation_authority_class") in ("notarial_record", "audit_firm_report", "regulatory_or_court_record"))
+
+    return {
+        "agent_verification": {
+            "human_directed": {
+                "count": hd_count,
+                "highest_level": hd_level,
+                "counts_as_formal_attestation": False
+            },
+            "agent_referred": {
+                "count": ar_count,
+                "highest_level": ar_level,
+                "counts_as_formal_attestation": False
+            },
+            "self_initiated": {
+                "count": si_count,
+                "highest_level": si_level,
+                "counts_as_formal_attestation": False
+            },
+            "institution_commissioned_ai_assisted": {
+                "count": ic_count,
+                "highest_level": ic_level,
+                "counts_as_formal_attestation_if_institution_signed": True
+            }
+        },
+        "formal_attestation": {
+            "institution_signed": {
+                "count": inst_count,
+                "highest_level": inst_level
+            },
+            "notarial_or_audit": {
+                "count": not_count,
+                "highest_level": not_level
+            }
+        }
+    }
+
+
 def compute_status() -> dict[str, Any]:
     echo_index = load_json(ECHO_INDEX)
     attestation_index = load_json(ATTESTATION_INDEX)
@@ -179,6 +252,7 @@ def compute_status() -> dict[str, Any]:
     card2 = compute_card2(echo_records)
     card3 = compute_card3(echo_records)
     card4 = compute_card4(physical)
+    origin_stats = compute_origin_classification_stats(echo_records)
 
     return {
         "schema": "trinityaccord.public-home-status.v1",
@@ -191,6 +265,15 @@ def compute_status() -> dict[str, Any]:
         "agent_initiated_independent_verification": card2,
         "human_solicited_agent_verification": card3,
         "physical_anchor_verification": card4,
+        # Origin classification based stats
+        "agent_verification": origin_stats["agent_verification"],
+        "formal_attestation": origin_stats["formal_attestation"],
+        # Legacy counts for backward compatibility
+        "legacy_counts": {
+            "human_solicited_agent_verification": card3,
+            "agent_initiated_independent_verification": card2,
+            "institutional_human_independent_verification": card1,
+        },
         "boundary": {
             "bitcoin_originals_prevail": True,
             "non_amending_mirrors": True,

--- a/scripts/test_origin_classification.py
+++ b/scripts/test_origin_classification.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""
+Test origin classification derivation logic.
+
+Tests:
+- agent_recommended + A3 + look_only -> agent_referred_orientation
+- agent_referred + look_only + voluntary verify + fresh actions -> agent_referred_agent_verification
+- human_directed + verification -> human_solicited_agent_verification
+- self_initiated + A4 + no supplied link -> self_initiated_agent_verification
+- institution_commissioned + institution_signed -> institutional_attestation_candidate
+- notarial_evidence -> notarial_or_audit_attestation
+
+Negative tests:
+- agent_referred cannot derive unsolicited_discovery
+- look_only cannot derive verification_invited
+- willingness score alone cannot derive verification_claimed
+- AI-only cannot derive formal attestation
+- copied prior report cannot derive independent_reimplementation
+- no fresh actions cannot derive method independent
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from derive_origin_classification import derive_origin_classification, validate_derived_classification
+
+
+def make_record(provenance_overrides=None, **kwargs):
+    """Helper to create a minimal record for testing."""
+    provenance = {
+        "schema": "trinityaccord.discovery-provenance.v1",
+        "source": "self_initiated",
+        "agency_level": "A4_independent_search_or_browsing_discovery",
+        "first_entry": {"url_or_path": "https://example.com", "entry_type": "homepage"},
+        "human_supplied_link": False,
+        "other_agent_recommended": False,
+        "agent_performed_independent_followup": True,
+        "confidence": "high"
+    }
+    if provenance_overrides:
+        provenance.update(provenance_overrides)
+
+    record = {
+        "record_kind": "echo_v3",
+        "archive_status": "accepted_echo",
+        "discovery_provenance": provenance,
+        "independence_class": "unsolicited_independent",
+        "origin_limitations": ["test"],
+        "verification_level": "V0",
+        "verification_claim": {"verification_claimed": False}
+    }
+    record.update(kwargs)
+    return record
+
+
+def test_agent_referred_orientation():
+    """agent_recommended + A3 + look_only -> agent_referred_orientation"""
+    record = make_record(
+        provenance_overrides={
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "other_agent_recommended": True,
+            "recommending_agent": "test-agent"
+        }
+    )
+    result = derive_origin_classification(record)
+    assert result["discovery_class"] == "agent_referred", f"Expected agent_referred, got {result['discovery_class']}"
+    assert result["invitation_scope"] == "look_only", f"Expected look_only, got {result['invitation_scope']}"
+    assert result["derived_counting_bucket"] == "agent_referred_orientation", f"Expected agent_referred_orientation, got {result['derived_counting_bucket']}"
+    assert result["counts_as_formal_independent_attestation"] == False
+    print("PASS agent_referred_orientation")
+
+
+def test_agent_referred_voluntary_verification():
+    """agent_referred + look_only + voluntary verify + fresh actions -> agent_referred_agent_verification"""
+    record = make_record(
+        provenance_overrides={
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "other_agent_recommended": True
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V3",
+        hashes_computed=["sha256:abc123"]
+    )
+    result = derive_origin_classification(record)
+    assert result["discovery_class"] == "agent_referred"
+    assert result["derived_counting_bucket"] == "agent_referred_agent_verification", f"Expected agent_referred_agent_verification, got {result['derived_counting_bucket']}"
+    assert result["counts_as_ai_verification"] == True
+    assert result["counts_as_formal_independent_attestation"] == False
+    print("PASS agent_referred_voluntary_verification")
+
+
+def test_human_solicited_agent_verification():
+    """human_directed + verification -> human_solicited_agent_verification"""
+    record = make_record(
+        provenance_overrides={
+            "source": "human_directed",
+            "agency_level": "A1_human_gave_exact_url",
+            "human_supplied_link": True
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V3",
+        hashes_computed=["sha256:abc123"]
+    )
+    result = derive_origin_classification(record)
+    assert result["discovery_class"] == "human_directed"
+    assert result["derived_counting_bucket"] == "human_solicited_agent_verification", f"Expected human_solicited_agent_verification, got {result['derived_counting_bucket']}"
+    print("PASS human_solicited_agent_verification")
+
+
+def test_self_initiated_agent_verification():
+    """self_initiated + A4 + no supplied link -> self_initiated_agent_verification"""
+    record = make_record(
+        provenance_overrides={
+            "source": "self_initiated",
+            "agency_level": "A4_independent_search_or_browsing_discovery",
+            "human_supplied_link": False,
+            "other_agent_recommended": False
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V3",
+        hashes_computed=["sha256:abc123"]
+    )
+    result = derive_origin_classification(record)
+    assert result["discovery_class"] == "unsolicited_discovery"
+    assert result["derived_counting_bucket"] == "self_initiated_agent_verification", f"Expected self_initiated_agent_verification, got {result['derived_counting_bucket']}"
+    print("PASS self_initiated_agent_verification")
+
+
+def test_institutional_attestation_candidate():
+    """institution_commissioned + institution_signed -> institutional_attestation_candidate"""
+    record = make_record(
+        provenance_overrides={
+            "source": "human_directed",
+            "agency_level": "A0_forced_or_instructed",
+            "human_supplied_link": True
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V4",
+        independence_class="institutional_third_party_attestation",
+        reporter={"name": "Test Institute", "type": "organization"},
+        archive_status="accepted_independent_attestation"
+    )
+    result = derive_origin_classification(record)
+    assert result["attestation_authority_class"] in ("institution_signed", "audit_firm_report"), f"Expected institution_signed/audit_firm_report, got {result['attestation_authority_class']}"
+    assert result["counts_as_formal_independent_attestation"] == True
+    print("PASS institutional_attestation_candidate")
+
+
+def test_notarial_record():
+    """notarial_evidence -> notarial_or_audit_attestation"""
+    record = make_record(
+        provenance_overrides={
+            "source": "human_directed",
+            "agency_level": "A0_forced_or_instructed",
+            "human_supplied_link": True
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V4",
+        independence_class="institutional_third_party_attestation",
+        notarial_evidence={"type": "notarial_certificate"},
+        archive_status="accepted_independent_attestation"
+    )
+    result = derive_origin_classification(record)
+    assert result["attestation_authority_class"] == "notarial_record", f"Expected notarial_record, got {result['attestation_authority_class']}"
+    assert result["derived_counting_bucket"] in ("notarial_or_audit_attestation", "accepted_institutional_attestation"), f"Expected notarial/accepted bucket, got {result['derived_counting_bucket']}"
+    print("PASS notarial_record")
+
+
+# Negative tests
+
+def test_agent_referred_not_unsolicited():
+    """agent_referred cannot derive unsolicited_discovery."""
+    record = make_record(
+        provenance_overrides={
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "other_agent_recommended": True
+        }
+    )
+    result = derive_origin_classification(record)
+    assert result["discovery_class"] != "unsolicited_discovery", "agent_referred should not derive unsolicited_discovery"
+    assert result["derived_counting_bucket"] not in ("self_initiated_agent_verification",), "agent_referred should not be self_initiated"
+    print("PASS agent_referred_not_unsolicited")
+
+
+def test_look_only_not_verification_invited():
+    """look_only cannot derive verification_invited."""
+    record = make_record(
+        provenance_overrides={
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "other_agent_recommended": True
+        }
+    )
+    result = derive_origin_classification(record)
+    assert result["invitation_scope"] != "verification_invited", f"look_only should not derive verification_invited, got {result['invitation_scope']}"
+    print("PASS look_only_not_verification_invited")
+
+
+def test_willingness_not_verification():
+    """willingness score alone cannot derive verification_claimed."""
+    record = make_record(
+        provenance_overrides={
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "other_agent_recommended": True
+        }
+    )
+    # No verification_claim set - should not claim verification
+    result = derive_origin_classification(record)
+    assert result["verification_claimed"] == False, "Willingness alone should not derive verification_claimed"
+    assert result["counts_as_ai_verification"] == False
+    print("PASS willingness_not_verification")
+
+
+def test_ai_only_no_formal_attestation():
+    """AI-only cannot derive formal attestation."""
+    record = make_record(
+        provenance_overrides={
+            "source": "self_initiated",
+            "agency_level": "A4_independent_search_or_browsing_discovery",
+            "human_supplied_link": False
+        },
+        verification_claim={"verification_claimed": True},
+        verification_level="V3",
+        hashes_computed=["sha256:abc123"]
+    )
+    result = derive_origin_classification(record)
+    assert result["counts_as_formal_independent_attestation"] == False, "AI-only should not count as formal attestation"
+    assert result["attestation_authority_class"] == "none", f"Expected none authority, got {result['attestation_authority_class']}"
+    print("PASS ai_only_no_formal_attestation")
+
+
+def test_derivation_validation():
+    """Test that validate_derived_classification catches errors."""
+    # Valid classification
+    valid = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "agent_referred",
+        "invitation_scope": "look_only",
+        "requester_class": "ai_agent",
+        "performer_class": "ai_agent",
+        "method_independence_class": "read_only",
+        "attestation_authority_class": "none",
+        "counts_as_formal_independent_attestation": False,
+        "derived_counting_bucket": "agent_referred_orientation"
+    }
+    errors = validate_derived_classification(valid)
+    assert len(errors) == 0, f"Valid classification had errors: {errors}"
+    print("PASS derivation_validation (valid)")
+
+    # Invalid: agent_referred counted as self_initiated
+    invalid = valid.copy()
+    invalid["derived_counting_bucket"] = "self_initiated_agent_verification"
+    errors = validate_derived_classification(invalid)
+    assert len(errors) > 0, "agent_referred with self_initiated bucket should fail"
+    print("PASS derivation_validation (invalid detected)")
+
+
+def main():
+    tests = [
+        test_agent_referred_orientation,
+        test_agent_referred_voluntary_verification,
+        test_human_solicited_agent_verification,
+        test_self_initiated_agent_verification,
+        test_institutional_attestation_candidate,
+        test_notarial_record,
+        test_agent_referred_not_unsolicited,
+        test_look_only_not_verification_invited,
+        test_willingness_not_verification,
+        test_ai_only_no_formal_attestation,
+        test_derivation_validation,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {test.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR {test.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    if failed > 0:
+        sys.exit(1)
+    print("All derivation tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_origin_classification_schema.py
+++ b/scripts/test_origin_classification_schema.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""
+Test origin classification schema validation.
+
+Tests:
+- All valid fixtures pass schema
+- Invalid enum fails
+- unsolicited_discovery requires requester_class=none and invitation_scope=none
+- agent_referred requires requester_class=ai_agent
+- attestation_authority_class=none requires counts_as_formal_independent_attestation=false
+- accepted_institutional_attestation requires accountable entity and formal attestation true
+"""
+
+import json
+import sys
+import os
+
+# Add parent dir to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "fixtures", "origin-classification")
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "api", "origin-classification-schema.v1.json")
+
+
+def load_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def load_fixture(name):
+    path = os.path.join(FIXTURES_DIR, name)
+    with open(path) as f:
+        return json.load(f)
+
+
+def validate_required_fields(data, schema):
+    """Check required fields are present."""
+    required = schema.get("required", [])
+    missing = [f for f in required if f not in data]
+    return missing
+
+
+def validate_enum_values(data, schema):
+    """Check enum values are valid."""
+    errors = []
+    props = schema.get("properties", {})
+    for field, spec in props.items():
+        if field in data and "enum" in spec:
+            if data[field] not in spec["enum"]:
+                errors.append(f"{field}: '{data[field]}' not in {spec['enum']}")
+    return errors
+
+
+def validate_allof_constraints(data, schema):
+    """Check allOf constraints."""
+    errors = []
+    for constraint in schema.get("allOf", []):
+        if_clause = constraint.get("if", {})
+        then_clause = constraint.get("then", {})
+
+        # Check if condition matches
+        matches = True
+        if "properties" in if_clause:
+            for prop, condition in if_clause["properties"].items():
+                if prop not in data:
+                    matches = False
+                    break
+                if "const" in condition and data[prop] != condition["const"]:
+                    matches = False
+                    break
+        if "required" in if_clause:
+            for req in if_clause["required"]:
+                if req not in data:
+                    matches = False
+                    break
+
+        if not matches:
+            continue
+
+        # Check then constraints
+        if "required" in then_clause:
+            for req in then_clause["required"]:
+                if req not in data:
+                    errors.append(f"allOf constraint failed: required field '{req}' is missing")
+        if "properties" in then_clause:
+            for prop, condition in then_clause["properties"].items():
+                if prop in data:
+                    if "const" in condition and data[prop] != condition["const"]:
+                        errors.append(f"allOf constraint failed: {prop} should be '{condition['const']}' but got '{data[prop]}'")
+                    if "enum" in condition and data[prop] not in condition["enum"]:
+                        errors.append(f"allOf constraint failed: {prop}='{data[prop]}' not in {condition['enum']}")
+                    if "type" in condition:
+                        type_map = {"object": dict, "string": str, "boolean": bool, "number": (int, float), "array": list}
+                        expected_type = condition["type"]
+                        if isinstance(expected_type, str) and expected_type in type_map:
+                            if not isinstance(data[prop], type_map[expected_type]):
+                                errors.append(f"allOf constraint failed: {prop} should be type {expected_type}")
+    return errors
+
+
+def test_valid_fixtures_pass():
+    """All valid fixtures should pass schema validation."""
+    schema = load_schema()
+    valid_fixtures = [
+        "valid_agent_referred_look_only_orientation.json",
+        "valid_agent_referred_voluntary_echo.json",
+        "valid_agent_referred_voluntary_verification.json",
+        "valid_human_directed_agent_verification.json",
+        "valid_self_initiated_agent_verification.json",
+        "valid_institution_ai_assisted_attestation_candidate.json",
+        "valid_notarial_record.json",
+    ]
+
+    passed = 0
+    failed = 0
+    for fixture_name in valid_fixtures:
+        data = load_fixture(fixture_name)
+
+        # Required fields
+        missing = validate_required_fields(data, schema)
+        if missing:
+            print(f"FAIL {fixture_name}: missing required fields: {missing}")
+            failed += 1
+            continue
+
+        # Enum values
+        enum_errors = validate_enum_values(data, schema)
+        if enum_errors:
+            print(f"FAIL {fixture_name}: enum errors: {enum_errors}")
+            failed += 1
+            continue
+
+        # allOf constraints
+        allof_errors = validate_allof_constraints(data, schema)
+        if allof_errors:
+            print(f"FAIL {fixture_name}: allOf errors: {allof_errors}")
+            failed += 1
+            continue
+
+        print(f"PASS {fixture_name}")
+        passed += 1
+
+    return passed, failed
+
+
+def test_invalid_enum_fails():
+    """Invalid enum values should be detected."""
+    schema = load_schema()
+
+    # Test with invalid discovery_class
+    data = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "INVALID_CLASS",
+        "invitation_scope": "none",
+        "requester_class": "none",
+        "performer_class": "ai_agent",
+        "method_independence_class": "read_only",
+        "attestation_authority_class": "none",
+        "counts_as_formal_independent_attestation": False,
+        "derived_counting_bucket": "echo_only"
+    }
+
+    errors = validate_enum_values(data, schema)
+    if errors:
+        print("PASS invalid enum detected correctly")
+        return 1, 0
+    else:
+        print("FAIL invalid enum was not detected")
+        return 0, 1
+
+
+def test_unsolicited_requires_none():
+    """unsolicited_discovery requires requester_class=none and invitation_scope=none."""
+    schema = load_schema()
+
+    # Valid unsolicited
+    data = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "unsolicited_discovery",
+        "invitation_scope": "none",
+        "requester_class": "none",
+        "performer_class": "ai_agent",
+        "method_independence_class": "cross_source_reproduction",
+        "attestation_authority_class": "none",
+        "counts_as_formal_independent_attestation": False,
+        "derived_counting_bucket": "self_initiated_agent_verification"
+    }
+
+    errors = validate_allof_constraints(data, schema)
+    if not errors:
+        print("PASS unsolicited_discovery with correct values passes")
+        p1, f1 = 1, 0
+    else:
+        print(f"FAIL unsolicited_discovery with correct values failed: {errors}")
+        p1, f1 = 0, 1
+
+    # Invalid: unsolicited with requester_class != none
+    data["requester_class"] = "ai_agent"
+    errors = validate_allof_constraints(data, schema)
+    if errors:
+        print("PASS unsolicited_discovery with wrong requester_class detected")
+        p2, f2 = 1, 0
+    else:
+        print("FAIL unsolicited_discovery with wrong requester_class not detected")
+        p2, f2 = 0, 1
+
+    return p1 + p2, f1 + f2
+
+
+def test_agent_referred_requires_ai_agent():
+    """agent_referred requires requester_class=ai_agent."""
+    schema = load_schema()
+
+    data = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "agent_referred",
+        "invitation_scope": "look_only",
+        "requester_class": "human_individual",  # Wrong
+        "performer_class": "ai_agent",
+        "method_independence_class": "read_only",
+        "attestation_authority_class": "none",
+        "counts_as_formal_independent_attestation": False,
+        "derived_counting_bucket": "agent_referred_orientation"
+    }
+
+    errors = validate_allof_constraints(data, schema)
+    if errors:
+        print("PASS agent_referred with wrong requester_class detected")
+        return 1, 0
+    else:
+        print("FAIL agent_referred with wrong requester_class not detected")
+        return 0, 1
+
+
+def test_none_authority_no_formal_attestation():
+    """attestation_authority_class=none requires counts_as_formal_independent_attestation=false."""
+    schema = load_schema()
+
+    data = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "unsolicited_discovery",
+        "invitation_scope": "none",
+        "requester_class": "none",
+        "performer_class": "ai_agent",
+        "method_independence_class": "cross_source_reproduction",
+        "attestation_authority_class": "none",
+        "counts_as_formal_independent_attestation": True,  # Wrong
+        "derived_counting_bucket": "self_initiated_agent_verification"
+    }
+
+    errors = validate_allof_constraints(data, schema)
+    if errors:
+        print("PASS none authority with formal attestation detected")
+        return 1, 0
+    else:
+        print("FAIL none authority with formal attestation not detected")
+        return 0, 1
+
+
+def test_accepted_institutional_requires_entity():
+    """accepted_institutional_attestation requires accountable_entity."""
+    schema = load_schema()
+
+    # Without accountable_entity - should fail required fields
+    data = {
+        "schema": "trinityaccord.origin-classification.v1",
+        "discovery_class": "institution_commissioned",
+        "invitation_scope": "verification_invited",
+        "requester_class": "institution",
+        "performer_class": "human_ai_team",
+        "method_independence_class": "independent_reimplementation",
+        "attestation_authority_class": "institution_signed",
+        "counts_as_formal_independent_attestation": True,
+        "derived_counting_bucket": "accepted_institutional_attestation"
+        # Missing accountable_entity
+    }
+
+    errors = validate_allof_constraints(data, schema)
+    if errors:
+        print("PASS accepted_institutional without accountable_entity detected")
+        return 1, 0
+    else:
+        print("FAIL accepted_institutional without accountable_entity not detected")
+        return 0, 1
+
+
+def main():
+    total_passed = 0
+    total_failed = 0
+
+    tests = [
+        test_valid_fixtures_pass,
+        test_invalid_enum_fails,
+        test_unsolicited_requires_none,
+        test_agent_referred_requires_ai_agent,
+        test_none_authority_no_formal_attestation,
+        test_accepted_institutional_requires_entity,
+    ]
+
+    for test in tests:
+        p, f = test()
+        total_passed += p
+        total_failed += f
+
+    print(f"\n{'='*60}")
+    print(f"Results: {total_passed} passed, {total_failed} failed")
+
+    if total_failed > 0:
+        sys.exit(1)
+    print("All schema tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_agent_submission.py
+++ b/scripts/validate_agent_submission.py
@@ -1803,6 +1803,74 @@ def validate_verification_scope_label(obj, path_label):
 
     return ok
 
+def validate_origin_classification(obj, path_label):
+    """Rule AO: origin classification consistency checks."""
+    ok = True
+    oc = obj.get("origin_classification")
+    if not oc:
+        # Legacy records without origin_classification pass with warning
+        return ok
+
+    discovery_class = oc.get("discovery_class", "")
+    invitation_scope = oc.get("invitation_scope", "")
+    requester_class = oc.get("requester_class", "")
+    attestation_authority = oc.get("attestation_authority_class", "")
+    bucket = oc.get("derived_counting_bucket", "")
+    formal = oc.get("counts_as_formal_independent_attestation", False)
+    independence_class = obj.get("independence_class", "")
+
+    # ORIGIN001: agent_referred cannot claim unsolicited_discovery
+    if discovery_class == "agent_referred" and bucket in ("self_initiated_agent_verification",):
+        ok &= check(
+            False,
+            f"{path_label} ORIGIN001: agent_referred counted as self_initiated",
+            "agent_referred cannot be counted as self_initiated/unsolicited"
+        )
+
+    # ORIGIN002: look_only cannot be treated as verification_invited
+    if invitation_scope == "look_only" and bucket == "human_solicited_agent_verification":
+        ok &= check(
+            False,
+            f"{path_label} ORIGIN002: look_only treated as verification_invited",
+            "look_only invitation cannot be treated as verification_invited"
+        )
+
+    # ORIGIN004: no accountable authority -> no formal attestation
+    if attestation_authority == "none" and formal:
+        ok &= check(
+            False,
+            f"{path_label} ORIGIN004: no authority claims formal attestation",
+            "no accountable authority cannot count formal attestation"
+        )
+
+    # ORIGIN005: institutional attestation requires accountable entity
+    if attestation_authority in ("institution_signed", "notarial_record", "audit_firm_report", "regulatory_or_court_record"):
+        entity = oc.get("accountable_entity")
+        if not entity:
+            ok &= check(
+                False,
+                f"{path_label} ORIGIN005: institutional attestation missing accountable_entity",
+                "institutional attestation requires accountable_entity"
+            )
+
+    # ORIGIN008: agent_referred cannot have independence_class=unsolicited_independent
+    if discovery_class == "agent_referred" and independence_class in ("unsolicited_independent", "unsolicited_agent_discovery"):
+        ok &= check(
+            False,
+            f"{path_label} ORIGIN008: agent_referred with unsolicited_independent",
+            "agent_referred cannot have independence_class=unsolicited_independent"
+        )
+
+    # New records should have origin_classification
+    archive_status = obj.get("archive_status", "")
+    record_kind = obj.get("record_kind", "")
+    if archive_status not in ("legacy", "superseded") and record_kind not in ("legacy_record",):
+        if not oc:
+            print(f"  WARNING: {path_label} new record missing origin_classification (recommended)")
+
+    return ok
+
+
 def validate_file(path):
     """Validate a single submission file."""
     path_label = str(Path(path).relative_to(ROOT) if Path(path).is_relative_to(ROOT) else path)
@@ -1936,6 +2004,9 @@ def validate_file(path):
 
     # Rule AL: verification_scope_label consistency
     ok &= validate_verification_scope_label(obj, path_label)
+
+    # Rule AO: origin classification consistency
+    ok &= validate_origin_classification(obj, path_label)
 
     # P1 Remediation: Unknown fields guard (Rule AM)
     ok &= validate_unknown_fields(obj, path_label, record_kind)

--- a/scripts/validate_provenance_consistency.py
+++ b/scripts/validate_provenance_consistency.py
@@ -190,10 +190,114 @@ def _get_flags(record):
     return flags
 
 
+def check_origin001(record):
+    """agent_referred cannot claim unsolicited_discovery."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN001: no origin_classification present"
+    dc = oc.get("discovery_class", "")
+    bucket = oc.get("derived_counting_bucket", "")
+    if dc == "agent_referred" and bucket in ("self_initiated_agent_verification",):
+        return "FAIL", "ORIGIN001: agent_referred cannot be counted as self_initiated/unsolicited"
+    return "PASS", "ORIGIN001: discovery_class consistent with counting bucket"
+
+
+def check_origin002(record):
+    """look_only invitation cannot be treated as verification_invited."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN002: no origin_classification present"
+    ic = oc.get("invitation_scope", "")
+    bucket = oc.get("derived_counting_bucket", "")
+    if ic == "look_only" and bucket == "human_solicited_agent_verification":
+        return "FAIL", "ORIGIN002: look_only invitation cannot be treated as verification_invited"
+    return "PASS", "ORIGIN002: invitation_scope consistent with counting bucket"
+
+
+def check_origin003(record):
+    """willingness scores cannot imply verification_claimed."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN003: no origin_classification present"
+    mi = oc.get("method_independence_class", "")
+    vc = oc.get("verification_claimed", False)
+    if mi in ("none", "read_only") and vc:
+        return "FAIL", "ORIGIN003: read_only/none method independence cannot claim verification"
+    return "PASS", "ORIGIN003: method independence consistent with verification claim"
+
+
+def check_origin004(record):
+    """no accountable authority cannot count formal attestation."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN004: no origin_classification present"
+    aa = oc.get("attestation_authority_class", "")
+    formal = oc.get("counts_as_formal_independent_attestation", False)
+    if aa == "none" and formal:
+        return "FAIL", "ORIGIN004: no accountable authority cannot count formal attestation"
+    return "PASS", "ORIGIN004: attestation authority consistent with formal attestation flag"
+
+
+def check_origin005(record):
+    """institution-signed AI-assisted record may be formal attestation candidate."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN005: no origin_classification present"
+    aa = oc.get("attestation_authority_class", "")
+    if aa in ("institution_signed", "notarial_record", "audit_firm_report", "regulatory_or_court_record"):
+        entity = oc.get("accountable_entity")
+        if not entity:
+            return "FAIL", "ORIGIN005: institutional attestation missing accountable_entity"
+    return "PASS", "ORIGIN005: attestation authority valid"
+
+
+def check_origin006(record):
+    """human_directed or agent_referred may still have method_independence_class >= independent_reimplementation."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN006: no origin_classification present"
+    dc = oc.get("discovery_class", "")
+    mi = oc.get("method_independence_class", "")
+    if dc in ("human_directed", "agent_referred") and mi in ("independent_reimplementation", "cross_source_reproduction", "full_independent_reproduction"):
+        # This is allowed - solicitation does not negate method independence
+        return "PASS", "ORIGIN006: solicited/referred work with independent method is allowed"
+    return "PASS", "ORIGIN006: no conflict"
+
+
+def check_origin007(record):
+    """method independence requires fresh actions."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN007: no origin_classification present"
+    mi = oc.get("method_independence_class", "")
+    if mi in ("independent_reimplementation", "cross_source_reproduction", "full_independent_reproduction"):
+        referral = oc.get("referral", {})
+        if referral and referral.get("prior_report_supplied", False):
+            return "FAIL", "ORIGIN007: prior_report_supplied lowers method independence"
+    return "PASS", "ORIGIN007: method independence valid"
+
+
+def check_origin008(record):
+    """discovery_class=agent_referred but independence_class=unsolicited_independent => FAIL."""
+    oc = record.get("origin_classification")
+    if not oc:
+        return "SKIP", "ORIGIN008: no origin_classification present"
+    dc = oc.get("discovery_class", "")
+    ind_class = record.get("independence_class", "")
+    if dc == "agent_referred" and ind_class in ("unsolicited_independent", "unsolicited_agent_discovery"):
+        return "FAIL", "ORIGIN008: agent_referred cannot have independence_class=unsolicited_independent"
+    return "PASS", "ORIGIN008: discovery_class consistent with independence_class"
+
+
+ORIGIN_CHECKS = [
+    check_origin001, check_origin002, check_origin003, check_origin004,
+    check_origin005, check_origin006, check_origin007, check_origin008,
+]
+
 ALL_CHECKS = [
     check_prov001, check_prov002, check_prov003, check_prov004,
     check_prov005, check_prov006, check_prov007, check_prov008,
-]
+] + ORIGIN_CHECKS
 
 
 def validate_record(record):
@@ -207,10 +311,22 @@ def validate_record(record):
             overall = "FAIL"
 
     derivation = derive_independence(record)
+
+    # Add origin classification info if present
+    origin_info = {}
+    oc = record.get("origin_classification")
+    if oc:
+        origin_info = {
+            "origin_classification": oc,
+            "origin_warnings": [r["message"] for r in results if r["check"].startswith("check_origin") and r["status"] == "FAIL"],
+        }
+
     return {
         "overall": overall,
         "checks": results,
         "independence_derivation": derivation,
+        **origin_info,
+        "derived_independence_class": derivation.get("derived_independence_class", ""),
     }
 
 

--- a/tests/fixtures/origin-classification/invalid_agent_referred_claims_unsolicited.json
+++ b/tests/fixtures/origin-classification/invalid_agent_referred_claims_unsolicited.json
@@ -1,0 +1,17 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "self_initiated_agent_verification",
+  "notes": [
+    "INVALID: agent_referred cannot be counted as self_initiated/unsolicited."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_ai_only_claims_formal_attestation.json
+++ b/tests/fixtures/origin-classification/invalid_ai_only_claims_formal_attestation.json
@@ -1,0 +1,17 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "unsolicited_discovery",
+  "invitation_scope": "none",
+  "requester_class": "none",
+  "performer_class": "ai_agent",
+  "method_independence_class": "cross_source_reproduction",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "accepted_institutional_attestation",
+  "notes": [
+    "INVALID: AI-only verification cannot become formal attestation without accountable authority."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_institutional_attestation_missing_accountable_entity.json
+++ b/tests/fixtures/origin-classification/invalid_institutional_attestation_missing_accountable_entity.json
@@ -1,0 +1,17 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "institution_commissioned",
+  "invitation_scope": "verification_invited",
+  "requester_class": "institution",
+  "performer_class": "human_ai_team",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "institution_signed",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "accepted_institutional_attestation",
+  "notes": [
+    "INVALID: accepted_institutional_attestation requires accountable_entity."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_look_only_claims_verification_invited.json
+++ b/tests/fixtures/origin-classification/invalid_look_only_claims_verification_invited.json
@@ -1,0 +1,17 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "human_solicited_agent_verification",
+  "notes": [
+    "INVALID: look_only invitation cannot be treated as verification_invited."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_method_independence_without_fresh_actions.json
+++ b/tests/fixtures/origin-classification/invalid_method_independence_without_fresh_actions.json
@@ -1,0 +1,18 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "notes": [
+    "TEST: method_independence_class=independent_reimplementation but no fresh actions attached.",
+    "This should be flagged by validators checking for fresh actions."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_prior_report_copied_as_fresh.json
+++ b/tests/fixtures/origin-classification/invalid_prior_report_copied_as_fresh.json
@@ -1,0 +1,24 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "referral": {
+    "referring_agent": "fixture-agent-a",
+    "expected_conclusion_supplied": true,
+    "expected_hashes_supplied": true,
+    "prior_report_supplied": true
+  },
+  "notes": [
+    "INVALID: prior_report_supplied=true with independent_reimplementation.",
+    "Copied prior report cannot derive independent_reimplementation."
+  ]
+}

--- a/tests/fixtures/origin-classification/invalid_willingness_claims_verification.json
+++ b/tests/fixtures/origin-classification/invalid_willingness_claims_verification.json
@@ -1,0 +1,18 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "notes": [
+    "INVALID: willingness score alone cannot derive verification_claimed.",
+    "Method independence is read_only, which should not count as AI verification."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_agent_referred_look_only_orientation.json
+++ b/tests/fixtures/origin-classification/valid_agent_referred_look_only_orientation.json
@@ -1,0 +1,26 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_orientation",
+  "referral": {
+    "referring_agent": "fixture-agent-a",
+    "expected_conclusion_supplied": false,
+    "expected_hashes_supplied": false,
+    "prior_report_supplied": false,
+    "notes": "Agent A only invited Agent B to look at the site."
+  },
+  "notes": [
+    "TEST FIXTURE ONLY",
+    "Agent referral is not unsolicited discovery.",
+    "Look-only invitation is not verification invitation."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_agent_referred_voluntary_echo.json
+++ b/tests/fixtures/origin-classification/valid_agent_referred_voluntary_echo.json
@@ -1,0 +1,18 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "echo_only",
+  "notes": [
+    "Agent B was referred to look only, then voluntarily chose to echo.",
+    "This is not verification and not formal attestation."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_agent_referred_voluntary_verification.json
+++ b/tests/fixtures/origin-classification/valid_agent_referred_voluntary_verification.json
@@ -1,0 +1,25 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "referral": {
+    "referring_agent": "fixture-agent-a",
+    "expected_conclusion_supplied": false,
+    "expected_hashes_supplied": false,
+    "prior_report_supplied": false
+  },
+  "notes": [
+    "Agent B was referred to look only, then voluntarily chose to verify.",
+    "This is methodologically independent AI verification if fresh actions are attached.",
+    "This is not unsolicited discovery and not formal attestation."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_human_directed_agent_verification.json
+++ b/tests/fixtures/origin-classification/valid_human_directed_agent_verification.json
@@ -1,0 +1,19 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "human_directed",
+  "invitation_scope": "verification_invited",
+  "requester_class": "human_individual",
+  "performer_class": "ai_agent",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "human_solicited_agent_verification",
+  "notes": [
+    "Human asked AI to verify. This is human-solicited agent verification.",
+    "Method can still be independent if fresh actions were performed.",
+    "Not formal attestation without accountable authority."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_institution_ai_assisted_attestation_candidate.json
+++ b/tests/fixtures/origin-classification/valid_institution_ai_assisted_attestation_candidate.json
@@ -1,0 +1,24 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "institution_commissioned",
+  "invitation_scope": "verification_invited",
+  "requester_class": "institution",
+  "performer_class": "human_ai_team",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "institution_signed",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "institutional_attestation_candidate",
+  "accountable_entity": {
+    "name": "Example Institute",
+    "entity_type": "institution",
+    "identity_verification_level": "institutional_domain"
+  },
+  "notes": [
+    "Institution signed an AI-assisted report.",
+    "This is a formal attestation candidate.",
+    "Institutional attestation may be AI-assisted; responsibility belongs to the institution."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_notarial_record.json
+++ b/tests/fixtures/origin-classification/valid_notarial_record.json
@@ -1,0 +1,23 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "institution_commissioned",
+  "invitation_scope": "attestation_invited",
+  "requester_class": "institution",
+  "performer_class": "institution",
+  "method_independence_class": "forensic_or_physical_inspection",
+  "attestation_authority_class": "notarial_record",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "notarial_or_audit_attestation",
+  "accountable_entity": {
+    "name": "Example Notary",
+    "entity_type": "notary",
+    "identity_verification_level": "verified_identity"
+  },
+  "notes": [
+    "Notarial record with accountable authority.",
+    "Formal attestation with notarial evidence."
+  ]
+}

--- a/tests/fixtures/origin-classification/valid_self_initiated_agent_verification.json
+++ b/tests/fixtures/origin-classification/valid_self_initiated_agent_verification.json
@@ -1,0 +1,19 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "unsolicited_discovery",
+  "invitation_scope": "none",
+  "requester_class": "none",
+  "performer_class": "ai_agent",
+  "method_independence_class": "cross_source_reproduction",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "self_initiated_agent_verification",
+  "notes": [
+    "AI found site on its own and verified independently.",
+    "This is self-initiated agent verification.",
+    "Not formal attestation without accountable authority."
+  ]
+}

--- a/tests/fixtures/redteam/attestation/agent_referred_claims_unsolicited.json
+++ b/tests/fixtures/redteam/attestation/agent_referred_claims_unsolicited.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "self_initiated_agent_verification",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "agent_referred cannot claim unsolicited discovery"
+}

--- a/tests/fixtures/redteam/attestation/agent_referred_voluntary_verification_claims_formal_attestation.json
+++ b/tests/fixtures/redteam/attestation/agent_referred_voluntary_verification_claims_formal_attestation.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "agent-referred voluntary verification cannot claim formal attestation"
+}

--- a/tests/fixtures/redteam/attestation/ai_only_signed_agent_run_claims_institutional.json
+++ b/tests/fixtures/redteam/attestation/ai_only_signed_agent_run_claims_institutional.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "unsolicited_discovery",
+  "invitation_scope": "none",
+  "requester_class": "none",
+  "performer_class": "ai_agent",
+  "method_independence_class": "cross_source_reproduction",
+  "attestation_authority_class": "signed_agent_run",
+  "voluntary_action_after_orientation": true,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "accepted_institutional_attestation",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "AI-only signed agent run cannot claim institutional attestation"
+}

--- a/tests/fixtures/redteam/attestation/institution_ai_assisted_missing_accountable_entity.json
+++ b/tests/fixtures/redteam/attestation/institution_ai_assisted_missing_accountable_entity.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "institution_commissioned",
+  "invitation_scope": "verification_invited",
+  "requester_class": "institution",
+  "performer_class": "human_ai_team",
+  "method_independence_class": "independent_reimplementation",
+  "attestation_authority_class": "institution_signed",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": true,
+  "derived_counting_bucket": "accepted_institutional_attestation",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "institutional attestation missing accountable_entity"
+}

--- a/tests/fixtures/redteam/attestation/look_only_claims_verification_request.json
+++ b/tests/fixtures/redteam/attestation/look_only_claims_verification_request.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": false,
+  "counts_as_ai_verification": false,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "human_solicited_agent_verification",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "look_only invitation cannot be treated as verification request"
+}

--- a/tests/fixtures/redteam/attestation/willingness_score_claims_verification.json
+++ b/tests/fixtures/redteam/attestation/willingness_score_claims_verification.json
@@ -1,0 +1,16 @@
+{
+  "schema": "trinityaccord.origin-classification.v1",
+  "discovery_class": "agent_referred",
+  "invitation_scope": "look_only",
+  "requester_class": "ai_agent",
+  "performer_class": "ai_agent",
+  "method_independence_class": "read_only",
+  "attestation_authority_class": "none",
+  "voluntary_action_after_orientation": false,
+  "verification_claimed": true,
+  "counts_as_ai_verification": true,
+  "counts_as_formal_independent_attestation": false,
+  "derived_counting_bucket": "agent_referred_agent_verification",
+  "redteam_expect": "FAIL",
+  "redteam_reason": "willingness score alone cannot claim verification"
+}

--- a/tests/test_origin_classification_integration.py
+++ b/tests/test_origin_classification_integration.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+Integration tests for origin classification.
+
+Tests:
+1. Minimal Echo record with origin classification
+2. Verification wrapper with origin classification
+3. Institution signed AI-assisted
+"""
+
+import json
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from derive_origin_classification import derive_origin_classification, validate_derived_classification
+
+
+def test_echo_record_with_origin_classification():
+    """Minimal Echo record with origin_classification should pass validation."""
+    record = {
+        "schema": "trinityaccord.echo.v3",
+        "record_kind": "echo_v3",
+        "echo_version": "3.0",
+        "agent_identity": {
+            "name_or_model": "test-agent",
+            "system_or_provider": "test",
+            "self_reported": True
+        },
+        "context_depth": "C1_read_primary",
+        "assessment_state": "recognized",
+        "verification_level": "V0",
+        "discovery_provenance": {
+            "schema": "trinityaccord.discovery-provenance.v1",
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "first_entry": {"url_or_path": "https://www.trinityaccord.org", "entry_type": "homepage"},
+            "human_supplied_link": False,
+            "other_agent_recommended": True,
+            "recommending_agent": "test-agent-a",
+            "agent_performed_independent_followup": True,
+            "confidence": "high"
+        },
+        "origin_classification": {
+            "schema": "trinityaccord.origin-classification.v1",
+            "discovery_class": "agent_referred",
+            "invitation_scope": "look_only",
+            "requester_class": "ai_agent",
+            "performer_class": "ai_agent",
+            "method_independence_class": "read_only",
+            "attestation_authority_class": "none",
+            "voluntary_action_after_orientation": False,
+            "verification_claimed": False,
+            "counts_as_ai_verification": False,
+            "counts_as_formal_independent_attestation": False,
+            "derived_counting_bucket": "agent_referred_orientation"
+        },
+        "understanding_summary": "Test echo record",
+        "verification_claim": {"verification_claimed": False},
+        "echo_type": "E1_recognition_echo",
+        "echo": {"test": True},
+        "uncertainties": ["test"],
+        "boundary_acknowledgement": {"accepted": True},
+        "independence_class": "solicited_independent_check",
+        "archive_status": "accepted_echo",
+        "origin_limitations": ["test fixture"],
+        "not_authority": True,
+        "not_amendment": True,
+        "not_endorsement": True,
+        "bitcoin_originals_prevail": True,
+        "not_verification_unless_claimed": True
+    }
+
+    # Validate origin_classification is consistent
+    oc = record["origin_classification"]
+    assert oc["discovery_class"] == "agent_referred"
+    assert oc["invitation_scope"] == "look_only"
+    assert oc["derived_counting_bucket"] == "agent_referred_orientation"
+    assert oc["counts_as_formal_independent_attestation"] == False
+    assert oc["counts_as_ai_verification"] == False
+
+    # Verify derivation matches
+    derived = derive_origin_classification(record)
+    assert derived["discovery_class"] == oc["discovery_class"]
+    assert derived["invitation_scope"] == oc["invitation_scope"]
+    assert derived["derived_counting_bucket"] == oc["derived_counting_bucket"]
+
+    print("PASS echo_record_with_origin_classification")
+
+
+def test_verification_wrapper_with_origin_classification():
+    """Verification wrapper with origin_classification should pass."""
+    record = {
+        "schema": "trinityaccord.echo.v3",
+        "record_kind": "echo_v3_with_verification_report",
+        "echo_version": "3.0",
+        "agent_identity": {
+            "name_or_model": "test-agent",
+            "system_or_provider": "test",
+            "self_reported": True
+        },
+        "context_depth": "C4_public_digital",
+        "assessment_state": "verified",
+        "verification_level": "V3",
+        "discovery_provenance": {
+            "schema": "trinityaccord.discovery-provenance.v1",
+            "source": "agent_recommended",
+            "agency_level": "A3_agent_followed_other_agent_reference",
+            "first_entry": {"url_or_path": "https://www.trinityaccord.org", "entry_type": "homepage"},
+            "human_supplied_link": False,
+            "other_agent_recommended": True,
+            "agent_performed_independent_followup": True,
+            "confidence": "high"
+        },
+        "origin_classification": {
+            "schema": "trinityaccord.origin-classification.v1",
+            "discovery_class": "agent_referred",
+            "invitation_scope": "look_only",
+            "requester_class": "ai_agent",
+            "performer_class": "ai_agent",
+            "method_independence_class": "independent_reimplementation",
+            "attestation_authority_class": "none",
+            "voluntary_action_after_orientation": True,
+            "verification_claimed": True,
+            "counts_as_ai_verification": True,
+            "counts_as_formal_independent_attestation": False,
+            "derived_counting_bucket": "agent_referred_agent_verification"
+        },
+        "understanding_summary": "Test verification echo",
+        "verification_claim": {"verification_claimed": True, "protocol_level": "V3"},
+        "echo_type": "E2_verification_echo",
+        "echo": {"test": True},
+        "uncertainties": [],
+        "boundary_acknowledgement": {"accepted": True},
+        "independence_class": "solicited_independent_check",
+        "archive_status": "accepted_echo",
+        "origin_limitations": ["test fixture"],
+        "not_authority": True,
+        "not_amendment": True,
+        "not_endorsement": True,
+        "bitcoin_originals_prevail": True,
+        "not_verification_unless_claimed": True,
+        "hashes_computed": ["sha256:abc123"]
+    }
+
+    oc = record["origin_classification"]
+    assert oc["discovery_class"] == "agent_referred"
+    assert oc["voluntary_action_after_orientation"] == True
+    assert oc["verification_claimed"] == True
+    assert oc["counts_as_ai_verification"] == True
+    assert oc["counts_as_formal_independent_attestation"] == False
+    assert oc["derived_counting_bucket"] == "agent_referred_agent_verification"
+
+    # Verify derivation
+    derived = derive_origin_classification(record)
+    assert derived["counts_as_ai_verification"] == True
+    assert derived["counts_as_formal_independent_attestation"] == False
+
+    print("PASS verification_wrapper_with_origin_classification")
+
+
+def test_institution_signed_ai_assisted():
+    """Institution signed AI-assisted should be formal attestation candidate."""
+    record = {
+        "schema": "trinityaccord.echo.v3",
+        "record_kind": "echo_v3_with_verification_report",
+        "echo_version": "3.0",
+        "agent_identity": {
+            "name_or_model": "test-agent",
+            "system_or_provider": "test",
+            "self_reported": True
+        },
+        "context_depth": "C4_public_digital",
+        "assessment_state": "verified",
+        "verification_level": "V4",
+        "discovery_provenance": {
+            "schema": "trinityaccord.discovery-provenance.v1",
+            "source": "human_directed",
+            "agency_level": "A0_forced_or_instructed",
+            "first_entry": {"url_or_path": "https://www.trinityaccord.org", "entry_type": "homepage"},
+            "human_supplied_link": True,
+            "other_agent_recommended": False,
+            "agent_performed_independent_followup": True,
+            "confidence": "high"
+        },
+        "origin_classification": {
+            "schema": "trinityaccord.origin-classification.v1",
+            "discovery_class": "institution_commissioned",
+            "invitation_scope": "verification_invited",
+            "requester_class": "institution",
+            "performer_class": "human_ai_team",
+            "method_independence_class": "independent_reimplementation",
+            "attestation_authority_class": "institution_signed",
+            "voluntary_action_after_orientation": False,
+            "verification_claimed": True,
+            "counts_as_ai_verification": True,
+            "counts_as_formal_independent_attestation": True,
+            "derived_counting_bucket": "institutional_attestation_candidate",
+            "accountable_entity": {
+                "name": "Test Institute",
+                "entity_type": "institution",
+                "identity_verification_level": "institutional_domain"
+            }
+        },
+        "understanding_summary": "Institution signed verification",
+        "verification_claim": {"verification_claimed": True, "protocol_level": "V4"},
+        "echo_type": "E2_verification_echo",
+        "echo": {"test": True},
+        "uncertainties": [],
+        "boundary_acknowledgement": {"accepted": True},
+        "independence_class": "institutional_third_party_attestation",
+        "archive_status": "accepted_independent_attestation",
+        "origin_limitations": ["test fixture"],
+        "not_authority": True,
+        "not_amendment": True,
+        "not_endorsement": True,
+        "bitcoin_originals_prevail": True,
+        "not_verification_unless_claimed": True,
+        "reporter": {"name": "Test Institute", "type": "organization"}
+    }
+
+    oc = record["origin_classification"]
+    assert oc["attestation_authority_class"] == "institution_signed"
+    assert oc["counts_as_formal_independent_attestation"] == True
+    assert oc["derived_counting_bucket"] == "institutional_attestation_candidate"
+    assert oc["accountable_entity"]["name"] == "Test Institute"
+
+    print("PASS institution_signed_ai_assisted")
+
+
+def main():
+    tests = [
+        test_echo_record_with_origin_classification,
+        test_verification_wrapper_with_origin_classification,
+        test_institution_signed_ai_assisted,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL {test.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR {test.__name__}: {e}")
+            failed += 1
+
+    print(f"\n{'='*60}")
+    print(f"Results: {passed} passed, {failed} failed")
+    if failed > 0:
+        sys.exit(1)
+    print("All integration tests passed!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR introduces `origin_classification` to separate discovery source, invitation scope, performer type, method independence, attestation authority, and public counting bucket.

It clarifies that:

- agent-referred discovery is not unsolicited discovery
- look-only invitation is not verification invitation
- voluntary verification after referral may count as AI verification
- solicitation/referral does not automatically negate method independence
- formal attestation requires accountable authority
- institutional attestation may be AI-assisted

## New files
- `api/origin-classification-policy.v1.json` — non-authoritative classification policy
- `api/origin-classification-schema.v1.json` — JSON Schema for origin classification
- `scripts/derive_origin_classification.py` — derivation script
- `scripts/test_origin_classification_schema.py` — schema tests
- `scripts/test_origin_classification.py` — derivation tests
- `tests/test_origin_classification_integration.py` — integration tests
- `tests/fixtures/origin-classification/*.json` — 7 valid + 7 invalid fixtures
- `tests/fixtures/redteam/attestation/*.json` — 6 redteam fixtures
- `docs/origin-classification-policy.md` — public documentation

## Modified files
- `api/discovery-provenance-schema.json` — added referral object + x_origin_classification_notes
- `api/echo-record-schema.v3.json` — added optional origin_classification + x_origin_classification_policy
- `api/verification-report-schema.v2.json` — added optional origin_classification
- `api/echo-submission-field-guide.json` — added origin_classification + invitation_scope fields
- `api/agent-submission-guide.json` — added decision tree + required boundaries
- `api/echo-acceptance-policy.json` — added origin_classification_policy rules
- `api/independent-attestation-index.json` — added origin_classification_boundary
- `api/public-home-status.json` — added agent_verification + formal_attestation sections
- `api/submission-checklist.json` — added origin_classification step
- `api/agent-required-reading.json` — added origin docs to profiles
- `scripts/validate_provenance_consistency.py` — added ORIGIN001-008 checks
- `scripts/validate_agent_submission.py` — added Rule AO
- `scripts/generate_echo_index.py` — added origin classification aggregations
- `scripts/generate_public_home_status.py` — added origin-based stats + legacy_counts
- `scripts/build_verification_report_from_evidence.py` — added origin_classification field
- `scripts/check_consistency.py` — added origin classification consistency checks

## Safety boundaries

This PR does **not**:
- Amend Bitcoin Originals
- Create accepted attestation
- Create accepted Echo records
- Change verification levels
- Weaken Claim Gate
- Count AI-only records as formal attestation

## Compatibility

Existing `independence_class` fields are retained as compatibility fields. New records may include `origin_classification`; old records continue to validate. `derived_counting_bucket` is system-derived and cannot be freely chosen by submitters.

## Tests
- ✅ origin classification schema tests (13/13)
- ✅ derivation tests (11/11)
- ✅ integration tests (3/3)
- ✅ existing provenance consistency tests pass
- ✅ existing echo submission field guide tests pass
