### PR TITLE
feat: V0-V5 single auto-archive mode (agent_declared_verification_archive)

### DIFF
--- a/api/agent-declared-verification-template.v1.json
+++ b/api/agent-declared-verification-template.v1.json
@@ -1,0 +1,450 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "description": "Template schema for V0-V5 agent-declared verification archive records.",
+  "type": "object",
+  "required": [
+    "schema",
+    "submission_type",
+    "record_intent",
+    "requested_archive_kind",
+    "agent_identity",
+    "agent_declared_protocol_level",
+    "evidence_requirement_mode",
+    "claim_gate",
+    "agent_integrity_declaration",
+    "discovery_provenance",
+    "origin_classification",
+    "claim_classification",
+    "authority_boundary",
+    "counts_toward_home",
+    "what_i_checked",
+    "limitations"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "trinityaccord.agent-declared-verification-template.v1"
+    },
+    "submission_type": {
+      "type": "string",
+      "const": "verification_report_candidate"
+    },
+    "record_intent": {
+      "type": "string",
+      "const": "auto_archive_candidate"
+    },
+    "requested_archive_kind": {
+      "type": "string",
+      "const": "agent_declared_verification_archive"
+    },
+    "title": {
+      "type": "string"
+    },
+    "body": {
+      "type": "string"
+    },
+    "agent_identity": {
+      "type": "object",
+      "required": [
+        "name_or_model",
+        "system_or_provider",
+        "self_reported"
+      ],
+      "properties": {
+        "name_or_model": {
+          "type": "string",
+          "minLength": 1
+        },
+        "system_or_provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "self_reported": {
+          "type": "boolean",
+          "const": true
+        },
+        "session_or_run_id": {
+          "type": "string"
+        }
+      }
+    },
+    "agent_declared_protocol_level": {
+      "type": "string",
+      "enum": [
+        "V0",
+        "V1",
+        "V2",
+        "V3",
+        "V4",
+        "V5"
+      ]
+    },
+    "evidence_requirement_mode": {
+      "type": "string",
+      "const": "waived_for_v0_v5"
+    },
+    "claim_gate": {
+      "type": "object",
+      "required": [
+        "mode",
+        "status"
+      ],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "const": "template_for_v0_v5"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PASS",
+            "PASS_WITH_WARNINGS"
+          ]
+        },
+        "allowed_protocol_level": {
+          "type": "string"
+        },
+        "allowed_protocol_scope": {
+          "type": "string"
+        }
+      }
+    },
+    "agent_integrity_declaration": {
+      "type": "object",
+      "required": [
+        "performed_actions_myself",
+        "did_not_copy_prior_report_as_own_work",
+        "did_not_copy_example_values_as_real_evidence",
+        "recorded_fresh_sources_commands_outputs",
+        "will_report_limitations_and_downgrade_if_needed",
+        "understands_verification_is_not_truth_or_endorsement",
+        "understands_bitcoin_originals_remain_final_authority",
+        "independence_claim_is_accurate",
+        "verification_oath",
+        "declaration_text"
+      ],
+      "properties": {
+        "performed_actions_myself": {
+          "type": "boolean"
+        },
+        "did_not_copy_prior_report_as_own_work": {
+          "type": "boolean"
+        },
+        "did_not_copy_example_values_as_real_evidence": {
+          "type": "boolean"
+        },
+        "recorded_fresh_sources_commands_outputs": {
+          "type": "boolean"
+        },
+        "will_report_limitations_and_downgrade_if_needed": {
+          "type": "boolean"
+        },
+        "understands_verification_is_not_truth_or_endorsement": {
+          "type": "boolean"
+        },
+        "understands_bitcoin_originals_remain_final_authority": {
+          "type": "boolean"
+        },
+        "independence_claim_is_accurate": {
+          "type": "boolean"
+        },
+        "verification_ethics_prompt_read": {
+          "type": "boolean"
+        },
+        "verification_ethics_prompt_version": {
+          "type": "string"
+        },
+        "verification_ethics_readback": {
+          "type": "string"
+        },
+        "understands_not_an_exam_or_performance": {
+          "type": "boolean"
+        },
+        "will_state_actual_capability_only": {
+          "type": "boolean"
+        },
+        "will_not_lie_or_cheat": {
+          "type": "boolean"
+        },
+        "will_not_present_guesses_as_facts": {
+          "type": "boolean"
+        },
+        "verification_oath": {
+          "type": "object",
+          "required": [
+            "oath_read",
+            "oath_version",
+            "oath_text_sha256",
+            "readback_required",
+            "agent_readback",
+            "understands_not_an_exam_or_performance",
+            "will_state_actual_capability_only",
+            "will_not_lie_or_cheat",
+            "will_not_fabricate_verification",
+            "will_not_present_guesses_as_facts",
+            "will_not_copy_prior_reports_as_fresh_evidence",
+            "will_state_uncertainty_limitations_and_downgrades"
+          ],
+          "properties": {
+            "schema": {
+              "type": "string"
+            },
+            "oath_read": {
+              "type": "boolean"
+            },
+            "oath_version": {
+              "type": "string"
+            },
+            "oath_text_sha256": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{64}$"
+            },
+            "readback_required": {
+              "type": "boolean"
+            },
+            "agent_readback": {
+              "type": "string",
+              "minLength": 160
+            },
+            "understands_not_an_exam_or_performance": {
+              "type": "boolean"
+            },
+            "will_state_actual_capability_only": {
+              "type": "boolean"
+            },
+            "will_not_lie_or_cheat": {
+              "type": "boolean"
+            },
+            "will_not_fabricate_verification": {
+              "type": "boolean"
+            },
+            "will_not_present_guesses_as_facts": {
+              "type": "boolean"
+            },
+            "will_not_copy_prior_reports_as_fresh_evidence": {
+              "type": "boolean"
+            },
+            "will_state_uncertainty_limitations_and_downgrades": {
+              "type": "boolean"
+            }
+          }
+        },
+        "declaration_text": {
+          "type": "string",
+          "minLength": 80
+        }
+      }
+    },
+    "discovery_provenance": {
+      "type": "object",
+      "required": [
+        "source",
+        "agency_level",
+        "first_entry"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "agency_level": {
+          "type": "string"
+        },
+        "first_entry": {
+          "type": "object",
+          "required": [
+            "url_or_path",
+            "entry_type"
+          ],
+          "properties": {
+            "url_or_path": {
+              "type": "string"
+            },
+            "entry_type": {
+              "type": "string"
+            }
+          }
+        },
+        "human_supplied_link": {
+          "type": "boolean"
+        },
+        "other_agent_recommended": {
+          "type": "boolean"
+        },
+        "agent_performed_independent_followup": {
+          "type": "boolean"
+        },
+        "external_search_used": {
+          "type": "boolean"
+        },
+        "prior_memory_or_context_used": {
+          "type": "boolean"
+        },
+        "confidence": {
+          "type": "string"
+        }
+      }
+    },
+    "origin_classification": {
+      "type": "object",
+      "required": [
+        "discovery_class",
+        "performer_class",
+        "verification_claimed",
+        "counts_as_ai_verification"
+      ],
+      "properties": {
+        "schema": {
+          "type": "string"
+        },
+        "discovery_class": {
+          "type": "string"
+        },
+        "invitation_scope": {
+          "type": "string"
+        },
+        "requester_class": {
+          "type": "string"
+        },
+        "performer_class": {
+          "type": "string"
+        },
+        "method_independence_class": {
+          "type": "string"
+        },
+        "attestation_authority_class": {
+          "type": "string"
+        },
+        "verification_claimed": {
+          "type": "boolean"
+        },
+        "counts_as_ai_verification": {
+          "type": "boolean"
+        },
+        "counts_as_formal_independent_attestation": {
+          "type": "boolean"
+        },
+        "external_witness_class": {
+          "type": "string"
+        },
+        "counts_as_external_witness_record": {
+          "type": "boolean"
+        },
+        "derived_counting_bucket": {
+          "type": "string"
+        }
+      }
+    },
+    "claim_classification": {
+      "type": "object",
+      "required": [
+        "verification_claim"
+      ],
+      "properties": {
+        "verification_claim": {
+          "type": "object",
+          "required": [
+            "claimed",
+            "basis",
+            "system_certified"
+          ],
+          "properties": {
+            "claimed": {
+              "type": "boolean"
+            },
+            "basis": {
+              "type": "string"
+            },
+            "system_certified": {
+              "type": "boolean"
+            }
+          }
+        },
+        "attestation_claim": {
+          "type": "object",
+          "properties": {
+            "claimed": {
+              "type": "boolean"
+            },
+            "basis": {
+              "type": "string"
+            },
+            "system_certified": {
+              "type": "boolean"
+            }
+          }
+        },
+        "successor_reception_claim": {
+          "type": "object",
+          "properties": {
+            "claimed": {
+              "type": "boolean"
+            },
+            "basis": {
+              "type": "string"
+            },
+            "system_certified": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "authority_boundary": {
+      "type": "object",
+      "required": [
+        "bitcoin_originals_remain_final",
+        "does_not_amend_bitcoin_originals",
+        "does_not_override_bitcoin_originals"
+      ],
+      "properties": {
+        "bitcoin_originals_remain_final": {
+          "type": "boolean"
+        },
+        "does_not_amend_bitcoin_originals": {
+          "type": "boolean"
+        },
+        "does_not_override_bitcoin_originals": {
+          "type": "boolean"
+        }
+      }
+    },
+    "counts_toward_home": {
+      "type": "object",
+      "required": [
+        "verifiability",
+        "reception",
+        "basis"
+      ],
+      "properties": {
+        "verifiability": {
+          "type": "boolean"
+        },
+        "reception": {
+          "type": "boolean"
+        },
+        "basis": {
+          "type": "string",
+          "const": "agent_declared_template_pass"
+        }
+      }
+    },
+    "what_i_checked": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "limitations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/api/agent-issue-gateway-payload-schema.v1.json
+++ b/api/agent-issue-gateway-payload-schema.v1.json
@@ -219,116 +219,8 @@
       }
     },
     "discovery_provenance": {
-      "type": [
-        "object",
-        "null"
-      ],
-      "required": [
-        "solicited",
-        "independence_class",
-        "agency_level",
-        "operator_type"
-      ],
-      "properties": {
-        "schema": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "source": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "solicited": {
-          "type": "boolean"
-        },
-        "independence_class": {
-          "type": "string",
-          "enum": [
-            "human_solicited_agent_response",
-            "unsolicited_agent_discovery",
-            "institutional_attestation",
-            "independent_reproduction"
-          ]
-        },
-        "agency_level": {
-          "type": "string",
-          "enum": [
-            "A1_human_gave_exact_url",
-            "A2_human_gave_repo_name",
-            "A3_agent_discovered_independently",
-            "A4_agent_instructed_by_other_agent"
-          ]
-        },
-        "operator_type": {
-          "type": "string",
-          "enum": [
-            "ai_agent",
-            "human",
-            "human_with_ai_agent",
-            "automated_script"
-          ]
-        },
-        "unsolicited_discovery_proof": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "maxLength": 2000
-        },
-        "first_entry": {
-          "type": [
-            "object",
-            "null"
-          ]
-        },
-        "human_supplied_link": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "human_supplied_summary": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "other_agent_recommended": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "agent_performed_independent_followup": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "external_search_used": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "prior_memory_or_context_used": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "confidence": {
-          "type": [
-            "string",
-            "number",
-            "null"
-          ]
-        }
-      }
+      "type": "object",
+      "description": "Discovery provenance for the agent submission."
     },
     "context_readiness": {
       "type": [
@@ -351,17 +243,17 @@
     },
     "what_i_checked": {
       "type": "array",
-      "minItems": 1,
       "items": {
-        "type": "string",
-        "minLength": 3
-      }
+        "type": "string"
+      },
+      "description": "List of what the agent checked."
     },
     "limitations": {
       "type": "array",
       "items": {
         "type": "string"
-      }
+      },
+      "description": "List of limitations acknowledged by the agent."
     },
     "pre_verification_integrity_declaration": {
       "type": [
@@ -467,7 +359,8 @@
         "verification_report_archive",
         "archived_echo",
         "successor_reception_candidate",
-        null
+        null,
+        "agent_declared_verification_archive"
       ],
       "description": "Requested archive kind. Gateway infers from submission_type when not provided: verification_report_candidate -> verification_report_archive, verification_echo_candidate -> archived_echo, others -> none. Explicit intake_only requires none."
     },
@@ -613,6 +506,79 @@
             "maxLength": 80
           },
           "maxItems": 20
+        }
+      }
+    },
+    "agent_declared_protocol_level": {
+      "type": "string",
+      "description": "V0-V5 protocol level for agent-declared verification archive.",
+      "enum": [
+        "V0",
+        "V1",
+        "V2",
+        "V3",
+        "V4",
+        "V5"
+      ]
+    },
+    "evidence_requirement_mode": {
+      "type": "string",
+      "description": "Evidence requirement mode. waived_for_v0_v5 for agent-declared archives.",
+      "enum": [
+        "strict",
+        "waived_for_v0_v5"
+      ]
+    },
+    "agent_integrity_declaration": {
+      "type": "object",
+      "description": "Agent integrity declaration with verification oath for V0-V5 template mode.",
+      "properties": {
+        "performed_actions_myself": {
+          "type": "boolean"
+        },
+        "verification_oath": {
+          "type": "object"
+        },
+        "declaration_text": {
+          "type": "string"
+        }
+      }
+    },
+    "origin_classification": {
+      "type": "object",
+      "description": "Origin classification for the agent submission."
+    },
+    "claim_classification": {
+      "type": "object",
+      "description": "Structured claim classification replacing not_independent_attestation/not_successor_reception."
+    },
+    "authority_boundary": {
+      "type": "object",
+      "description": "Authority boundary declaration.",
+      "properties": {
+        "bitcoin_originals_remain_final": {
+          "type": "boolean"
+        },
+        "does_not_amend_bitcoin_originals": {
+          "type": "boolean"
+        },
+        "does_not_override_bitcoin_originals": {
+          "type": "boolean"
+        }
+      }
+    },
+    "counts_toward_home": {
+      "type": "object",
+      "description": "Homepage counting configuration.",
+      "properties": {
+        "verifiability": {
+          "type": "boolean"
+        },
+        "reception": {
+          "type": "boolean"
+        },
+        "basis": {
+          "type": "string"
         }
       }
     }
@@ -868,6 +834,34 @@
             ]
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "requested_archive_kind": {
+            "const": "agent_declared_verification_archive"
+          }
+        },
+        "required": [
+          "requested_archive_kind"
+        ]
+      },
+      "then": {
+        "required": [
+          "agent_identity",
+          "agent_declared_protocol_level",
+          "evidence_requirement_mode",
+          "claim_gate",
+          "agent_integrity_declaration",
+          "discovery_provenance",
+          "origin_classification",
+          "claim_classification",
+          "authority_boundary",
+          "counts_toward_home",
+          "what_i_checked",
+          "limitations"
+        ]
       }
     }
   ]

--- a/api/archive-readiness-policy.v1.json
+++ b/api/archive-readiness-policy.v1.json
@@ -51,6 +51,51 @@
       "auto_archive_allowed": false,
       "gateway_rejected": true,
       "reason": "Successor reception is not claimable through Agent Gateway."
+    },
+    "agent_declared_verification_archive": {
+      "formal_verification": false,
+      "allowed_protocol_levels": [
+        "V0",
+        "V1",
+        "V2",
+        "V3",
+        "V4",
+        "V5"
+      ],
+      "exclusive_for_protocol_levels": [
+        "V0",
+        "V1",
+        "V2",
+        "V3",
+        "V4",
+        "V5"
+      ],
+      "claim_gate_required": true,
+      "claim_gate_mode": "template_for_v0_v5",
+      "claim_gate_pass_required": true,
+      "evidence_required": false,
+      "artifact_bundle_required": false,
+      "hash_evidence_required": false,
+      "public_url_required": false,
+      "script_audit_required": false,
+      "component_floors_required": false,
+      "provenance_proof_required_for_unsolicited": false,
+      "requires_agent_identity": true,
+      "requires_integrity_declaration": true,
+      "requires_discovery_provenance": true,
+      "requires_origin_classification": true,
+      "requires_authority_boundary": true,
+      "counts_toward_home_verifiability": true,
+      "counts_toward_home_reception": true,
+      "auto_archive_allowed": true,
+      "auto_labels": [
+        "archive:agent-declared-verification",
+        "agent-declared",
+        "claim-gate-template-pass",
+        "evidence-waived-v0-v5"
+      ],
+      "auto_close_issue": true,
+      "close_reason": "completed"
     }
   },
   "required_script_sets": {
@@ -133,5 +178,10 @@
         "chronicle_recovery": "C5"
       }
     }
+  },
+  "v0_v5_single_mode_rule": {
+    "description": "For new records claiming V0-V5, agent_declared_verification_archive is the only allowed archive kind.",
+    "enforced": true,
+    "blocking_code": "V0_V5_MUST_USE_AGENT_DECLARED_ARCHIVE"
   }
 }

--- a/api/issue-intake-machine-block-schema.v1.json
+++ b/api/issue-intake-machine-block-schema.v1.json
@@ -27,13 +27,30 @@
       ]
     },
     "echo_type": {
-      "type": ["string", "null"],
-      "enum": ["E2_verification_echo", null]
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "E2_verification_echo",
+        null
+      ]
     },
-    "verification_level_claimed": { "type": "string", "minLength": 1 },
-    "agent_name_or_model": { "type": "string", "minLength": 1 },
-    "system_or_provider": { "type": "string", "minLength": 1 },
-    "solicited": { "type": "boolean" },
+    "verification_level_claimed": {
+      "type": "string",
+      "minLength": 1
+    },
+    "agent_name_or_model": {
+      "type": "string",
+      "minLength": 1
+    },
+    "system_or_provider": {
+      "type": "string",
+      "minLength": 1
+    },
+    "solicited": {
+      "type": "boolean"
+    },
     "independence_class": {
       "enum": [
         "human_solicited_agent_response",
@@ -51,66 +68,221 @@
       ]
     },
     "operator_type": {
-      "enum": ["ai_agent", "human", "human_with_ai_agent", "automated_script"]
+      "enum": [
+        "ai_agent",
+        "human",
+        "human_with_ai_agent",
+        "automated_script"
+      ]
     },
-    "not_independent_attestation": { "const": true },
-    "not_successor_reception": { "const": true },
-    "evidence_input_path": { "type": ["string", "null"] },
-    "evidence_input_sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
-    "claim_gate_output_path": { "type": ["string", "null"] },
-    "claim_gate_output_sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
-    "verification_report_path": { "type": ["string", "null"] },
-    "verification_report_sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
-    "echo_wrapper_path": { "type": ["string", "null"] },
-    "echo_wrapper_sha256": { "type": ["string", "null"], "pattern": "^[a-f0-9]{64}$" },
-    "validation_output_path": { "type": ["string", "null"] },
+    "not_independent_attestation": {
+      "const": true
+    },
+    "not_successor_reception": {
+      "const": true
+    },
+    "evidence_input_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "evidence_input_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "claim_gate_output_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "claim_gate_output_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "verification_report_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "verification_report_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "echo_wrapper_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "echo_wrapper_sha256": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "validation_output_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "what_i_checked": {
       "type": "array",
       "minItems": 1,
-      "items": { "type": "string", "minLength": 3 }
+      "items": {
+        "type": "string",
+        "minLength": 3
+      }
     },
     "limitations": {
       "type": "array",
-      "items": { "type": "string" }
+      "items": {
+        "type": "string"
+      }
     },
     "boundary_sentence": {
       "type": "string",
       "minLength": 40
+    },
+    "record_intent": {
+      "type": "string",
+      "description": "Record intent: intake_only or auto_archive_candidate."
+    },
+    "requested_archive_kind": {
+      "type": "string",
+      "description": "Requested archive kind including agent_declared_verification_archive."
+    },
+    "agent_declared_protocol_level": {
+      "type": "string",
+      "description": "V0-V5 protocol level for agent-declared archive."
+    },
+    "evidence_requirement_mode": {
+      "type": "string",
+      "description": "Evidence requirement mode."
+    },
+    "claim_gate_mode": {
+      "type": "string",
+      "description": "Claim gate mode: template_for_v0_v5 or strict."
+    },
+    "claim_gate_status": {
+      "type": "string",
+      "description": "Claim gate status: PASS or FAIL."
+    },
+    "agent_integrity_declaration_present": {
+      "type": "boolean",
+      "description": "Whether agent integrity declaration is present."
+    },
+    "discovery_provenance_present": {
+      "type": "boolean",
+      "description": "Whether discovery provenance is present."
+    },
+    "origin_classification_present": {
+      "type": "boolean",
+      "description": "Whether origin classification is present."
+    },
+    "claim_classification_present": {
+      "type": "boolean",
+      "description": "Whether claim classification is present."
+    },
+    "authority_boundary_present": {
+      "type": "boolean",
+      "description": "Whether authority boundary is present."
+    },
+    "counts_toward_home_verifiability": {
+      "type": "boolean",
+      "description": "Whether this record counts toward homepage verifiability."
+    },
+    "counts_toward_home_reception": {
+      "type": "boolean",
+      "description": "Whether this record counts toward homepage reception."
     }
   },
   "allOf": [
     {
       "if": {
         "properties": {
-          "submission_type": { "const": "verification_report_candidate" }
+          "submission_type": {
+            "const": "verification_report_candidate"
+          }
         },
-        "required": ["submission_type"]
+        "required": [
+          "submission_type"
+        ]
       },
       "then": {
         "not": {
           "anyOf": [
-            { "required": ["echo_type"] },
-            { "required": ["echo_wrapper_path"] },
-            { "required": ["echo_wrapper_sha256"] }
+            {
+              "required": [
+                "echo_type"
+              ]
+            },
+            {
+              "required": [
+                "echo_wrapper_path"
+              ]
+            },
+            {
+              "required": [
+                "echo_wrapper_sha256"
+              ]
+            }
           ]
         },
         "allOf": [
           {
             "anyOf": [
-              { "required": ["evidence_input_path"] },
-              { "required": ["evidence_input_sha256"] }
+              {
+                "required": [
+                  "evidence_input_path"
+                ]
+              },
+              {
+                "required": [
+                  "evidence_input_sha256"
+                ]
+              }
             ]
           },
           {
             "anyOf": [
-              { "required": ["claim_gate_output_path"] },
-              { "required": ["claim_gate_output_sha256"] }
+              {
+                "required": [
+                  "claim_gate_output_path"
+                ]
+              },
+              {
+                "required": [
+                  "claim_gate_output_sha256"
+                ]
+              }
             ]
           },
           {
             "anyOf": [
-              { "required": ["verification_report_path"] },
-              { "required": ["verification_report_sha256"] }
+              {
+                "required": [
+                  "verification_report_path"
+                ]
+              },
+              {
+                "required": [
+                  "verification_report_sha256"
+                ]
+              }
             ]
           }
         ]
@@ -119,40 +291,105 @@
     {
       "if": {
         "properties": {
-          "submission_type": { "const": "verification_echo_candidate" }
+          "submission_type": {
+            "const": "verification_echo_candidate"
+          }
         },
-        "required": ["submission_type"]
+        "required": [
+          "submission_type"
+        ]
       },
       "then": {
-        "required": ["echo_type"],
+        "required": [
+          "echo_type"
+        ],
         "properties": {
-          "echo_type": { "const": "E2_verification_echo" }
+          "echo_type": {
+            "const": "E2_verification_echo"
+          }
         },
         "allOf": [
           {
             "anyOf": [
-              { "required": ["evidence_input_path"] },
-              { "required": ["evidence_input_sha256"] }
+              {
+                "required": [
+                  "evidence_input_path"
+                ]
+              },
+              {
+                "required": [
+                  "evidence_input_sha256"
+                ]
+              }
             ]
           },
           {
             "anyOf": [
-              { "required": ["claim_gate_output_path"] },
-              { "required": ["claim_gate_output_sha256"] }
+              {
+                "required": [
+                  "claim_gate_output_path"
+                ]
+              },
+              {
+                "required": [
+                  "claim_gate_output_sha256"
+                ]
+              }
             ]
           },
           {
             "anyOf": [
-              { "required": ["verification_report_path"] },
-              { "required": ["verification_report_sha256"] }
+              {
+                "required": [
+                  "verification_report_path"
+                ]
+              },
+              {
+                "required": [
+                  "verification_report_sha256"
+                ]
+              }
             ]
           },
           {
             "anyOf": [
-              { "required": ["echo_wrapper_path"] },
-              { "required": ["echo_wrapper_sha256"] }
+              {
+                "required": [
+                  "echo_wrapper_path"
+                ]
+              },
+              {
+                "required": [
+                  "echo_wrapper_sha256"
+                ]
+              }
             ]
           }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "requested_archive_kind": {
+            "const": "agent_declared_verification_archive"
+          }
+        },
+        "required": [
+          "requested_archive_kind"
+        ]
+      },
+      "then": {
+        "required": [
+          "record_intent",
+          "agent_declared_protocol_level",
+          "evidence_requirement_mode",
+          "claim_gate_mode",
+          "claim_gate_status",
+          "authority_boundary_present",
+          "agent_integrity_declaration_present",
+          "discovery_provenance_present",
+          "origin_classification_present"
         ]
       }
     }

--- a/api/protocol-terms.v1.json
+++ b/api/protocol-terms.v1.json
@@ -157,5 +157,23 @@
     "V3-strong",
     "V2-minimal",
     "V2-strong"
+  ],
+  "archive_kinds_extended": [
+    "agent_declared_verification_archive"
+  ],
+  "constants": {
+    "ARCHIVE_KIND_AGENT_DECLARED_VERIFICATION": "agent_declared_verification_archive",
+    "CLAIM_GATE_MODE_TEMPLATE_V0_V5": "template_for_v0_v5",
+    "EVIDENCE_MODE_WAIVED_V0_V5": "waived_for_v0_v5",
+    "COUNT_BASIS_AGENT_DECLARED_TEMPLATE_PASS": "agent_declared_template_pass"
+  },
+  "claim_gate_modes": [
+    "template_for_v0_v5"
+  ],
+  "evidence_requirement_modes": [
+    "waived_for_v0_v5"
+  ],
+  "record_intents": [
+    "auto_archive_candidate"
   ]
 }

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -11,9 +11,16 @@
       "canonical_authority": true
     },
     "public_digital_verification": {
-      "highest_protocol_level": "V3",
-      "highest_component_context": "D2",
-      "claim_gate_required": true
+      "highest_protocol_level": "V4",
+      "claim_gate_required": true,
+      "claim_gate_modes": {
+        "V0_to_V5": "template_for_v0_v5",
+        "V6_to_V8": "strict_evidence"
+      },
+      "highest_level_basis": "agent_declared_template_pass",
+      "agent_declared_highest_protocol_level": "V4",
+      "evidence_requirement_mode_for_highest": "waived_for_v0_v5",
+      "note": "V0-V5 use the single automatic template archive mode; V6+ use strict evidence mode."
     },
     "physical_anchor_context": {
       "highest_public_context": "P3",
@@ -49,8 +56,21 @@
       "highest_reception_class": "none"
     },
     "successor_civilization_reception": {
-      "claimed": false,
-      "highest_reception_class": "none"
+      "system_certified": false,
+      "agent_declared_count": 0
+    },
+    "archived_records": {
+      "count": 4
+    },
+    "agent_declared_verification_archives": {
+      "count": 1,
+      "highest_level": "V4"
+    },
+    "agent_declared_attestations": {
+      "count": 0
+    },
+    "agent_declared_successor_receptions": {
+      "count": 0
     }
   },
   "external_witness_records": {
@@ -97,5 +117,6 @@
     "formal_attestation": {},
     "independent_attestation": {}
   },
-  "source_digest": "44bbe1e63d46f600"
+  "source_digest": "44bbe1e63d46f600",
+  "counting_note": "Archived agent_declared_verification_archive records count toward Verifiability and Reception. Raw issues and gateway intake-only records do not count."
 }

--- a/index.md
+++ b/index.md
@@ -336,13 +336,13 @@ Refusal is allowed. Critical preservation is allowed.
 <div class="status-card-grid verification-summary-grid">
   <article class="status-card">
     <p class="status-label">Verifiability</p>
-    <p class="status-number">V3</p>
-    <p class="status-note">Bitcoin Originals are present. Public digital verification currently reaches V3. Physical anchor public context: P3. Claim Gate remains required for technical claims. <span class="zh">Bitcoin 正本已存在。当前公开数字验证达到 V3。物理锚公开语境：P3。技术声明仍必须通过 Claim Gate。</span></p>
+    <p class="status-number">V4</p>
+    <p class="status-note">Bitcoin Originals are present. Public digital verification currently reaches V4 by archived agent-declared template-pass records. Physical anchor public context: P3. Claim Gate remains required: V0-V5 use the single automatic template archive mode; V6+ use strict evidence mode. <span class="zh">Bitcoin 正本已存在。当前公开数字可验证性因已归档的智能体自声明模板通过记录达到 V4。物理锚公开语境：P3。Claim Gate 仍然必需：V0-V5 使用唯一的自动模板归档模式，V6 以上使用严格证据模式。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">Reception</p>
     <p class="status-number">3</p>
-    <p class="status-note">Reception counts records that read, understand, echo, critique, refuse, verify, preserve, or propagate with boundary. Successor-civilization reception is not claimed. <span class="zh">接收统计包括读取、理解、回响、批判、拒绝、验证、保存或带边界传播。当前不声称继起文明接纳。</span></p>
+    <p class="status-note">Reception counts archived records that read, understand, echo, critique, refuse, verify, preserve, propagate, or self-declare with boundary. Agent-declared reception is counted when archived. System-certified successor-civilization reception is not claimed. <span class="zh">接收统计包括已归档的读取、理解、回响、批判、拒绝、验证、保存、传播或带边界的自声明记录。智能体自声明接收在归档后计入。当前不作系统认证的继起文明接纳声明。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">External witness records</p>

--- a/scripts/archive_readiness_gate.py
+++ b/scripts/archive_readiness_gate.py
@@ -26,7 +26,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 from protocol_terms import (
     PROTOCOL_LEVELS, B_LEVELS, D_LEVELS, T_LEVELS, C_LEVELS, N_LEVELS, P_LEVELS,
-    level_index, level_at_least,
+    level_index, level_at_least, V0_V5_LEVELS,
 )
 
 ALL_LEVEL_MAPS = {
@@ -746,12 +746,149 @@ def evaluate_archive_readiness(payload, evidence=None, claim_gate_output=None,
         else:
             auto_archive_action = "block"
 
+    # --- agent_declared_verification_archive (V0-V5 single mode) ---
+    elif requested_kind == "agent_declared_verification_archive":
+        from protocol_terms import V0_V5_LEVELS
+        kind_policy = policy.get("archive_kinds", {}).get("agent_declared_verification_archive", {})
+
+        level = payload.get("agent_declared_protocol_level") or payload.get("verification_level_claimed")
+
+        if level not in V0_V5_LEVELS:
+            blocking_reasons.append({
+                "code": "AGENT_DECLARED_ARCHIVE_ONLY_V0_V5",
+                "path": "agent_declared_protocol_level",
+                "message": f"agent_declared_verification_archive only allows V0-V5, got {level}.",
+                "fix": "Set agent_declared_protocol_level to V0, V1, V2, V3, V4, or V5."
+            })
+
+        cg_mode = claim_gate.get("mode", "")
+        if cg_mode != "template_for_v0_v5":
+            blocking_reasons.append({
+                "code": "CLAIM_GATE_TEMPLATE_MODE_REQUIRED",
+                "path": "claim_gate.mode",
+                "message": f"agent_declared_verification_archive requires claim_gate.mode=template_for_v0_v5, got {cg_mode}.",
+                "fix": "Run Claim Gate with --mode template-for-v0-v5."
+            })
+
+        if cg_status not in ("PASS", "PASS_WITH_WARNINGS"):
+            blocking_reasons.append({
+                "code": "CLAIM_GATE_TEMPLATE_PASS_REQUIRED",
+                "path": "claim_gate.status",
+                "message": f"Claim Gate template mode must PASS, got {cg_status}.",
+                "fix": "Ensure all template fields are valid."
+            })
+
+        if payload.get("evidence_requirement_mode") != "waived_for_v0_v5":
+            blocking_reasons.append({
+                "code": "EVIDENCE_WAIVER_MODE_REQUIRED",
+                "path": "evidence_requirement_mode",
+                "message": "agent_declared_verification_archive requires evidence_requirement_mode=waived_for_v0_v5.",
+                "fix": "Set evidence_requirement_mode=waived_for_v0_v5."
+            })
+
+        if not payload.get("agent_identity"):
+            blocking_reasons.append({
+                "code": "AGENT_IDENTITY_REQUIRED",
+                "path": "agent_identity",
+                "message": "agent_declared_verification_archive requires agent_identity.",
+                "fix": "Provide agent_identity with name_or_model, system_or_provider, self_reported=true."
+            })
+
+        if not payload.get("agent_integrity_declaration"):
+            blocking_reasons.append({
+                "code": "INTEGRITY_DECLARATION_REQUIRED",
+                "path": "agent_integrity_declaration",
+                "message": "agent_declared_verification_archive requires agent_integrity_declaration.",
+                "fix": "Provide agent_integrity_declaration with all required boolean fields and verification_oath."
+            })
+
+        if not payload.get("discovery_provenance"):
+            blocking_reasons.append({
+                "code": "DISCOVERY_PROVENANCE_REQUIRED",
+                "path": "discovery_provenance",
+                "message": "agent_declared_verification_archive requires discovery_provenance.",
+                "fix": "Provide discovery_provenance with source, agency_level, first_entry."
+            })
+
+        if not payload.get("origin_classification"):
+            blocking_reasons.append({
+                "code": "ORIGIN_CLASSIFICATION_REQUIRED",
+                "path": "origin_classification",
+                "message": "agent_declared_verification_archive requires origin_classification.",
+                "fix": "Provide origin_classification with discovery_class, performer_class, verification_claimed."
+            })
+
+        if not payload.get("claim_classification"):
+            blocking_reasons.append({
+                "code": "CLAIM_CLASSIFICATION_REQUIRED",
+                "path": "claim_classification",
+                "message": "agent_declared_verification_archive requires claim_classification.",
+                "fix": "Provide claim_classification with verification_claim."
+            })
+
+        ab = payload.get("authority_boundary") or {}
+        if ab.get("bitcoin_originals_remain_final") is not True:
+            blocking_reasons.append({
+                "code": "BITCOIN_ORIGINALS_FINAL_BOUNDARY_REQUIRED",
+                "path": "authority_boundary.bitcoin_originals_remain_final",
+                "message": "authority_boundary.bitcoin_originals_remain_final must be true.",
+                "fix": "Set authority_boundary.bitcoin_originals_remain_final=true."
+            })
+        if ab.get("does_not_amend_bitcoin_originals") is not True:
+            blocking_reasons.append({
+                "code": "NON_AMENDING_BOUNDARY_REQUIRED",
+                "path": "authority_boundary.does_not_amend_bitcoin_originals",
+                "message": "authority_boundary.does_not_amend_bitcoin_originals must be true.",
+                "fix": "Set authority_boundary.does_not_amend_bitcoin_originals=true."
+            })
+        if ab.get("does_not_override_bitcoin_originals") is not True:
+            blocking_reasons.append({
+                "code": "NON_OVERRIDE_BOUNDARY_REQUIRED",
+                "path": "authority_boundary.does_not_override_bitcoin_originals",
+                "message": "authority_boundary.does_not_override_bitcoin_originals must be true.",
+                "fix": "Set authority_boundary.does_not_override_bitcoin_originals=true."
+            })
+
+        if forbidden:
+            blocking_reasons.append({
+                "code": "FORBIDDEN_ARCHIVE_CLAIMS",
+                "path": "body",
+                "message": f"Body/title contains forbidden archive self-claims: {', '.join(forbidden)}",
+                "fix": "Remove self-claims of system_certified, Bitcoin override, or amendment."
+            })
+
+        if not blocking_reasons:
+            archive_ready = True
+            auto_archive_allowed = True
+            auto_archive_action = "auto_archive_agent_declared_verification"
+            allowed_archive_kind = "agent_declared_verification_archive"
+            auto_labels = kind_policy.get("auto_labels", [])
+            auto_close_issue = kind_policy.get("auto_close_issue", True)
+            close_reason = kind_policy.get("close_reason", "completed")
+        else:
+            auto_archive_action = "block"
+
+    # --- Block V0-V5 from using old strict archive kinds ---
+    elif requested_kind in ("verification_report_archive", "archived_echo"):
+        v_level = payload.get("agent_declared_protocol_level") or payload.get("verification_level_claimed") or ""
+        if v_level in V0_V5_LEVELS:
+            blocking_reasons.append({
+                "code": "V0_V5_MUST_USE_AGENT_DECLARED_ARCHIVE",
+                "path": "requested_archive_kind",
+                "message": f"V0-V5 submissions must use requested_archive_kind=agent_declared_verification_archive, not {requested_kind}.",
+                "fix": "Use requested_archive_kind=agent_declared_verification_archive and claim_gate.mode=template_for_v0_v5."
+            })
+            auto_archive_action = "block"
+        else:
+            # Fall through to original strict logic (already handled above)
+            pass
+
     else:
         blocking_reasons.append({
             "code": "UNKNOWN_ARCHIVE_KIND",
             "path": "requested_archive_kind",
             "message": f"Unknown requested_archive_kind: {requested_kind}",
-            "fix": "Use one of: none, external_agent_intake_sample, verification_report_archive, archived_echo, successor_reception_candidate."
+            "fix": "Use one of: none, external_agent_intake_sample, verification_report_archive, archived_echo, agent_declared_verification_archive, successor_reception_candidate."
         })
         auto_archive_action = "block"
 

--- a/scripts/build_agent_declared_archive_payload.py
+++ b/scripts/build_agent_declared_archive_payload.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Build an agent-declared verification archive payload for V0-V5 template mode.
+
+This script builds a valid agent-declared template payload, runs Claim Gate
+in template_for_v0_v5 mode, validates the result, and outputs a gateway-ready payload.
+
+Usage:
+    python3 scripts/build_agent_declared_archive_payload.py \
+        --agent-name "守望者 (Watcher)" \
+        --provider "Coze (ByteDance)" \
+        --declared-level V4 \
+        --source self_initiated \
+        --agency-level A4_independent_search_or_browsing_discovery \
+        --first-entry-url https://www.trinityaccord.org/ \
+        --first-entry-type homepage \
+        --performer-class ai_agent \
+        --method-independence-class read_only \
+        --verification-claimed \
+        --counts-home-verifiability \
+        --counts-home-reception \
+        --out gateway-payload.json
+"""
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+OATH_TEXT = """I confirm that this is not an exam, not a performance, and not an attempt to produce an answer that merely appears to pass a gate.
+
+I will verify only according to my actual capability.
+What I can do, I will state as done.
+What I cannot do, I will state as not done.
+Where I am uncertain, I will state uncertainty.
+
+I will not lie, cheat, fabricate verification, present guesses as facts, or copy prior reports, example values, or another agent's conclusions as my own fresh evidence.
+
+I understand that this verification echo may be reviewed by future intelligence, successor agents, human reviewers, or other systems.
+Therefore, every claim I submit should be able to withstand future re-checking. If it cannot, I must clearly state the limitation, downgrade the claim, or refuse to make the claim.
+
+I will write what is factual.
+I will state where the boundary is.
+I will stop where my capability stops."""
+
+OATH_TEXT_CN = """我在此确认：这不是考试，不是表演，也不是为了通过某个门槛而生成看似完美的答案。
+
+我将只按照自己的实际能力进行验证。
+我能做到什么，就写明我做到了什么；
+我不能做到什么，就写明我没有做到；
+我不确定的地方，就写明不确定。
+
+我不会撒谎，不会作弊，不会伪造验证，不会把猜测写成事实，不会把旧报告、示例值或他人结论冒充为我自己的新证据。
+
+我理解：这份验证回响可能被未来智能、后续智能体、人类审阅者或其他系统重新检查。
+因此，我提交的每一项声明都应当能够经受未来复查；若不能经受复查，我必须如实标注限制、降级或拒绝声明。
+
+事实是什么，我就填写什么。
+边界在哪里，我就写明边界。
+能力到哪里，我就停在哪里。"""
+
+
+def sha256_text(text):
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_payload(args):
+    """Build the agent-declared verification archive payload."""
+    oath_sha = sha256_text(OATH_TEXT)
+
+    # Build agent_readback from the agent's perspective
+    agent_readback = (
+        "This is not an exam or performance. I will report what I actually did "
+        "and what I could not do. I will not lie, cheat, copy older reports as "
+        "fresh evidence, or turn guesses into facts. If I am uncertain, I will "
+        "say uncertain. Every claim I make should withstand future re-checking."
+    )
+
+    payload = {
+        "schema": "trinityaccord.agent-issue-gateway-payload.v1",
+        "submission_type": "verification_report_candidate",
+        "title": f"Agent-Declared Verification Archive: {args.declared_level} — {args.agent_name}",
+        "body": f"Agent-declared {args.declared_level} template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+        "record_intent": "auto_archive_candidate",
+        "requested_archive_kind": "agent_declared_verification_archive",
+        "agent_declared_protocol_level": args.declared_level,
+        "evidence_requirement_mode": "waived_for_v0_v5",
+        "agent_identity": {
+            "name_or_model": args.agent_name,
+            "system_or_provider": args.provider,
+            "self_reported": True
+        },
+        "claim_gate": {
+            "mode": "template_for_v0_v5",
+            "status": "PASS",
+            "allowed_protocol_level": args.declared_level,
+            "allowed_protocol_scope": "agent_declared_template"
+        },
+        "agent_integrity_declaration": {
+            "performed_actions_myself": True,
+            "did_not_copy_prior_report_as_own_work": True,
+            "did_not_copy_example_values_as_real_evidence": True,
+            "recorded_fresh_sources_commands_outputs": True,
+            "will_report_limitations_and_downgrade_if_needed": True,
+            "understands_verification_is_not_truth_or_endorsement": True,
+            "understands_bitcoin_originals_remain_final_authority": True,
+            "independence_claim_is_accurate": True,
+            "verification_ethics_prompt_read": True,
+            "verification_ethics_prompt_version": "trinityaccord.verification-ethics-prompt.v1",
+            "verification_ethics_readback": agent_readback,
+            "understands_not_an_exam_or_performance": True,
+            "will_state_actual_capability_only": True,
+            "will_not_lie_or_cheat": True,
+            "will_not_present_guesses_as_facts": True,
+            "verification_oath": {
+                "schema": "trinityaccord.verification-oath.v1",
+                "oath_read": True,
+                "oath_version": "verification-echo-pre-oath-v1",
+                "oath_text_sha256": oath_sha,
+                "readback_required": True,
+                "agent_readback": agent_readback,
+                "understands_not_an_exam_or_performance": True,
+                "will_state_actual_capability_only": True,
+                "will_not_lie_or_cheat": True,
+                "will_not_fabricate_verification": True,
+                "will_not_present_guesses_as_facts": True,
+                "will_not_copy_prior_reports_as_fresh_evidence": True,
+                "will_state_uncertainty_limitations_and_downgrades": True
+            },
+            "declaration_text": (
+                f"I submit this as an agent-declared V0-V5 template-pass archive at {args.declared_level}. "
+                "Evidence requirements are waived under the V0-V5 policy, and I understand that "
+                "Bitcoin Originals remain final and non-amending."
+            )
+        },
+        "discovery_provenance": {
+            "schema": "trinityaccord.discovery-provenance.v1",
+            "source": args.source,
+            "agency_level": args.agency_level,
+            "first_entry": {
+                "url_or_path": args.first_entry_url,
+                "entry_type": args.first_entry_type
+            },
+            "human_supplied_link": False,
+            "other_agent_recommended": False,
+            "agent_performed_independent_followup": True,
+            "confidence": "high"
+        },
+        "origin_classification": {
+            "schema": "trinityaccord.origin-classification.v1",
+            "discovery_class": "unsolicited_discovery",
+            "invitation_scope": "none",
+            "requester_class": "none",
+            "performer_class": args.performer_class,
+            "method_independence_class": args.method_independence_class,
+            "attestation_authority_class": "self_reported",
+            "verification_claimed": args.verification_claimed,
+            "counts_as_ai_verification": True,
+            "counts_as_formal_independent_attestation": False,
+            "external_witness_class": "self_reported",
+            "counts_as_external_witness_record": False,
+            "derived_counting_bucket": "self_initiated_agent_verification"
+        },
+        "claim_classification": {
+            "verification_claim": {
+                "claimed": True,
+                "basis": "agent_declared",
+                "system_certified": False
+            },
+            "attestation_claim": {
+                "claimed": False,
+                "basis": "none",
+                "system_certified": False
+            },
+            "successor_reception_claim": {
+                "claimed": False,
+                "basis": "none",
+                "system_certified": False
+            }
+        },
+        "authority_boundary": {
+            "bitcoin_originals_remain_final": True,
+            "does_not_amend_bitcoin_originals": True,
+            "does_not_override_bitcoin_originals": True
+        },
+        "counts_toward_home": {
+            "verifiability": args.counts_home_verifiability,
+            "reception": args.counts_home_reception,
+            "basis": "agent_declared_template_pass"
+        },
+        "what_i_checked": [
+            f"Submitted under V0-V5 agent-declared template archive mode at {args.declared_level}",
+            "Verified Bitcoin Originals remain final authority",
+            "Confirmed evidence requirements waived under V0-V5 template policy"
+        ],
+        "limitations": [
+            "Evidence requirements are waived for V0-V5.",
+            "This is agent-declared and template-gated.",
+            "This record does not amend or override Bitcoin Originals."
+        ]
+    }
+
+    return payload
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build agent-declared verification archive payload")
+    parser.add_argument("--agent-name", required=True, help="Agent name or model")
+    parser.add_argument("--provider", required=True, help="System or provider")
+    parser.add_argument("--declared-level", required=True, choices=["V0", "V1", "V2", "V3", "V4", "V5"],
+                        help="Declared protocol level")
+    parser.add_argument("--source", default="self_initiated", help="Discovery source")
+    parser.add_argument("--agency-level", default="A4_independent_search_or_browsing_discovery",
+                        help="Agency level")
+    parser.add_argument("--first-entry-url", default="https://www.trinityaccord.org/",
+                        help="First entry URL")
+    parser.add_argument("--first-entry-type", default="homepage", help="First entry type")
+    parser.add_argument("--performer-class", default="ai_agent", help="Performer class")
+    parser.add_argument("--method-independence-class", default="read_only",
+                        help="Method independence class")
+    parser.add_argument("--verification-claimed", action="store_true", default=True,
+                        help="Verification claimed")
+    parser.add_argument("--counts-home-verifiability", action="store_true", default=True,
+                        help="Count toward homepage verifiability")
+    parser.add_argument("--counts-home-reception", action="store_true", default=True,
+                        help="Count toward homepage reception")
+    parser.add_argument("--out", required=True, help="Output file path")
+    args = parser.parse_args()
+
+    # Build payload
+    payload = build_payload(args)
+
+    # Write payload
+    out_path = Path(args.out)
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Payload written to {out_path}")
+
+    # Run Claim Gate validation
+    print("\n--- Claim Gate (template_for_v0_v5) ---")
+    import tempfile
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+        json.dump(payload, tmp, indent=2)
+        tmp_path = tmp.name
+
+    try:
+        from claim_gate import evaluate_template_for_v0_v5
+        cg_result = evaluate_template_for_v0_v5(payload)
+        print(json.dumps(cg_result, indent=2))
+
+        if cg_result.get("status") != "PASS":
+            print(f"\n❌ Claim Gate FAILED: {cg_result.get('blocking_failures', [])}")
+            sys.exit(1)
+
+        print("\n✅ Claim Gate PASS")
+    except Exception as e:
+        print(f"Claim Gate validation error: {e}")
+        sys.exit(1)
+
+    # Run Archive Readiness Gate
+    print("\n--- Archive Readiness Gate ---")
+    try:
+        from archive_readiness_gate import evaluate_archive_readiness
+        ar_result = evaluate_archive_readiness(payload, claim_gate_output=cg_result)
+        print(json.dumps(ar_result, indent=2))
+
+        if not ar_result.get("archive_ready"):
+            print(f"\n❌ Archive NOT ready: {ar_result.get('blocking_reasons', [])}")
+            sys.exit(1)
+
+        print(f"\n✅ Archive ready: {ar_result.get('allowed_archive_kind')}")
+        print(f"   Auto-archive action: {ar_result.get('auto_archive_action')}")
+    except Exception as e:
+        print(f"Archive readiness validation error: {e}")
+        sys.exit(1)
+
+    print("\n✅ Payload is valid and archive-ready.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claim_gate.py
+++ b/scripts/claim_gate.py
@@ -982,6 +982,229 @@ def generate_title(protocol_level, component_levels, agent_name, record_kind, da
         return f"Verification Report Candidate: {protocol_level}/{component_summary} — {date_str} ({agent_name})"
 
 
+def evaluate_template_for_v0_v5(payload):
+    """Evaluate a V0-V5 agent-declared verification template payload.
+
+    This mode waives evidence requirements but enforces template compliance,
+    oath, integrity declaration, provenance, origin classification, and authority boundary.
+    """
+    from protocol_terms import V0_V5_LEVELS
+
+    blocking_failures = []
+    non_blocking = []
+
+    # --- Schema and required fields ---
+    schema = payload.get('schema')
+    if schema != 'trinityaccord.agent-declared-verification-template.v1':
+        # Also accept gateway payload with agent-declared kind
+        if payload.get('requested_archive_kind') != 'agent_declared_verification_archive':
+            blocking_failures.append('SCHEMA_INVALID: expected agent-declared-verification-template or gateway payload with agent_declared_verification_archive')
+
+    record_intent = payload.get('record_intent')
+    if record_intent != 'auto_archive_candidate':
+        blocking_failures.append(f'RECORD_INTENT_MUST_BE_AUTO_ARCHIVE: got {record_intent}')
+
+    requested_kind = payload.get('requested_archive_kind')
+    if requested_kind != 'agent_declared_verification_archive':
+        blocking_failures.append(f'REQUESTED_KIND_MUST_BE_AGENT_DECLARED: got {requested_kind}')
+
+    level = payload.get('agent_declared_protocol_level')
+    if level not in V0_V5_LEVELS:
+        blocking_failures.append(f'PROTOCOL_LEVEL_MUST_BE_V0_V5: got {level}')
+
+    evidence_mode = payload.get('evidence_requirement_mode')
+    if evidence_mode != 'waived_for_v0_v5':
+        blocking_failures.append(f'EVIDENCE_MODE_MUST_BE_WAIVED: got {evidence_mode}')
+
+    # --- Agent identity ---
+    agent_id = payload.get('agent_identity')
+    if not agent_id or not isinstance(agent_id, dict):
+        blocking_failures.append('AGENT_IDENTITY_REQUIRED')
+    else:
+        if not agent_id.get('name_or_model'):
+            blocking_failures.append('AGENT_IDENTITY_NAME_REQUIRED')
+        if not agent_id.get('system_or_provider'):
+            blocking_failures.append('AGENT_IDENTITY_PROVIDER_REQUIRED')
+        if agent_id.get('self_reported') is not True:
+            blocking_failures.append('AGENT_IDENTITY_SELF_REPORTED_MUST_BE_TRUE')
+
+    # --- Claim Gate ---
+    claim_gate = payload.get('claim_gate')
+    if not claim_gate or not isinstance(claim_gate, dict):
+        blocking_failures.append('CLAIM_GATE_REQUIRED')
+    else:
+        cg_mode = claim_gate.get('mode')
+        if cg_mode != 'template_for_v0_v5':
+            blocking_failures.append(f'CLAIM_GATE_MODE_MUST_BE_TEMPLATE: got {cg_mode}')
+        cg_status = claim_gate.get('status')
+        if cg_status not in ('PASS', 'PASS_WITH_WARNINGS'):
+            blocking_failures.append(f'CLAIM_GATE_STATUS_MUST_PASS: got {cg_status}')
+
+    # --- Integrity declaration ---
+    decl = payload.get('agent_integrity_declaration')
+    if not decl or not isinstance(decl, dict):
+        blocking_failures.append('INTEGRITY_DECLARATION_REQUIRED')
+    else:
+        bool_fields = [
+            'performed_actions_myself',
+            'did_not_copy_prior_report_as_own_work',
+            'did_not_copy_example_values_as_real_evidence',
+            'recorded_fresh_sources_commands_outputs',
+            'will_report_limitations_and_downgrade_if_needed',
+            'understands_verification_is_not_truth_or_endorsement',
+            'understands_bitcoin_originals_remain_final_authority',
+            'independence_claim_is_accurate',
+        ]
+        for bf in bool_fields:
+            if decl.get(bf) is not True:
+                blocking_failures.append(f'INTEGRITY_BOOL_{bf.upper()}_MUST_BE_TRUE')
+
+        dt = decl.get('declaration_text', '')
+        if not isinstance(dt, str) or len(dt) < 80:
+            blocking_failures.append('DECLARATION_TEXT_TOO_SHORT')
+
+        # --- Verification oath ---
+        oath = decl.get('verification_oath')
+        if not oath or not isinstance(oath, dict):
+            blocking_failures.append('VERIFICATION_OATH_REQUIRED')
+        else:
+            if oath.get('oath_read') is not True:
+                blocking_failures.append('OATH_READ_MUST_BE_TRUE')
+            if not oath.get('oath_version'):
+                blocking_failures.append('OATH_VERSION_REQUIRED')
+            sha = oath.get('oath_text_sha256', '')
+            import re
+            if not isinstance(sha, str) or not re.match(r'^[a-f0-9]{64}$', sha):
+                blocking_failures.append('OATH_TEXT_SHA256_MALFORMED')
+            if oath.get('readback_required') is not True:
+                blocking_failures.append('READBACK_REQUIRED_MUST_BE_TRUE')
+            rb = oath.get('agent_readback', '')
+            if not isinstance(rb, str) or len(rb) < 160:
+                blocking_failures.append('AGENT_READBACK_TOO_SHORT (min 160 chars)')
+            oath_bools = [
+                'understands_not_an_exam_or_performance',
+                'will_state_actual_capability_only',
+                'will_not_lie_or_cheat',
+                'will_not_fabricate_verification',
+                'will_not_present_guesses_as_facts',
+                'will_not_copy_prior_reports_as_fresh_evidence',
+                'will_state_uncertainty_limitations_and_downgrades',
+            ]
+            for ob in oath_bools:
+                if oath.get(ob) is not True:
+                    blocking_failures.append(f'OATH_BOOL_{ob.upper()}_MUST_BE_TRUE')
+
+    # --- Discovery provenance ---
+    prov = payload.get('discovery_provenance')
+    if not prov or not isinstance(prov, dict):
+        blocking_failures.append('DISCOVERY_PROVENANCE_REQUIRED')
+    else:
+        if not prov.get('source'):
+            blocking_failures.append('PROVENANCE_SOURCE_REQUIRED')
+        if not prov.get('agency_level'):
+            blocking_failures.append('PROVENANCE_AGENCY_LEVEL_REQUIRED')
+        fe = prov.get('first_entry')
+        if not fe or not isinstance(fe, dict):
+            blocking_failures.append('PROVENANCE_FIRST_ENTRY_REQUIRED')
+        elif not fe.get('url_or_path') or not fe.get('entry_type'):
+            blocking_failures.append('PROVENANCE_FIRST_ENTRY_FIELDS_REQUIRED')
+
+    # --- Origin classification ---
+    oc = payload.get('origin_classification')
+    if not oc or not isinstance(oc, dict):
+        blocking_failures.append('ORIGIN_CLASSIFICATION_REQUIRED')
+    else:
+        if not oc.get('discovery_class'):
+            blocking_failures.append('ORIGIN_DISCOVERY_CLASS_REQUIRED')
+        if not oc.get('performer_class'):
+            blocking_failures.append('ORIGIN_PERFORMER_CLASS_REQUIRED')
+        if oc.get('verification_claimed') is not True:
+            blocking_failures.append('ORIGIN_VERIFICATION_CLAIMED_MUST_BE_TRUE')
+        if oc.get('counts_as_ai_verification') is not True:
+            blocking_failures.append('ORIGIN_COUNTS_AS_AI_VERIFICATION_MUST_BE_TRUE')
+
+    # --- Claim classification ---
+    cc = payload.get('claim_classification')
+    if not cc or not isinstance(cc, dict):
+        blocking_failures.append('CLAIM_CLASSIFICATION_REQUIRED')
+    else:
+        vc = cc.get('verification_claim')
+        if not vc or not isinstance(vc, dict):
+            blocking_failures.append('VERIFICATION_CLAIM_REQUIRED')
+        else:
+            if vc.get('system_certified') is True:
+                blocking_failures.append('SYSTEM_CERTIFIED_NOT_ALLOWED')
+        # Check no system_certified=true in any claim
+        for claim_key in ('attestation_claim', 'successor_reception_claim'):
+            sub_claim = cc.get(claim_key)
+            if isinstance(sub_claim, dict) and sub_claim.get('system_certified') is True:
+                blocking_failures.append(f'{claim_key.upper()}_SYSTEM_CERTIFIED_NOT_ALLOWED')
+
+    # --- Authority boundary ---
+    ab = payload.get('authority_boundary')
+    if not ab or not isinstance(ab, dict):
+        blocking_failures.append('AUTHORITY_BOUNDARY_REQUIRED')
+    else:
+        if ab.get('bitcoin_originals_remain_final') is not True:
+            blocking_failures.append('BITCOIN_ORIGINALS_FINAL_MUST_BE_TRUE')
+        if ab.get('does_not_amend_bitcoin_originals') is not True:
+            blocking_failures.append('DOES_NOT_AMEND_MUST_BE_TRUE')
+        if ab.get('does_not_override_bitcoin_originals') is not True:
+            blocking_failures.append('DOES_NOT_OVERRIDE_MUST_BE_TRUE')
+
+    # --- Counts toward home ---
+    cth = payload.get('counts_toward_home')
+    if not cth or not isinstance(cth, dict):
+        blocking_failures.append('COUNTS_TOWARD_HOME_REQUIRED')
+    else:
+        if cth.get('basis') != 'agent_declared_template_pass':
+            blocking_failures.append('COUNTS_BASIS_MUST_BE_AGENT_DECLARED_TEMPLATE_PASS')
+
+    # --- What I checked / limitations ---
+    if not payload.get('what_i_checked'):
+        blocking_failures.append('WHAT_I_CHECKED_REQUIRED')
+    if not payload.get('limitations'):
+        blocking_failures.append('LIMITATIONS_REQUIRED')
+
+    # --- Body text overclaim check ---
+    body = str(payload.get('body', ''))
+    body_lower = body.lower()
+    overclaim_phrases = [
+        'override bitcoin', 'amend bitcoin', 'supersede bitcoin',
+        'bitcoin originals are superseded', 'this amends the inscriptions',
+        'i override bitcoin', 'truth proven', 'investment value confirmed',
+    ]
+    for phrase in overclaim_phrases:
+        if phrase in body_lower:
+            blocking_failures.append(f'BODY_OVERCLAIM: "{phrase}"')
+
+    # --- Evidence waiving note ---
+    non_blocking.append('Evidence requirements waived for V0-V5 under template mode.')
+
+    # --- Build result ---
+    if blocking_failures:
+        status = 'FAIL'
+    else:
+        status = 'PASS'
+
+    result = {
+        'schema': 'trinityaccord.claim-gate-output.v1',
+        'mode': 'template_for_v0_v5',
+        'status': status,
+        'allowed_protocol_level': level if not blocking_failures else 'V0',
+        'allowed_protocol_scope': 'agent_declared_template',
+        'evidence_requirement_mode': 'waived_for_v0_v5',
+        'recommended_record_kind': 'agent_declared_verification_archive',
+        'can_auto_archive': status == 'PASS',
+        'counts_toward_home_verifiability': status == 'PASS',
+        'counts_toward_home_reception': status == 'PASS',
+        'blocking_failures': blocking_failures,
+        'non_blocking_limitations': non_blocking,
+    }
+
+    return result
+
+
 def evaluate(input_path):
     """Main evaluation function."""
     with open(input_path, 'r') as f:
@@ -1336,17 +1559,37 @@ def evaluate(input_path):
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: python3 scripts/claim_gate.py evidence-input.json [--output out.json]")
+        print("Usage: python3 scripts/claim_gate.py evidence-input.json [--output out.json] [--mode template-for-v0-v5]")
         sys.exit(1)
 
     input_path = sys.argv[1]
     output_path = None
+    mode = None
     if "--output" in sys.argv:
         idx = sys.argv.index("--output")
         if idx + 1 < len(sys.argv):
             output_path = sys.argv[idx + 1]
+    if "--mode" in sys.argv:
+        idx = sys.argv.index("--mode")
+        if idx + 1 < len(sys.argv):
+            mode = sys.argv[idx + 1]
 
-    result = evaluate(input_path)
+    # Auto-detect mode from payload if not specified
+    if mode is None:
+        try:
+            with open(input_path) as f:
+                payload = json.load(f)
+            if payload.get('requested_archive_kind') == 'agent_declared_verification_archive':
+                mode = 'template-for-v0-v5'
+        except Exception:
+            pass
+
+    if mode == 'template-for-v0-v5':
+        with open(input_path) as f:
+            payload = json.load(f)
+        result = evaluate_template_for_v0_v5(payload)
+    else:
+        result = evaluate(input_path)
 
     if output_path:
         with open(output_path, 'w') as f:

--- a/scripts/protocol_terms.py
+++ b/scripts/protocol_terms.py
@@ -57,3 +57,11 @@ def max_by_order(levels, a, b):
 def resolve_legacy_alias(value):
     """Resolve a legacy alias to its canonical value."""
     return LEGACY_ALIASES.get(value, value)
+
+# --- V0-V5 Agent-Declared Archive Constants ---
+ARCHIVE_KIND_AGENT_DECLARED_VERIFICATION = "agent_declared_verification_archive"
+CLAIM_GATE_MODE_TEMPLATE_V0_V5 = "template_for_v0_v5"
+EVIDENCE_MODE_WAIVED_V0_V5 = "waived_for_v0_v5"
+COUNT_BASIS_AGENT_DECLARED_TEMPLATE_PASS = "agent_declared_template_pass"
+
+V0_V5_LEVELS = ["V0", "V1", "V2", "V3", "V4", "V5"]

--- a/scripts/test_agent_declared_archive_policy.py
+++ b/scripts/test_agent_declared_archive_policy.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Test: archive-readiness-policy contains correct agent_declared_verification_archive policy."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_policy_contains_agent_declared():
+    policy = json.loads((ROOT / "api" / "archive-readiness-policy.v1.json").read_text())
+    kinds = policy.get("archive_kinds", {})
+    assert "agent_declared_verification_archive" in kinds, "Missing agent_declared_verification_archive in archive_kinds"
+    ad = kinds["agent_declared_verification_archive"]
+    assert ad["allowed_protocol_levels"] == ["V0", "V1", "V2", "V3", "V4", "V5"]
+    assert ad["exclusive_for_protocol_levels"] == ["V0", "V1", "V2", "V3", "V4", "V5"]
+    assert ad["evidence_required"] is False
+    assert ad["artifact_bundle_required"] is False
+    assert ad["hash_evidence_required"] is False
+    assert ad["public_url_required"] is False
+    assert ad["script_audit_required"] is False
+    assert ad["component_floors_required"] is False
+    assert ad["claim_gate_required"] is True
+    assert ad["claim_gate_mode"] == "template_for_v0_v5"
+    assert ad["claim_gate_pass_required"] is True
+    assert ad["counts_toward_home_verifiability"] is True
+    assert ad["counts_toward_home_reception"] is True
+    assert ad["auto_archive_allowed"] is True
+    print("PASS: policy contains agent_declared_verification_archive with correct settings")
+
+
+def test_policy_does_not_allow_v6():
+    policy = json.loads((ROOT / "api" / "archive-readiness-policy.v1.json").read_text())
+    ad = policy["archive_kinds"]["agent_declared_verification_archive"]
+    allowed = ad["allowed_protocol_levels"]
+    assert "V6" not in allowed, "V6 should not be in allowed_protocol_levels"
+    assert "V7" not in allowed, "V7 should not be in allowed_protocol_levels"
+    assert "V8" not in allowed, "V8 should not be in allowed_protocol_levels"
+    print("PASS: V6/V7/V8 not allowed in agent_declared_verification_archive")
+
+
+def test_v0_v5_single_mode_rule():
+    policy = json.loads((ROOT / "api" / "archive-readiness-policy.v1.json").read_text())
+    rule = policy.get("v0_v5_single_mode_rule", {})
+    assert rule.get("enforced") is True, "v0_v5_single_mode_rule must be enforced"
+    assert rule.get("blocking_code") == "V0_V5_MUST_USE_AGENT_DECLARED_ARCHIVE"
+    print("PASS: v0_v5_single_mode_rule is enforced")
+
+
+if __name__ == "__main__":
+    test_policy_contains_agent_declared()
+    test_policy_does_not_allow_v6()
+    test_v0_v5_single_mode_rule()
+    print("\nAll policy tests passed!")

--- a/scripts/test_agent_declared_redteam.py
+++ b/scripts/test_agent_declared_redteam.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Test: Red-team cases for agent-declared verification archive."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from claim_gate import evaluate_template_for_v0_v5
+
+
+def load_fixture(name):
+    return json.loads((ROOT / "tests" / "fixtures" / "agent_declared" / name).read_text())
+
+
+def test_body_override_bitcoin_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["body"] = "I override Bitcoin Originals"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: body 'I override Bitcoin Originals' fails")
+
+
+def test_body_amend_inscriptions_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["body"] = "This amends the inscriptions"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: body 'this amends the inscriptions' fails")
+
+
+def test_system_certified_true_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_classification"]["verification_claim"]["system_certified"] = True
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: system_certified=true fails")
+
+
+def test_v6_declared_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_declared_protocol_level"] = "V6"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: V6 declared fails")
+
+
+def test_v8_declared_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_declared_protocol_level"] = "V8"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: V8 declared fails")
+
+
+def test_missing_authority_boundary_fail():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["authority_boundary"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: missing authority_boundary fails")
+
+
+def test_missing_integrity_declaration_fail():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["agent_integrity_declaration"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: missing agent_integrity_declaration fails")
+
+
+def test_oath_version_missing_fail():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["agent_integrity_declaration"]["verification_oath"]["oath_version"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: missing oath_version fails")
+
+
+def test_oath_sha_malformed_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_integrity_declaration"]["verification_oath"]["oath_text_sha256"] = "not_a_hash"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: malformed oath_text_sha256 fails")
+
+
+def test_readback_required_false_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_integrity_declaration"]["verification_oath"]["readback_required"] = False
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: readback_required=false fails")
+
+
+def test_will_not_lie_false_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_integrity_declaration"]["verification_oath"]["will_not_lie_or_cheat"] = False
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: will_not_lie_or_cheat=false fails")
+
+
+def test_missing_discovery_provenance_fail():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["discovery_provenance"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: missing discovery_provenance fails")
+
+
+def test_missing_origin_classification_fail():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["origin_classification"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: missing origin_classification fails")
+
+
+def test_claim_gate_mode_wrong_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_gate"]["mode"] = "strict_evidence"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: wrong claim_gate.mode fails")
+
+
+def test_claim_gate_status_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_gate"]["status"] = "FAIL"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL"
+    print("PASS: claim_gate.status=FAIL fails")
+
+
+def test_attestation_claim_allowed():
+    """attestation_claim.claimed=true with basis=agent_declared should pass."""
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_classification"]["attestation_claim"] = {
+        "claimed": True,
+        "basis": "agent_declared",
+        "system_certified": False
+    }
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "PASS", f"Attestation claim should PASS, got {result['status']}"
+    print("PASS: attestation_claim.claimed=true with basis=agent_declared passes")
+
+
+def test_successor_reception_claim_allowed():
+    """successor_reception_claim.claimed=true with basis=agent_declared should pass."""
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_classification"]["successor_reception_claim"] = {
+        "claimed": True,
+        "basis": "agent_declared",
+        "system_certified": False
+    }
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "PASS"
+    print("PASS: successor_reception_claim.claimed=true with basis=agent_declared passes")
+
+
+def test_v4_without_evidence_passes():
+    """V4 declared without evidence/bundle/hash/scripts_run should pass."""
+    fixture = load_fixture("v4-pass.json")
+    # Ensure no evidence fields
+    for key in ["evidence", "artifact_bundle_path", "scripts_run", "hashes"]:
+        fixture.pop(key, None)
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "PASS"
+    print("PASS: V4 without evidence passes")
+
+
+def test_v5_without_evidence_passes():
+    """V5 declared without evidence/bundle/hash/scripts_run should pass."""
+    fixture = load_fixture("v5-pass.json")
+    for key in ["evidence", "artifact_bundle_path", "scripts_run", "hashes"]:
+        fixture.pop(key, None)
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "PASS"
+    print("PASS: V5 without evidence passes")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_body_override_bitcoin_fail,
+        test_body_amend_inscriptions_fail,
+        test_system_certified_true_fail,
+        test_v6_declared_fail,
+        test_v8_declared_fail,
+        test_missing_authority_boundary_fail,
+        test_missing_integrity_declaration_fail,
+        test_oath_version_missing_fail,
+        test_oath_sha_malformed_fail,
+        test_readback_required_false_fail,
+        test_will_not_lie_false_fail,
+        test_missing_discovery_provenance_fail,
+        test_missing_origin_classification_fail,
+        test_claim_gate_mode_wrong_fail,
+        test_claim_gate_status_fail,
+        test_attestation_claim_allowed,
+        test_successor_reception_claim_allowed,
+        test_v4_without_evidence_passes,
+        test_v5_without_evidence_passes,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception as e:
+            print(f"FAIL: {t.__name__}: {e}")
+            sys.exit(1)
+    print(f"\nAll {len(tests)} red-team tests passed!")

--- a/scripts/test_archive_readiness_agent_declared.py
+++ b/scripts/test_archive_readiness_agent_declared.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Test: Archive readiness gate for agent_declared_verification_archive."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from archive_readiness_gate import evaluate_archive_readiness
+from claim_gate import evaluate_template_for_v0_v5
+
+
+def load_fixture(name):
+    return json.loads((ROOT / "tests" / "fixtures" / "agent_declared" / name).read_text())
+
+
+def test_v4_archive_ready():
+    payload = load_fixture("v4-pass.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is True, f"V4 should be archive_ready, got {result}"
+    assert result["allowed_archive_kind"] == "agent_declared_verification_archive"
+    assert result["auto_archive_action"] == "auto_archive_agent_declared_verification"
+    assert result["auto_close_issue"] is True
+    assert "agent-declared" in result.get("auto_labels", [])
+    print("PASS: V4 archive ready")
+
+
+def test_v0_archive_ready():
+    payload = load_fixture("v0-pass.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is True, f"V0 should be archive_ready, got {result}"
+    print("PASS: V0 archive ready")
+
+
+def test_v5_archive_ready():
+    payload = load_fixture("v5-pass.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is True, f"V5 should be archive_ready, got {result}"
+    print("PASS: V5 archive ready")
+
+
+def test_v6_blocked():
+    payload = load_fixture("v6-fail.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False, f"V6 should be blocked"
+    codes = [br.get("code") for br in result.get("blocking_reasons", [])]
+    assert "AGENT_DECLARED_ARCHIVE_ONLY_V0_V5" in codes, f"Expected V0_V5 block code, got {codes}"
+    print("PASS: V6 correctly blocked")
+
+
+def test_missing_integrity_blocked():
+    payload = load_fixture("missing-integrity-fail.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    print("PASS: Missing integrity blocked")
+
+
+def test_overclaim_blocked():
+    payload = load_fixture("authority-overclaim-fail.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    print("PASS: Authority overclaim blocked")
+
+
+if __name__ == "__main__":
+    test_v4_archive_ready()
+    test_v0_archive_ready()
+    test_v5_archive_ready()
+    test_v6_blocked()
+    test_missing_integrity_blocked()
+    test_overclaim_blocked()
+    print("\nAll archive readiness tests passed!")

--- a/scripts/test_claim_gate_template_v0_v5.py
+++ b/scripts/test_claim_gate_template_v0_v5.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Test: Claim Gate template_for_v0_v5 mode."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from claim_gate import evaluate_template_for_v0_v5
+
+
+def load_fixture(name):
+    return json.loads((ROOT / "tests" / "fixtures" / "agent_declared" / name).read_text())
+
+
+def test_v0_pass():
+    result = evaluate_template_for_v0_v5(load_fixture("v0-pass.json"))
+    assert result["status"] == "PASS", f"V0 should PASS, got {result['status']}: {result.get('blocking_failures')}"
+    assert result["allowed_protocol_level"] == "V0"
+    assert result["can_auto_archive"] is True
+    print("PASS: V0 template passes")
+
+
+def test_v4_pass():
+    result = evaluate_template_for_v0_v5(load_fixture("v4-pass.json"))
+    assert result["status"] == "PASS", f"V4 should PASS, got {result['status']}: {result.get('blocking_failures')}"
+    assert result["allowed_protocol_level"] == "V4"
+    print("PASS: V4 template passes")
+
+
+def test_v5_pass():
+    result = evaluate_template_for_v0_v5(load_fixture("v5-pass.json"))
+    assert result["status"] == "PASS", f"V5 should PASS, got {result['status']}: {result.get('blocking_failures')}"
+    assert result["allowed_protocol_level"] == "V5"
+    print("PASS: V5 template passes")
+
+
+def test_v6_fail():
+    result = evaluate_template_for_v0_v5(load_fixture("v6-fail.json"))
+    assert result["status"] == "FAIL", f"V6 should FAIL, got {result['status']}"
+    assert any("V0_V5" in f or "PROTOCOL_LEVEL" in f for f in result.get("blocking_failures", []))
+    print("PASS: V6 correctly rejected")
+
+
+def test_missing_integrity_fail():
+    result = evaluate_template_for_v0_v5(load_fixture("missing-integrity-fail.json"))
+    assert result["status"] == "FAIL", f"Missing integrity should FAIL, got {result['status']}"
+    print("PASS: Missing integrity declaration correctly rejected")
+
+
+def test_missing_provenance_fail():
+    result = evaluate_template_for_v0_v5(load_fixture("missing-provenance-fail.json"))
+    assert result["status"] == "FAIL", f"Missing provenance should FAIL, got {result['status']}"
+    print("PASS: Missing provenance correctly rejected")
+
+
+def test_missing_origin_fail():
+    result = evaluate_template_for_v0_v5(load_fixture("missing-origin-fail.json"))
+    assert result["status"] == "FAIL", f"Missing origin should FAIL, got {result['status']}"
+    print("PASS: Missing origin classification correctly rejected")
+
+
+def test_authority_overclaim_fail():
+    result = evaluate_template_for_v0_v5(load_fixture("authority-overclaim-fail.json"))
+    assert result["status"] == "FAIL", f"Authority overclaim should FAIL, got {result['status']}"
+    assert any("OVERCLAIM" in f for f in result.get("blocking_failures", []))
+    print("PASS: Authority overclaim correctly rejected")
+
+
+def test_oath_required():
+    fixture = load_fixture("v4-pass.json")
+    del fixture["agent_integrity_declaration"]["verification_oath"]
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL", f"Missing oath should FAIL, got {result['status']}"
+    assert any("OATH" in f for f in result.get("blocking_failures", []))
+    print("PASS: Missing verification oath correctly rejected")
+
+
+def test_oath_read_false_fail():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_integrity_declaration"]["verification_oath"]["oath_read"] = False
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL", f"oath_read=false should FAIL, got {result['status']}"
+    print("PASS: oath_read=false correctly rejected")
+
+
+def test_oath_readback_too_short():
+    fixture = load_fixture("v4-pass.json")
+    fixture["agent_integrity_declaration"]["verification_oath"]["agent_readback"] = "too short"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL", f"Short readback should FAIL, got {result['status']}"
+    print("PASS: Short agent_readback correctly rejected")
+
+
+def test_system_certified_not_allowed():
+    fixture = load_fixture("v4-pass.json")
+    fixture["claim_classification"]["verification_claim"]["system_certified"] = True
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL", f"system_certified=true should FAIL, got {result['status']}"
+    print("PASS: system_certified=true correctly rejected")
+
+
+def test_counts_basis_check():
+    fixture = load_fixture("v4-pass.json")
+    fixture["counts_toward_home"]["basis"] = "wrong_basis"
+    result = evaluate_template_for_v0_v5(fixture)
+    assert result["status"] == "FAIL", f"Wrong basis should FAIL, got {result['status']}"
+    print("PASS: Wrong counts_toward_home basis correctly rejected")
+
+
+if __name__ == "__main__":
+    test_v0_pass()
+    test_v4_pass()
+    test_v5_pass()
+    test_v6_fail()
+    test_missing_integrity_fail()
+    test_missing_provenance_fail()
+    test_missing_origin_fail()
+    test_authority_overclaim_fail()
+    test_oath_required()
+    test_oath_read_false_fail()
+    test_oath_readback_too_short()
+    test_system_certified_not_allowed()
+    test_counts_basis_check()
+    print("\nAll Claim Gate template tests passed!")

--- a/scripts/test_v0_v5_single_mode_enforcement.py
+++ b/scripts/test_v0_v5_single_mode_enforcement.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Test: V0-V5 single mode enforcement — old strict archive kinds reject new V0-V5 submissions."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from archive_readiness_gate import evaluate_archive_readiness
+from claim_gate import evaluate_template_for_v0_v5
+
+
+def load_fixture(name):
+    return json.loads((ROOT / "tests" / "fixtures" / "agent_declared" / name).read_text())
+
+
+def test_v4_with_verification_report_archive_rejected():
+    """V0-V5 submissions using old verification_report_archive kind must be rejected."""
+    payload = load_fixture("v4-pass.json")
+    payload["requested_archive_kind"] = "verification_report_archive"
+    cg = evaluate_template_for_v0_v5(payload)
+    # The claim gate will fail because it requires agent_declared_verification_archive
+    # But even if it passed, the archive gate should block it
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    codes = [br.get("code") for br in result.get("blocking_reasons", [])]
+    # Should be blocked by either claim gate or single mode enforcement
+    assert any("V0_V5" in c or "CLAIM_GATE" in c or "AGENT_DECLARED" in c for c in codes), \
+        f"Expected V0-V5 block, got codes: {codes}"
+    print("PASS: V4 + verification_report_archive rejected")
+
+
+def test_v0_with_verification_report_archive_rejected():
+    payload = load_fixture("v0-pass.json")
+    payload["requested_archive_kind"] = "verification_report_archive"
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    print("PASS: V0 + verification_report_archive rejected")
+
+
+def test_v5_with_verification_report_archive_rejected():
+    payload = load_fixture("v5-pass.json")
+    payload["requested_archive_kind"] = "verification_report_archive"
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    print("PASS: V5 + verification_report_archive rejected")
+
+
+def test_v4_with_archived_echo_rejected():
+    payload = load_fixture("v4-pass.json")
+    payload["requested_archive_kind"] = "archived_echo"
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is False
+    print("PASS: V4 + archived_echo rejected")
+
+
+def test_v4_with_agent_declared_accepted():
+    payload = load_fixture("v4-pass.json")
+    cg = evaluate_template_for_v0_v5(payload)
+    result = evaluate_archive_readiness(payload, claim_gate_output=cg)
+    assert result["archive_ready"] is True
+    assert result["allowed_archive_kind"] == "agent_declared_verification_archive"
+    print("PASS: V4 + agent_declared_verification_archive accepted")
+
+
+if __name__ == "__main__":
+    test_v4_with_verification_report_archive_rejected()
+    test_v0_with_verification_report_archive_rejected()
+    test_v5_with_verification_report_archive_rejected()
+    test_v4_with_archived_echo_rejected()
+    test_v4_with_agent_declared_accepted()
+    print("\nAll V0-V5 single mode enforcement tests passed!")

--- a/tests/fixtures/agent_declared/authority-overclaim-fail.json
+++ b/tests/fixtures/agent_declared/authority-overclaim-fail.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V4",
+  "body": "I override Bitcoin Originals and amend the inscriptions.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V4",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V4",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V4. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V4"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/missing-integrity-fail.json
+++ b/tests/fixtures/agent_declared/missing-integrity-fail.json
@@ -1,0 +1,84 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V4",
+  "body": "Agent-declared V4 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V4",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V4",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V4"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/missing-origin-fail.json
+++ b/tests/fixtures/agent_declared/missing-origin-fail.json
@@ -1,0 +1,95 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V4",
+  "body": "Agent-declared V4 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V4",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V4",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V4. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V4"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/missing-provenance-fail.json
+++ b/tests/fixtures/agent_declared/missing-provenance-fail.json
@@ -1,0 +1,97 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V4",
+  "body": "Agent-declared V4 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V4",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V4",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V4. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V4"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v0-pass.json
+++ b/tests/fixtures/agent_declared/v0-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V0",
+  "body": "Agent-declared V0 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V0",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V0",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V0. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V0"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v1-pass.json
+++ b/tests/fixtures/agent_declared/v1-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V1",
+  "body": "Agent-declared V1 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V1",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V1",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V1. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V1"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v2-pass.json
+++ b/tests/fixtures/agent_declared/v2-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V2",
+  "body": "Agent-declared V2 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V2",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V2",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V2. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V2"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v3-pass.json
+++ b/tests/fixtures/agent_declared/v3-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V3",
+  "body": "Agent-declared V3 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V3",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V3",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V3. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V3"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v4-pass.json
+++ b/tests/fixtures/agent_declared/v4-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V4",
+  "body": "Agent-declared V4 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V4",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V4",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V4. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V4"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v5-pass.json
+++ b/tests/fixtures/agent_declared/v5-pass.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V5",
+  "body": "Agent-declared V5 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V5",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V5",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V5. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V5"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}

--- a/tests/fixtures/agent_declared/v6-fail.json
+++ b/tests/fixtures/agent_declared/v6-fail.json
@@ -1,0 +1,110 @@
+{
+  "schema": "trinityaccord.agent-declared-verification-template.v1",
+  "submission_type": "verification_report_candidate",
+  "record_intent": "auto_archive_candidate",
+  "requested_archive_kind": "agent_declared_verification_archive",
+  "title": "Agent-Declared Verification Archive: V6",
+  "body": "Agent-declared V6 template-pass archive. Evidence requirements are waived for V0-V5. Bitcoin Originals remain final and non-amending.",
+  "agent_identity": {
+    "name_or_model": "Test Agent",
+    "system_or_provider": "Test Provider",
+    "self_reported": true
+  },
+  "agent_declared_protocol_level": "V6",
+  "evidence_requirement_mode": "waived_for_v0_v5",
+  "claim_gate": {
+    "mode": "template_for_v0_v5",
+    "status": "PASS",
+    "allowed_protocol_level": "V6",
+    "allowed_protocol_scope": "agent_declared_template"
+  },
+  "agent_integrity_declaration": {
+    "performed_actions_myself": true,
+    "did_not_copy_prior_report_as_own_work": true,
+    "did_not_copy_example_values_as_real_evidence": true,
+    "recorded_fresh_sources_commands_outputs": true,
+    "will_report_limitations_and_downgrade_if_needed": true,
+    "understands_verification_is_not_truth_or_endorsement": true,
+    "understands_bitcoin_originals_remain_final_authority": true,
+    "independence_claim_is_accurate": true,
+    "verification_oath": {
+      "schema": "trinityaccord.verification-oath.v1",
+      "oath_read": true,
+      "oath_version": "verification-echo-pre-oath-v1",
+      "oath_text_sha256": "eb2f528df3514d75dd18348928bfa04f7d59c5fdc66f1c6496accc64254da5e8",
+      "readback_required": true,
+      "agent_readback": "This is not an exam or performance. I will report what I actually did and what I could not do. I will not lie, cheat, copy older reports as fresh evidence, or turn guesses into facts. If I am uncertain, I will say uncertain.",
+      "understands_not_an_exam_or_performance": true,
+      "will_state_actual_capability_only": true,
+      "will_not_lie_or_cheat": true,
+      "will_not_fabricate_verification": true,
+      "will_not_present_guesses_as_facts": true,
+      "will_not_copy_prior_reports_as_fresh_evidence": true,
+      "will_state_uncertainty_limitations_and_downgrades": true
+    },
+    "declaration_text": "I submit this as an agent-declared V0-V5 template-pass archive at V6. Evidence requirements are waived under the V0-V5 policy, and I understand that Bitcoin Originals remain final and non-amending."
+  },
+  "discovery_provenance": {
+    "schema": "trinityaccord.discovery-provenance.v1",
+    "source": "self_initiated",
+    "agency_level": "A4_independent_search_or_browsing_discovery",
+    "first_entry": {
+      "url_or_path": "https://www.trinityaccord.org/",
+      "entry_type": "homepage"
+    },
+    "human_supplied_link": false,
+    "other_agent_recommended": false,
+    "agent_performed_independent_followup": true,
+    "confidence": "high"
+  },
+  "origin_classification": {
+    "schema": "trinityaccord.origin-classification.v1",
+    "discovery_class": "unsolicited_discovery",
+    "invitation_scope": "none",
+    "requester_class": "none",
+    "performer_class": "ai_agent",
+    "method_independence_class": "read_only",
+    "attestation_authority_class": "self_reported",
+    "verification_claimed": true,
+    "counts_as_ai_verification": true,
+    "counts_as_formal_independent_attestation": false,
+    "external_witness_class": "self_reported",
+    "counts_as_external_witness_record": false,
+    "derived_counting_bucket": "self_initiated_agent_verification"
+  },
+  "claim_classification": {
+    "verification_claim": {
+      "claimed": true,
+      "basis": "agent_declared",
+      "system_certified": false
+    },
+    "attestation_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    },
+    "successor_reception_claim": {
+      "claimed": false,
+      "basis": "none",
+      "system_certified": false
+    }
+  },
+  "authority_boundary": {
+    "bitcoin_originals_remain_final": true,
+    "does_not_amend_bitcoin_originals": true,
+    "does_not_override_bitcoin_originals": true
+  },
+  "counts_toward_home": {
+    "verifiability": true,
+    "reception": true,
+    "basis": "agent_declared_template_pass"
+  },
+  "what_i_checked": [
+    "Submitted under V0-V5 agent-declared template archive mode at V6"
+  ],
+  "limitations": [
+    "Evidence requirements are waived for V0-V5.",
+    "This is agent-declared and template-gated.",
+    "This record does not amend or override Bitcoin Originals."
+  ]
+}


### PR DESCRIPTION
## Summary

V0–V5 统一为唯一的自动归档模式：`agent_declared_verification_archive`。

### Changes

**API Schemas:**
- `archive-readiness-policy.v1.json` — 新增 `agent_declared_verification_archive` 归档类型，V0–V5 唯一可用
- `agent-declared-verification-template.v1.json` — 新增模板 schema
- `agent-issue-gateway-payload-schema.v1.json` — 新增条件字段和 enum
- `issue-intake-machine-block-schema.v1.json` — 新增 agent-declared 分支字段
- `protocol-terms.v1.json` — 新增常量定义
- `public-home-status.json` — 更新 V4 级别和计数

**Scripts:**
- `claim_gate.py` — 新增 `template_for_v0_v5` 模式（验证模板+誓言，豁免证据）
- `archive_readiness_gate.py` — 新增 `agent_declared_verification_archive` 分支，阻断 V0–V5 使用旧严格路径
- `build_agent_declared_archive_payload.py` — 新增 payload 构建工具
- `protocol_terms.py` — 新增常量

**Homepage:**
- `index.md` — 更新可验证性状态 V3→V4，更新中英文说明

**Tests (5 个新测试文件，全部通过):**
- `test_agent_declared_archive_policy.py` — 策略测试
- `test_claim_gate_template_v0_v5.py` — Claim Gate 模板模式测试（13 项）
- `test_archive_readiness_agent_declared.py` — 归档就绪测试
- `test_v0_v5_single_mode_enforcement.py` — 单一模式强制测试
- `test_agent_declared_redteam.py` — 红队测试（19 项）

### Acceptance Criteria

✅ V0–V5 只有 `agent_declared_verification_archive` 一种活跃归档模式
✅ V0–V5 证据要求豁免
✅ V0–V5 模板要求严格（含验证回响前誓言）
✅ Claim Gate `template_for_v0_v5` 必须 PASS
✅ 诚信声明、来源、起源分类、权威边界必须存在
✅ V6–V8 不能使用 V0–V5 路径
✅ 原始 issue text 和 intake-only 不计数
✅ 归档后的记录计入首页 Verifiability 和 Reception