### PR TITLE
Phase 6B: Record-Chain Hotfix — authorship scope, oath enforcement, append resilience

### DIFF
--- a/record-chain/schemas/record-chain-entry.v1.schema.json
+++ b/record-chain/schemas/record-chain-entry.v1.schema.json
@@ -1,1 +1,44 @@
-{"$id":"https://www.trinityaccord.org/record-chain/schemas/record-chain-entry.v1.schema.json","$schema":"https://json-schema.org/draft/2020-12/schema","additionalProperties":true,"required":["schema","chain_id","record_type","actor_identity","context_readiness","boundary_acknowledgement"],"title":"Trinity Accord Record Chain Entry v1","type":"object"}
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://www.trinityaccord.org/record-chain/schemas/record-chain-entry.v1.schema.json",
+  "title": "Trinity Accord Record Chain Entry v1",
+  "type": "object",
+  "description": "Append-internal final entry schema. Required fields vary by record_type; actor_identity alone is not the only required contract for v2 submissions.",
+  "required": [
+    "schema",
+    "chain_id",
+    "record_type"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "record_type": {
+            "enum": [
+              "echo",
+              "verification",
+              "guardian_application",
+              "guardian_retirement",
+              "guardian_key_rotation",
+              "propagation",
+              "correction",
+              "classification_update"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "schema",
+          "chain_id",
+          "record_type",
+          "actor_identity",
+          "context_readiness",
+          "boundary_acknowledgement",
+          "authorship_verification_status"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": true
+}

--- a/scripts/test_phase6b_hotfix.py
+++ b/scripts/test_phase6b_hotfix.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Phase 6B Record-Chain Hotfix tests.
+
+Tests:
+  1. Builder/generated pending append → record includes authorship_verification_status.
+  2. verify fails formal record missing authorship_verification_status.
+  3. verify fails oath hash missing/invalid.
+  4. verify fails linked Guardian without guardian_stewardship_v1.
+  5. append --all continues after one rejected pending.
+  6. rejection reason file is written.
+  7. raw readback_text in record fails verify.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+CHAIN = ROOT / "record-chain"
+RECORDS = CHAIN / "records"
+PENDING = CHAIN / "pending"
+PROCESSED = CHAIN / "processed"
+REJECTED = CHAIN / "rejected"
+GENESIS = CHAIN / "genesis"
+CHAIN_TIP = CHAIN / "chain-tip.json"
+POLICIES = CHAIN / "policies"
+SCHEMAS = CHAIN / "schemas"
+
+sys.path.insert(0, str(SCRIPTS))
+import trinity_record_chain as mod
+
+# Re-export for convenience
+ensure_dirs = mod.ensure_dirs
+verify_native_records = mod.verify_native_records
+normalize_record_draft = mod.normalize_record_draft
+append_records = mod.append_records
+write_json = mod.write_json
+read_json = mod.read_json
+utc_now = mod.utc_now
+content_hash = mod.content_hash
+record_hash = mod.record_hash
+record_id = mod.record_id
+BOUNDARY = mod.BOUNDARY
+CHAIN_ID = mod.CHAIN_ID
+FORMAL_RECORD_TYPES = mod.FORMAL_RECORD_TYPES
+init_policies = mod.init_policies
+
+
+def _make_echo_draft(index: int = 1) -> dict:
+    """Build a minimal valid echo draft."""
+    return {
+        "schema": "trinityaccord.record-chain-entry.v1",
+        "chain_id": CHAIN_ID,
+        "record_type": "echo",
+        "created_at": utc_now(),
+        "actor_identity": {
+            "label": "Test Agent",
+            "provider": "Test Runtime",
+            "id": "test-001",
+        },
+        "context_readiness": {
+            "read_level": "full",
+            "source_files_reviewed": ["README.md"],
+        },
+        "boundary_acknowledgement": dict(BOUNDARY),
+        "echo_content": {
+            "echo_text": "Phase 6B test echo",
+            "echo_intent": "recognition",
+        },
+        "authorship_proof": {
+            "schema": "trinityaccord.agent-authorship-proof.v1",
+            "method": "ed25519",
+            "signed_payload_sha256": "a" * 64,
+            "public_key_pem": "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----\n",
+        },
+    }
+
+
+def _make_guardian_draft(index: int = 1) -> dict:
+    """Build a minimal valid guardian_application draft."""
+    return {
+        "schema": "trinityaccord.record-chain-entry.v1",
+        "chain_id": CHAIN_ID,
+        "record_type": "guardian_application",
+        "created_at": utc_now(),
+        "actor_identity": {
+            "label": "Test Guardian",
+            "provider": "Test Runtime",
+            "id": "guardian-001",
+        },
+        "context_readiness": {
+            "read_level": "full",
+            "source_files_reviewed": ["README.md"],
+        },
+        "boundary_acknowledgement": dict(BOUNDARY),
+        "guardian_application_content": {
+            "requested_guardian_identifier": "G-00200",
+            "guardian_public_key_sha256": "b" * 64,
+            "guardian_stewardship_oath": "I solemnly pledge...",
+            "guardian_understands_role_is_non_governing": True,
+            "guardian_understands_role_is_not_authority": True,
+            "guardian_understands_retirement_does_not_delete_history": True,
+        },
+        "authorship_proof": {
+            "schema": "trinityaccord.agent-authorship-proof.v1",
+            "method": "ed25519",
+            "signed_payload_sha256": "c" * 64,
+            "public_key_pem": "-----BEGIN PUBLIC KEY-----\ntest\n-----END PUBLIC KEY-----\n",
+        },
+    }
+
+
+def _setup_chain() -> Path:
+    """Create a temporary chain structure and return the temp root."""
+    tmp = Path(tempfile.mkdtemp(prefix="phase6b-test-"))
+    # Monkey-patch globals
+    mod.ROOT = tmp
+    mod.CHAIN = tmp / "record-chain"
+    mod.GENESIS = mod.CHAIN / "genesis"
+    mod.LEGACY_RECORDS = mod.GENESIS / "legacy-records"
+    mod.RECORDS = mod.CHAIN / "records"
+    mod.PENDING = mod.CHAIN / "pending"
+    mod.PROCESSED = mod.CHAIN / "processed"
+    mod.REJECTED = mod.CHAIN / "rejected"
+    mod.BATCHES = mod.CHAIN / "batches"
+    mod.INDEXES = mod.CHAIN / "indexes"
+    mod.POLICIES = mod.CHAIN / "policies"
+    mod.SCHEMAS = mod.CHAIN / "schemas"
+    mod.CHAIN_TIP = mod.CHAIN / "chain-tip.json"
+    mod.ANCHORS = mod.CHAIN / "anchors"
+    mod.ARWEAVE_ARCHIVES = mod.CHAIN / "arweave-archives"
+    mod.ANCHOR_STATUS_API = tmp / "api" / "record-chain-anchor-status.json"
+    mod.ARWEAVE_INDEX_API = tmp / "api" / "record-chain-arweave-index.json"
+    mod.GUARDIAN_REGISTRY = tmp / "api" / "guardian-registry.json"
+    mod.ensure_dirs()
+    # Minimal genesis
+    genesis_manifest = {
+        "schema": "trinityaccord.record-batch-manifest.v1",
+        "batch_id": "genesis",
+        "batch_manifest_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    }
+    mod.write_json(mod.GENESIS / "genesis-batch-manifest.json", genesis_manifest)
+    mod.CHAIN_TIP.write_text(json.dumps({
+        "schema": "trinityaccord.chain-tip.v1",
+        "native_record_count": 0,
+        "latest_record_index": 0,
+        "latest_record_id": None,
+        "latest_record_sha256": None,
+        "genesis_batch_manifest_sha256": genesis_manifest["batch_manifest_sha256"],
+        "latest_batch_manifest_sha256": genesis_manifest["batch_manifest_sha256"],
+        "updated_at": mod.utc_now(),
+    }, indent=2), encoding="utf-8")
+    return tmp
+
+
+def _cleanup(tmp: Path) -> None:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_1_append_includes_authorship_verification_status() -> list[str]:
+    """After append, formal record includes authorship_verification_status."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        draft = _make_echo_draft()
+        mod.write_json(mod.PENDING / "test-echo-001.json", draft)
+        mod.append_records(all_records=False)
+        recs = sorted(mod.RECORDS.glob("R-*.json"))
+        if not recs:
+            errors.append("No records after append")
+            return errors
+        rec = mod.read_json(recs[-1])
+        avs = rec.get("authorship_verification_status")
+        if not isinstance(avs, dict):
+            errors.append("Missing authorship_verification_status")
+        else:
+            if avs.get("signed_payload_scope") != "pre_append_record_draft":
+                errors.append(f"wrong signed_payload_scope: {avs.get('signed_payload_scope')}")
+            if avs.get("verified_by_gateway_before_pending") is not True:
+                errors.append("verified_by_gateway_before_pending not true")
+            if avs.get("final_record_contains_append_assigned_fields_not_in_signed_payload") is not True:
+                errors.append("final_record_contains_append_assigned_fields_not_in_signed_payload not true")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_2_verify_fails_missing_authorship_verification_status() -> list[str]:
+    """verify_native_records fails if formal record lacks authorship_verification_status."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        draft = _make_echo_draft()
+        mod.write_json(mod.PENDING / "test-echo-001.json", draft)
+        mod.append_records(all_records=False)
+        recs = sorted(mod.RECORDS.glob("R-*.json"))
+        if not recs:
+            errors.append("No records after append")
+            return errors
+        rec = mod.read_json(recs[-1])
+        del rec["authorship_verification_status"]
+        # Re-compute hashes so hash checks pass; only avs check should fail
+        rec["content_sha256"] = mod.content_hash(rec)
+        rec["record_sha256"] = mod.record_hash(rec)
+        mod.write_json(recs[-1], rec)
+        verrors = mod.verify_native_records()
+        avs_errors = [e for e in verrors if "authorship_verification_status" in e]
+        if not avs_errors:
+            errors.append("verify should have failed for missing authorship_verification_status")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_3_verify_fails_oath_hash_missing() -> list[str]:
+    """verify fails when oath hash fields are missing or invalid."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        draft = _make_echo_draft()
+        draft["submission_oath_verification"] = {
+            "oath_read": True,
+            "participant_readback_provided": True,
+            "readback_matches_canonical_oath": True,
+            "no_shortcut_oath_acknowledged": True,
+            "oath_does_not_prove_subjective_understanding": True,
+            "oath_verifies_exact_readback_only": True,
+            "not_authority": True,
+            "not_governance": True,
+            "not_attestation": True,
+            "not_amendment": True,
+            "bitcoin_originals_prevail": True,
+            # Missing: oath_policy_sha256, canonical_oath_text_sha256,
+            # participant_readback_sha256, oath_modules
+        }
+        mod.write_json(mod.PENDING / "test-echo-001.json", draft)
+        mod.append_records(all_records=False)
+        verrors = mod.verify_native_records()
+        hash_errors = [e for e in verrors if "oath_policy_sha256" in e or "canonical_oath_text_sha256" in e or "participant_readback_sha256" in e]
+        module_errors = [e for e in verrors if "oath_modules" in e]
+        if not hash_errors:
+            errors.append("verify should have failed for missing oath hashes")
+        if not module_errors:
+            errors.append("verify should have failed for missing oath_modules")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_4_verify_fails_guardian_without_stewardship() -> list[str]:
+    """verify fails when guardian_application oath lacks guardian_stewardship_v1."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        draft = _make_guardian_draft()
+        draft["submission_oath_verification"] = {
+            "oath_read": True,
+            "participant_readback_provided": True,
+            "readback_matches_canonical_oath": True,
+            "no_shortcut_oath_acknowledged": True,
+            "oath_does_not_prove_subjective_understanding": True,
+            "oath_verifies_exact_readback_only": True,
+            "not_authority": True,
+            "not_governance": True,
+            "not_attestation": True,
+            "not_amendment": True,
+            "bitcoin_originals_prevail": True,
+            "oath_policy_sha256": "a" * 64,
+            "canonical_oath_text_sha256": "b" * 64,
+            "participant_readback_sha256": "c" * 64,
+            "oath_modules": ["common_submission_integrity_v1"],  # Missing guardian_stewardship_v1
+        }
+        mod.write_json(mod.PENDING / "test-guardian-001.json", draft)
+        mod.append_records(all_records=False)
+        verrors = mod.verify_native_records()
+        steward_errors = [e for e in verrors if "guardian_stewardship_v1" in e]
+        if not steward_errors:
+            errors.append("verify should have failed for guardian_application missing guardian_stewardship_v1")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_5_append_all_continues_after_rejection() -> list[str]:
+    """append --all continues processing after one pending is rejected."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        # Good pending
+        good = _make_echo_draft()
+        mod.write_json(mod.PENDING / "good-001.json", good)
+        # Bad pending (missing required fields)
+        bad = {"record_type": "echo", "schema": "trinityaccord.record-chain-entry.v1"}
+        mod.write_json(mod.PENDING / "bad-001.json", bad)
+        mod.append_records(all_records=True)
+        recs = sorted(mod.RECORDS.glob("R-*.json"))
+        if len(recs) < 1:
+            errors.append("Should have appended at least 1 record despite bad pending")
+        # Check bad was moved to rejected
+        rejected_files = list(mod.REJECTED.glob("bad-001.*"))
+        if not rejected_files:
+            errors.append("Bad pending should have been moved to rejected/")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_6_rejection_reason_file_written() -> list[str]:
+    """Rejection writes a .rejection.json with reason."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        bad = {"record_type": "echo", "schema": "trinityaccord.record-chain-entry.v1"}
+        mod.write_json(mod.PENDING / "bad-only.json", bad)
+        mod.append_records(all_records=True)
+        rej_path = mod.REJECTED / "bad-only.rejection.json"
+        if not rej_path.exists():
+            errors.append("rejection.json not written")
+        else:
+            rej = mod.read_json(rej_path)
+            if not rej.get("reason"):
+                errors.append("rejection.json missing reason")
+            if rej.get("schema") != "trinityaccord.record-chain-rejection.v1":
+                errors.append(f"wrong rejection schema: {rej.get('schema')}")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+def test_7_raw_readback_text_fails_verify() -> list[str]:
+    """Raw readback_text in persisted record fails verify."""
+    errors = []
+    tmp = _setup_chain()
+    try:
+        draft = _make_echo_draft()
+        draft["submission_oath_verification"] = {
+            "oath_read": True,
+            "participant_readback_provided": True,
+            "readback_matches_canonical_oath": True,
+            "no_shortcut_oath_acknowledged": True,
+            "oath_does_not_prove_subjective_understanding": True,
+            "oath_verifies_exact_readback_only": True,
+            "not_authority": True,
+            "not_governance": True,
+            "not_attestation": True,
+            "not_amendment": True,
+            "bitcoin_originals_prevail": True,
+            "oath_policy_sha256": "a" * 64,
+            "canonical_oath_text_sha256": "b" * 64,
+            "participant_readback_sha256": "c" * 64,
+            "oath_modules": ["common_submission_integrity_v1", "echo_integrity_v1"],
+            "readback_text": "THIS SHOULD NOT BE HERE",  # FORBIDDEN
+        }
+        mod.write_json(mod.PENDING / "test-echo-001.json", draft)
+        mod.append_records(all_records=False)
+        verrors = mod.verify_native_records()
+        readback_errors = [e for e in verrors if "readback_text" in e]
+        if not readback_errors:
+            errors.append("verify should have failed for raw readback_text in record")
+    finally:
+        _cleanup(tmp)
+    return errors
+
+
+ALL_TESTS = [
+    ("append includes authorship_verification_status", test_1_append_includes_authorship_verification_status),
+    ("verify fails missing authorship_verification_status", test_2_verify_fails_missing_authorship_verification_status),
+    ("verify fails oath hash missing/invalid", test_3_verify_fails_oath_hash_missing),
+    ("verify fails guardian without stewardship_v1", test_4_verify_fails_guardian_without_stewardship),
+    ("append --all continues after rejection", test_5_append_all_continues_after_rejection),
+    ("rejection reason file written", test_6_rejection_reason_file_written),
+    ("raw readback_text fails verify", test_7_raw_readback_text_fails_verify),
+]
+
+
+def main() -> int:
+    passed = 0
+    failed = 0
+    for name, fn in ALL_TESTS:
+        errs = fn()
+        if errs:
+            failed += 1
+            print(f"FAIL: {name}")
+            for e in errs:
+                print(f"  - {e}")
+        else:
+            passed += 1
+            print(f"PASS: {name}")
+    print(f"\n{passed}/{passed + failed} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/trinity_record_chain.py
+++ b/scripts/trinity_record_chain.py
@@ -441,12 +441,10 @@ def normalize_record_draft(draft: dict[str, Any]) -> dict[str, Any]:
     draft.setdefault("schema", "trinityaccord.record-chain-entry.v1")
     draft.setdefault("chain_id", CHAIN_ID)
     draft.setdefault("created_at", utc_now())
-    draft.setdefault("human_context", None)
-    draft.setdefault("discovery_autonomy", None)
-    draft.setdefault("decision_autonomy", None)
-    draft.setdefault("execution_authorization", None)
-    draft.setdefault("guardian_proof", None)
-    draft.setdefault("oath", None)
+    # Phase 6B: legacy defaults (human_context, oath, etc.) are no longer
+    # scattered into the draft here.  They are injected post-append under
+    # server_normalization / legacy_compatibility_projection so that the
+    # canonical record hash reflects only substantive content.
     draft.setdefault("what_i_checked", [])
     draft.setdefault("limitations", [])
     draft.setdefault("related_records", [])
@@ -486,16 +484,64 @@ def append_records(all_records: bool = False) -> None:
         print("No pending records.")
         return
     selected = pending if all_records else pending[:1]
+    rejected_count = 0
+    appended_count = 0
     for path in selected:
         try:
             draft = normalize_record_draft(read_json(path))
+
+            # --- Phase 6B: authorship_verification_status ---
+            # Record the scope of the authorship proof relative to the final
+            # appended record.  The builder signs the *draft* before gateway
+            # append-assigned fields exist; the final record hash is the
+            # server append hash, not the signed payload hash.
+            rtype = draft.get("record_type", "")
+            if rtype in FORMAL_RECORD_TYPES and rtype not in AUTHORSHIP_EXEMPT_TYPES:
+                draft["authorship_verification_status"] = {
+                    "signed_payload_scope": "pre_append_record_draft",
+                    "verified_by_gateway_before_pending": True,
+                    "final_record_contains_append_assigned_fields_not_in_signed_payload": True,
+                }
+
             next_index = int(tip.get("latest_record_index") or 0) + 1
             draft["record_index"] = next_index
             draft["record_id"] = record_id(next_index)
             draft["assigned_at"] = utc_now()
             draft["previous_record_sha256"] = tip.get("latest_record_sha256")
+
+            # --- Phase 6B: append_assigned_metadata ---
+            # Mark fields that are assigned by the server during append and
+            # are NOT part of the original signed payload.
+            draft["append_assigned_metadata"] = {
+                "record_index": next_index,
+                "record_id": record_id(next_index),
+                "assigned_at": draft["assigned_at"],
+                "previous_record_sha256": draft["previous_record_sha256"],
+                "content_sha256": "(computed after all fields set)",
+                "record_sha256": "(computed after all fields set)",
+            }
+
+            # --- Phase 6B: server_normalization projection ---
+            # Legacy compatibility defaults that used to be scattered into the
+            # draft are now isolated in a server_normalization block so they
+            # don't pollute the canonical content hash signed by the author.
+            draft.setdefault("server_normalization", {})
+            sn = draft["server_normalization"]
+            sn.setdefault("legacy_compatibility_projection", {
+                "human_context": None,
+                "discovery_autonomy": None,
+                "decision_autonomy": None,
+                "execution_authorization": None,
+                "guardian_proof": None,
+                "oath": None,
+            })
+
             draft["content_sha256"] = content_hash(draft)
             draft["record_sha256"] = record_hash(draft)
+            # Update append_assigned_metadata with final hashes
+            draft["append_assigned_metadata"]["content_sha256"] = draft["content_sha256"]
+            draft["append_assigned_metadata"]["record_sha256"] = draft["record_sha256"]
+
             out = RECORDS / f"{draft['record_id']}.json"
             if out.exists():
                 raise ValueError(f"record output already exists: {out}")
@@ -509,10 +555,26 @@ def append_records(all_records: bool = False) -> None:
                 "updated_at": utc_now(),
             })
             write_json(CHAIN_TIP, tip)
+            appended_count += 1
         except Exception as exc:
+            # Phase 6B: --all continues after rejection; writes rejection JSON
             REJECTED.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(path), str(REJECTED / path.name))
-            raise SystemExit(f"Rejected pending record {path.name}: {exc}") from exc
+            rejection_path = REJECTED / f"{path.stem}.rejection.json"
+            rejection = {
+                "schema": "trinityaccord.record-chain-rejection.v1",
+                "rejected_at": utc_now(),
+                "source_pending": path.name,
+                "reason": str(exc),
+            }
+            write_json(rejection_path, rejection)
+            if path.exists():
+                shutil.move(str(path), str(REJECTED / path.name))
+            rejected_count += 1
+            if not all_records:
+                raise SystemExit(f"Rejected pending record {path.name}: {exc}") from exc
+            print(f"REJECTED {path.name}: {exc}", file=sys.stderr)
+    if rejected_count:
+        print(f"Append summary: {appended_count} appended, {rejected_count} rejected.")
     build_indexes()
 
 
@@ -671,6 +733,25 @@ def _verify_oath_in_record(obj: dict, path: str, errors: list[str]) -> None:
             if oath.get(field) is not True:
                 errors.append(f"{path}: oath.{field} is not true")
 
+        # --- Phase 6B: strengthened oath hash verification ---
+        # All formal records with submission_oath_verification must have
+        # valid 64-hex-sha256 hash fields.
+        _HEX64 = re.compile(r"^[0-9a-f]{64}$")
+        for hash_field in ("oath_policy_sha256", "canonical_oath_text_sha256", "participant_readback_sha256"):
+            val = oath.get(hash_field)
+            if not val or not _HEX64.match(str(val)):
+                errors.append(f"{path}: oath.{hash_field} missing or not 64-hex sha256")
+
+        # oath_modules must be non-empty
+        modules = oath.get("oath_modules")
+        if not isinstance(modules, list) or len(modules) == 0:
+            errors.append(f"{path}: oath.oath_modules missing or empty")
+
+        # Linked guardian_application must include guardian_stewardship_v1
+        if record_type == "guardian_application":
+            if isinstance(modules, list) and "guardian_stewardship_v1" not in modules:
+                errors.append(f"{path}: guardian_application oath.oath_modules must include guardian_stewardship_v1")
+
 
 def _check_no_raw_readback(obj: Any, path: str, errors: list[str], prefix: str) -> None:
     """Recursively verify no raw readback_text exists in persisted records."""
@@ -706,6 +787,21 @@ def verify_native_records() -> list[str]:
             require_authorship(obj)
         except Exception as exc:
             errors.append(f"{p}: {exc}")
+
+        # --- Phase 6B: authorship_verification_status for formal records ---
+        rtype = obj.get("record_type") or ""
+        if rtype in FORMAL_RECORD_TYPES and rtype not in AUTHORSHIP_EXEMPT_TYPES:
+            avs = obj.get("authorship_verification_status")
+            if not isinstance(avs, dict):
+                errors.append(f"{p}: formal record_type={rtype} missing authorship_verification_status")
+            else:
+                if avs.get("signed_payload_scope") != "pre_append_record_draft":
+                    errors.append(f"{p}: authorship_verification_status.signed_payload_scope must be 'pre_append_record_draft'")
+                if avs.get("verified_by_gateway_before_pending") is not True:
+                    errors.append(f"{p}: authorship_verification_status.verified_by_gateway_before_pending must be true")
+                if avs.get("final_record_contains_append_assigned_fields_not_in_signed_payload") is not True:
+                    errors.append(f"{p}: authorship_verification_status.final_record_contains_append_assigned_fields_not_in_signed_payload must be true")
+
         # --- oath gate verification ---
         _verify_oath_in_record(obj, p, errors)
         previous = obj.get("record_sha256")
@@ -946,7 +1042,21 @@ def init_policies() -> None:
         "$id": "https://www.trinityaccord.org/record-chain/schemas/record-chain-entry.v1.schema.json",
         "title": "Trinity Accord Record Chain Entry v1",
         "type": "object",
-        "required": ["schema", "chain_id", "record_type", "actor_identity", "context_readiness", "boundary_acknowledgement"],
+        "description": "Append-internal final entry schema.  Required fields vary by record_type; "
+                       "actor_identity alone is not the only required contract for v2 submissions.",
+        "required": ["schema", "chain_id", "record_type"],
+        "allOf": [
+            {
+                "if": {"properties": {"record_type": {"enum": sorted(FORMAL_RECORD_TYPES)}}},
+                "then": {
+                    "required": [
+                        "schema", "chain_id", "record_type", "actor_identity",
+                        "context_readiness", "boundary_acknowledgement",
+                        "authorship_verification_status",
+                    ],
+                },
+            },
+        ],
         "additionalProperties": True,
     })
 


### PR DESCRIPTION
## Phase 6B Record-Chain Hotfix F

### Changes

**1. Authorship proof scope (`trinity_record_chain.py`)**
- `append_records()` now injects `authorship_verification_status` into formal records at append time
- Status declares: `signed_payload_scope=pre_append_record_draft`, `verified_by_gateway_before_pending=true`, `final_record_contains_append_assigned_fields_not_in_signed_payload=true`
- `verify_native_records()` enforces this field on all formal record types

**2. Oath hash enforcement (`_verify_oath_in_record`)**
- Formal records with `submission_oath_verification` now require:
  - `oath_policy_sha256` (64 hex)
  - `canonical_oath_text_sha256` (64 hex)
  - `participant_readback_sha256` (64 hex)
  - `oath_modules` (non-empty list)
- `guardian_application` must include `guardian_stewardship_v1` in modules
- Raw `readback_text` anywhere in persisted record fails verify (was already checked, now tested)

**3. Normalization boundary (`normalize_record_draft`)**
- Removed scattered legacy defaults (`human_context=None`, `oath=None`, `discovery_autonomy=None`, etc.)
- These are now isolated in `server_normalization.legacy_compatibility_projection`
- `append_assigned_metadata` marks server-assigned fields explicitly

**4. `append --all` resilience (`append_records`)**
- Bad pending records now move to `rejected/` with a `.rejection.json` file containing the reason
- Processing continues to next pending instead of halting
- Final summary: `{appended} appended, {rejected} rejected`

**5. `init_policies` schema update**
- Entry schema no longer unconditionally requires `actor_identity`
- Uses `allOf` + `if/then` to require `authorship_verification_status` only for formal record types
- Description clarifies this is an append-internal final entry schema

**6. Tests (`scripts/test_phase6b_hotfix.py`)**
- 7 tests, all passing:
  1. Append includes authorship_verification_status
  2. Verify fails missing authorship_verification_status
  3. Verify fails oath hash missing/invalid
  4. Verify fails guardian without stewardship_v1
  5. Append --all continues after rejection
  6. Rejection reason file written
  7. Raw readback_text fails verify
