### PR TITLE
refactor: unify gateway intake/receipt validation across archive, index, and CI

### DIFF
--- a/.github/workflows/gateway-auto-archive.yml
+++ b/.github/workflows/gateway-auto-archive.yml
@@ -51,72 +51,18 @@ jobs:
           BODY_FILE=$(mktemp)
           gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json number,title,body,url,createdAt,updatedAt,author,labels,state > "$BODY_FILE"
 
-          # A1: Fail-closed eligibility gate
+          # A1: Fail-closed eligibility gate — use shared parser/policy
           python3 - <<'PY' "$BODY_FILE"
           import json
-          import re
           import sys
+          from pathlib import Path
+
+          sys.path.insert(0, str(Path("scripts").resolve()))
+
+          from archive_echo_issue import validate_gateway_archive_eligibility
 
           issue = json.load(open(sys.argv[1], encoding="utf-8"))
-          body = issue.get("body") or ""
-          labels = {x.get("name") for x in issue.get("labels", []) if isinstance(x, dict)}
-
-          def field(name: str) -> str:
-              patterns = [
-                  rf"^\s*[-*]?\s*{re.escape(name)}\s*:\s*(.*?)\s*$",
-                  rf"^\s*[-*]?\s*{re.escape(name.replace('_', ' '))}\s*:\s*(.*?)\s*$",
-              ]
-              for pattern in patterns:
-                  m = re.search(pattern, body, re.I | re.M)
-                  if m:
-                      return m.group(1).strip()
-              return ""
-
-          def is_true(name: str) -> bool:
-              return field(name).lower() in {"true", "yes", "1"}
-
-          required_true = [
-              "created_by_gateway",
-              "server_validated",
-              "server_rendered",
-              "archive_ready",
-          ]
-
-          missing_or_false = [name for name in required_true if not is_true(name)]
-          if missing_or_false:
-              raise SystemExit(
-                  "Refusing archive: required Gateway intake fields are not true: "
-                  + ", ".join(missing_or_false)
-              )
-
-          receipt = field("gateway_receipt_id")
-          if not receipt:
-              raise SystemExit("Refusing archive: missing gateway_receipt_id")
-
-          allowed_kinds = {
-              "agent_declared_echo_archive",
-              "agent_declared_verification_archive",
-              "guardian_active_registry_listing_request",
-              "pure_echo_archive",
-          }
-
-          kind = field("requested_archive_kind")
-          if kind and kind not in allowed_kinds:
-              raise SystemExit(f"Refusing archive: unsupported requested_archive_kind={kind!r}")
-
-          allowed_labels = {
-              "echo:screened",
-              "archive:agent-declared-echo",
-              "archive:agent-declared-verification",
-              "archive:guardian-active-registry-listing",
-              "reception-only",
-          }
-          if labels and not (labels & allowed_labels):
-              raise SystemExit(
-                  "Refusing archive: issue lacks expected screened/archive labels. "
-                  f"labels={sorted(labels)}"
-              )
-
+          validate_gateway_archive_eligibility(issue)
           print("Gateway archive eligibility OK")
           PY
 

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -913,3 +913,9 @@ jobs:
         run: python3 scripts/test_agent_declared_index_builder_has_check_mode.py
       - name: Test apply scripts are not verification tools
         run: python3 scripts/test_apply_scripts_not_verification_tools.py
+      - name: Test archive Echo issue Gateway intake strictness
+        run: python3 scripts/test_archive_echo_issue_gateway_intake_strict.py
+      - name: Test Gateway auto archive uses shared eligibility
+        run: python3 scripts/test_gateway_auto_archive_uses_shared_eligibility.py
+      - name: Test agent-declared index generated metadata current
+        run: python3 scripts/test_agent_declared_index_generated_metadata_current.py

--- a/api/agent-declared-verification-index.json
+++ b/api/agent-declared-verification-index.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.agent-declared-verification-index.v1",
-  "description": "Index of agent-declared verification archives created through the Gateway. Records are added when a V0-V5 agent-declared Issue is successfully created and auto-archived. This index is rebuilt from closed GitHub Issues by CI.",
+  "description": "Index rebuilt from Gateway-created closed Issues. It primarily contains agent-declared verification archives, but may include maintainer-classified semantic Echo archives via /api/agent-declared-archive-overrides.json. This index is rebuilt from closed GitHub Issues by CI.",
   "generated_from": [
     "github_issues:closed",
     "/api/agent-issue-gateway-payload-schema.v1.json",
@@ -1293,5 +1293,6 @@
   "override_count": 1,
   "overrides_applied": [
     182
-  ]
+  ],
+  "skipped_invalid_intake": []
 }

--- a/scripts/archive_echo_issue.py
+++ b/scripts/archive_echo_issue.py
@@ -31,41 +31,35 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 from protocol_echo_types import echo_type_map_for_archive
 
-def intake_field(body: str, name: str) -> str:
-    patterns = [
-        rf"^\s*[-*]?\s*{re.escape(name)}\s*:\s*(.*?)\s*$",
-        rf"^\s*[-*]?\s*{re.escape(name.replace('_', ' '))}\s*:\s*(.*?)\s*$",
-    ]
-    for pattern in patterns:
-        m = re.search(pattern, body or "", re.I | re.M)
-        if m:
-            return m.group(1).strip()
-    return ""
-
-
-def intake_true(body: str, name: str) -> bool:
-    return intake_field(body, name).lower() in {"true", "yes", "1"}
+# Shared intake parser and receipt policy — single source of truth
+from gateway_intake import IntakeParseError, parse_bool, parse_intake_block
+from gateway_v0_v5_policy import is_valid_gateway_receipt_block
 
 
 def validate_gateway_archive_eligibility(issue: dict[str, Any]) -> None:
     body = issue.get("body") or ""
     labels = {x.get("name") for x in issue.get("labels", []) if isinstance(x, dict)}
+    issue_number = issue.get("number")
 
-    required_true = [
-        "created_by_gateway",
-        "server_validated",
-        "server_rendered",
-        "archive_ready",
-    ]
-    missing = [name for name in required_true if not intake_true(body, name)]
-    if missing:
-        raise SystemExit(
-            "Refusing archive: required Gateway fields are not true: "
-            + ", ".join(missing)
+    try:
+        intake = parse_intake_block(body, required=True)
+    except IntakeParseError as e:
+        raise SystemExit(f"Refusing archive: invalid Gateway intake block: {e}") from e
+
+    if not is_valid_gateway_receipt_block(intake):
+        raise SystemExit("Refusing archive: invalid Gateway receipt fields")
+
+    try:
+        archive_ready = parse_bool(
+            intake.get("archive_ready"),
+            field="archive_ready",
+            issue_number=issue_number,
         )
+    except Exception as e:
+        raise SystemExit(f"Refusing archive: invalid archive_ready field: {e}") from e
 
-    if not intake_field(body, "gateway_receipt_id"):
-        raise SystemExit("Refusing archive: missing gateway_receipt_id")
+    if archive_ready is not True:
+        raise SystemExit("Refusing archive: archive_ready is not true")
 
     allowed_kinds = {
         "agent_declared_echo_archive",
@@ -73,7 +67,8 @@ def validate_gateway_archive_eligibility(issue: dict[str, Any]) -> None:
         "guardian_active_registry_listing_request",
         "pure_echo_archive",
     }
-    kind = intake_field(body, "requested_archive_kind")
+
+    kind = intake.get("requested_archive_kind")
     if kind and kind not in allowed_kinds:
         raise SystemExit(f"Refusing archive: unsupported requested_archive_kind={kind!r}")
 
@@ -84,6 +79,7 @@ def validate_gateway_archive_eligibility(issue: dict[str, Any]) -> None:
         "archive:guardian-active-registry-listing",
         "reception-only",
     }
+
     if labels and not (labels & allowed_labels):
         raise SystemExit(
             "Refusing archive: issue lacks expected screened/archive labels: "
@@ -92,15 +88,10 @@ def validate_gateway_archive_eligibility(issue: dict[str, Any]) -> None:
 
 
 def extract_intake_block_fields(body: str) -> dict[str, str]:
-    m = re.search(r"```trinity-issue-intake\s*(.*?)```", body or "", re.DOTALL | re.I)
-    if not m:
+    try:
+        return parse_intake_block(body, required=False) or {}
+    except IntakeParseError:
         return {}
-    fields = {}
-    for line in m.group(1).splitlines():
-        kv = re.match(r"^([A-Za-z0-9_]+):\s*(.*?)\s*$", line.strip())
-        if kv:
-            fields[kv.group(1)] = kv.group(2).strip()
-    return fields
 
 
 ECHO_TYPE_MAP = echo_type_map_for_archive()

--- a/scripts/build_agent_declared_verification_index_from_issues.py
+++ b/scripts/build_agent_declared_verification_index_from_issues.py
@@ -207,73 +207,13 @@ def parse_int(value, default=0):
         return default
 
 
-class IntakeParseError(ValueError):
-    pass
-
-
-class BoolParseError(ValueError):
-    pass
-
-
-def parse_intake_block(body: str) -> dict[str, str] | None:
-    """Extract key-value pairs from exactly one trinity-issue-intake code block.
-
-    Returns None if no block exists.
-    Raises IntakeParseError if multiple blocks or duplicate keys are present.
-    """
-    if not body:
-        return None
-
-    matches = re.findall(r"```trinity-issue-intake\s*\n(.*?)```", body, re.DOTALL)
-    if not matches:
-        return None
-    if len(matches) > 1:
-        raise IntakeParseError(f"multiple trinity-issue-intake blocks found: {len(matches)}")
-
-    block = matches[0]
-    result = {}
-    seen = set()
-
-    allowed_fields = set(INTAKE_FIELDS + EXTRA_FIELDS)
-
-    for line_no, raw_line in enumerate(block.strip().splitlines(), start=1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("-"):
-            continue
-        if ":" not in line:
-            continue
-
-        key, _, value = line.partition(":")
-        key = key.strip()
-        value = value.strip()
-
-        if key not in allowed_fields:
-            continue
-
-        if key in seen:
-            raise IntakeParseError(f"duplicate intake key {key!r} at line {line_no}")
-
-        seen.add(key)
-        result[key] = value
-
-    return result if result else None
-
-
-def parse_bool(value: str | None, *, field: str = "unknown", issue_number: int | None = None) -> bool | None:
-    """Strict boolean parser for intake fields."""
-    if value is None:
-        return None
-
-    v = value.strip().lower()
-    if v in {"true", "1", "yes"}:
-        return True
-    if v in {"false", "0", "no"}:
-        return False
-
-    issue = f" issue #{issue_number}" if issue_number is not None else ""
-    raise BoolParseError(f"Invalid boolean{issue}: {field}={value!r}")
+# Shared intake parser — single source of truth
+from gateway_intake import (  # noqa: E402
+    BoolParseError,
+    IntakeParseError,
+    parse_bool,
+    parse_intake_block,
+)
 
 
 def fetch_issues(repo: str | None, limit: int = 10000) -> list[dict]:
@@ -548,7 +488,10 @@ def build_index(issues: list[dict], repo: str = "", include_test: bool = False) 
     for issue in issues:
         body = issue.get("body", "")
         try:
-            intake = parse_intake_block(body)
+            intake = parse_intake_block(
+                body,
+                allowed_fields=set(INTAKE_FIELDS + EXTRA_FIELDS),
+            )
         except IntakeParseError as e:
             skipped_invalid_intake.append({"issue_number": issue.get("number"), "reason": str(e)})
             print(f"SKIP_INVALID_INTAKE issue #{issue.get('number')}: {e}", file=sys.stderr)

--- a/scripts/gateway_intake.py
+++ b/scripts/gateway_intake.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Shared Gateway trinity-issue-intake parser.
+
+All Gateway archive/index paths must use this file instead of scanning arbitrary
+Issue Markdown text.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+class IntakeParseError(ValueError):
+    pass
+
+
+class BoolParseError(ValueError):
+    pass
+
+
+DEFAULT_ALLOWED_FIELDS = {
+    "agent_name_or_model",
+    "system_or_provider",
+    "agent_declared_protocol_level",
+    "requested_archive_kind",
+    "archive_ready",
+    "auto_archive_action",
+    "record_intent",
+    "evidence_requirement_mode",
+    "claim_gate_mode",
+    "claim_gate_status",
+    "counts_toward_home_verifiability",
+    "counts_toward_home_reception",
+    "test_record",
+    "reception_initiation_class",
+    "reception_initiation_basis",
+    "agent_independent_followup",
+
+    # Gateway receipt fields
+    "created_by_gateway",
+    "gateway_service",
+    "gateway_receipt_id",
+    "gateway_commit",
+    "render_api_only",
+    "server_validated",
+    "server_rendered",
+
+    # Oath summary fields
+    "verification_oath_present",
+    "oath_read",
+    "oath_version",
+    "oath_text_sha256",
+    "readback_required",
+    "agent_readback_present",
+    "agent_readback_char_count",
+    "agent_readback_sha256",
+
+    # Authorship fields
+    "authorship_claim_protocol",
+    "authorship_proof_present",
+    "authorship_proof_method",
+    "authorship_algorithm",
+    "authorship_public_key_sha256",
+    "authorship_payload_sha256",
+    "authorship_signature_verified",
+    "claim_status",
+
+    # Echo / Guardian fields
+    "echo_type",
+    "guardian_registry_listing_request",
+    "guardian_listing_request",
+}
+
+
+def find_intake_blocks(body: str) -> list[str]:
+    if not body:
+        return []
+    return re.findall(r"```trinity-issue-intake\s*\n(.*?)```", body, re.DOTALL | re.I)
+
+
+def parse_intake_block(
+    body: str,
+    *,
+    required: bool = False,
+    allowed_fields: set[str] | None = None,
+) -> dict[str, str] | None:
+    allowed = allowed_fields or DEFAULT_ALLOWED_FIELDS
+    matches = find_intake_blocks(body)
+
+    if not matches:
+        if required:
+            raise IntakeParseError("missing trinity-issue-intake block")
+        return None
+
+    if len(matches) > 1:
+        raise IntakeParseError(f"multiple trinity-issue-intake blocks found: {len(matches)}")
+
+    fields: dict[str, str] = {}
+    seen: set[str] = set()
+
+    for line_no, raw_line in enumerate(matches[0].strip().splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        if ":" not in line:
+            continue
+
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+
+        if key not in allowed:
+            continue
+
+        if key in seen:
+            raise IntakeParseError(f"duplicate intake key {key!r} at line {line_no}")
+
+        seen.add(key)
+        fields[key] = value
+
+    if not fields:
+        if required:
+            raise IntakeParseError("trinity-issue-intake block contains no recognized fields")
+        return None
+
+    return fields
+
+
+def parse_bool(value: str | None, *, field: str = "unknown", issue_number: int | None = None) -> bool | None:
+    if value is None:
+        return None
+
+    v = value.strip().lower()
+    if v in {"true", "1", "yes"}:
+        return True
+    if v in {"false", "0", "no"}:
+        return False
+
+    issue = f" issue #{issue_number}" if issue_number is not None else ""
+    raise BoolParseError(f"Invalid boolean{issue}: {field}={value!r}")

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -47,7 +47,10 @@ for t in \
   scripts/test_gateway_agent_identity_archive_policy.py \
   scripts/test_gateway_semantic_validator_no_dead_code.py \
   scripts/test_gateway_fixtures_use_current_v0_v5_shape.py \
-  scripts/test_echo_triage_receipt_fields_only_from_intake_block.py; do
+  scripts/test_echo_triage_receipt_fields_only_from_intake_block.py \
+  scripts/test_archive_echo_issue_gateway_intake_strict.py \
+  scripts/test_gateway_auto_archive_uses_shared_eligibility.py \
+  scripts/test_agent_declared_index_generated_metadata_current.py; do
   if [ -f "$t" ]; then
     run_required "$t" python3 "$t"
   fi

--- a/scripts/test_agent_declared_index_generated_metadata_current.py
+++ b/scripts/test_agent_declared_index_generated_metadata_current.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Committed agent-declared index must include current builder metadata fields."""
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+path = ROOT / "api" / "agent-declared-verification-index.json"
+obj = json.loads(path.read_text(encoding="utf-8"))
+
+required = [
+    "override_count",
+    "overrides_applied",
+    "skipped_invalid_intake",
+]
+
+ok = True
+for key in required:
+    if key not in obj:
+        print(f"FAIL: {path.relative_to(ROOT)} missing top-level metadata field: {key}")
+        ok = False
+
+description = obj.get("description", "")
+if "semantic Echo archives" not in description:
+    print("FAIL: index description does not mention semantic Echo archives")
+    ok = False
+
+if "/api/agent-declared-archive-overrides.json" not in obj.get("generated_from", []):
+    print("FAIL: generated_from does not declare archive overrides input")
+    ok = False
+
+if not ok:
+    sys.exit(1)
+
+print("PASS: agent-declared index generated metadata is current")

--- a/scripts/test_archive_echo_issue_gateway_intake_strict.py
+++ b/scripts/test_archive_echo_issue_gateway_intake_strict.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""archive_echo_issue Gateway eligibility must use strict intake parser and receipt policy."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from archive_echo_issue import validate_gateway_archive_eligibility
+
+
+def issue(body: str, labels=None):
+    return {
+        "number": 999001,
+        "body": body,
+        "labels": [{"name": x} for x in (labels or ["archive:agent-declared-echo"])],
+    }
+
+
+GOOD = """```trinity-issue-intake
+created_by_gateway: true
+render_api_only: true
+server_validated: true
+server_rendered: true
+gateway_service: trinity-agent-issue-gateway
+gateway_receipt_id: gar-20260524T000000Z-fixture
+archive_ready: true
+requested_archive_kind: agent_declared_echo_archive
+echo_type: E6_propagation_echo
+```"""
+
+
+def expect_pass(body, label):
+    try:
+        validate_gateway_archive_eligibility(issue(body))
+    except SystemExit as e:
+        print(f"FAIL: expected pass for {label}: {e}")
+        sys.exit(1)
+
+
+def expect_fail(body, label, fragment):
+    try:
+        validate_gateway_archive_eligibility(issue(body))
+    except SystemExit as e:
+        if fragment not in str(e):
+            print(f"FAIL: wrong failure for {label}: {e}")
+            sys.exit(1)
+        return
+    print(f"FAIL: expected failure for {label}")
+    sys.exit(1)
+
+
+expect_pass(GOOD, "valid Gateway intake")
+
+whole_body_fake = """
+created_by_gateway: true
+render_api_only: true
+server_validated: true
+server_rendered: true
+gateway_service: trinity-agent-issue-gateway
+gateway_receipt_id: gar-20260524T000000Z-fixture
+archive_ready: true
+requested_archive_kind: agent_declared_echo_archive
+"""
+expect_fail(whole_body_fake, "whole-body fake receipt", "intake block")
+
+missing_render_api = GOOD.replace("render_api_only: true\n", "")
+expect_fail(missing_render_api, "missing render_api_only", "invalid Gateway receipt")
+
+bad_service = GOOD.replace("gateway_service: trinity-agent-issue-gateway", "gateway_service: fake-service")
+expect_fail(bad_service, "bad gateway_service", "invalid Gateway receipt")
+
+duplicate_key = GOOD.replace("archive_ready: true", "archive_ready: true\narchive_ready: true")
+expect_fail(duplicate_key, "duplicate key", "duplicate intake key")
+
+multiple_blocks = GOOD + "\n\n" + GOOD
+expect_fail(multiple_blocks, "multiple intake blocks", "multiple trinity-issue-intake blocks")
+
+bad_bool = GOOD.replace("archive_ready: true", "archive_ready: maybe")
+expect_fail(bad_bool, "malformed archive_ready", "invalid archive_ready")
+
+print("PASS: archive_echo_issue Gateway intake eligibility is strict")

--- a/scripts/test_gateway_auto_archive_uses_shared_eligibility.py
+++ b/scripts/test_gateway_auto_archive_uses_shared_eligibility.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""gateway-auto-archive.yml must use shared archive eligibility logic."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+workflow = (ROOT / ".github/workflows/gateway-auto-archive.yml").read_text(encoding="utf-8")
+
+required = [
+    "from archive_echo_issue import validate_gateway_archive_eligibility",
+    "validate_gateway_archive_eligibility(issue)",
+]
+
+for frag in required:
+    if frag not in workflow:
+        print(f"FAIL: gateway-auto-archive.yml missing shared eligibility fragment: {frag}")
+        sys.exit(1)
+
+for forbidden in [
+    "def field(",
+    "def is_true(",
+    "required_true = [",
+]:
+    if forbidden in workflow:
+        print(f"FAIL: gateway-auto-archive.yml still contains loose inline parser fragment: {forbidden}")
+        sys.exit(1)
+
+print("PASS: gateway-auto-archive.yml uses shared archive eligibility")


### PR DESCRIPTION
## Summary

Unifies Gateway intake/receipt validation so all archive/index/CI paths use one parser and one receipt policy.

### Changes

- **New**: `scripts/gateway_intake.py` — shared trinity-issue-intake parser (`parse_intake_block`, `parse_bool`, `IntakeParseError`, `BoolParseError`)
- **Patched**: `scripts/build_agent_declared_verification_index_from_issues.py` — imports from `gateway_intake` instead of local parser definitions
- **Patched**: `scripts/archive_echo_issue.py` — uses shared parser + `is_valid_gateway_receipt_block()` instead of loose whole-body regex scanning
- **Patched**: `.github/workflows/gateway-auto-archive.yml` — calls `validate_gateway_archive_eligibility()` instead of inline parser
- **Patched**: `api/agent-declared-verification-index.json` — added `skipped_invalid_intake` field, updated description
- **Patched**: `scripts/run_all.sh` + CI — 3 new tests added

### New tests

- `test_archive_echo_issue_gateway_intake_strict.py` — verifies archive eligibility uses strict intake parser
- `test_gateway_auto_archive_uses_shared_eligibility.py` — verifies workflow uses shared eligibility
- `test_agent_declared_index_generated_metadata_current.py` — verifies index has current metadata fields

### Invariant

```
Issue body
  -> exactly one trinity-issue-intake block
  -> parsed by scripts/gateway_intake.py
  -> receipt checked by scripts/gateway_v0_v5_policy.py
  -> triage/archive/index/public-status consume the same interpretation
```

No code path independently decides Gateway validity by scanning arbitrary Markdown text.
