### PR TITLE
fix: canonical Builder publish chain (PR-1)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -72,11 +72,13 @@ jobs:
           # Jekyll Docker action creates _site/ as root. Fix ownership so we
           # can copy builder-bundle files into it.
           sudo chown -R "$(id -u):$(id -g)" _site
+          mkdir -p _site/downloads
           mkdir -p _site/builder-bundles
+          cp downloads/record-chain-builder.mjs _site/downloads/record-chain-builder.mjs
+          cp downloads/record-chain-builder.mjs _site/builder-bundles/record-chain-builder.mjs
           cp builder-bundles/*.tar.gz _site/builder-bundles/
           cp builder-bundles/*.json _site/builder-bundles/
           cp scripts/download_and_run_builder_bundle.py _site/builder-bundles/
-          cp downloads/record-chain-builder.mjs _site/builder-bundles/
           cp api/builder-bundle-signing-key.v1.json _site/api/
           cp api/formal-builder-bundle-signatures.v1.json _site/api/
 
@@ -115,6 +117,7 @@ jobs:
           test -f _site/api/record-chain-submission-schema.v1.json
           test -f _site/api/record-chain-field-helper.v1.json
           test -f _site/api/record-chain-oath-policy.v1.json
+          test -f _site/downloads/record-chain-builder.mjs
           test -f _site/builder-bundles/record-chain-builder.mjs
           test -f _site/builder-bundles/download_and_run_builder_bundle.py
 
@@ -144,6 +147,9 @@ jobs:
           if [ "$failures" -gt 0 ]; then
             echo "::warning::${failures} legacy zero-clone builder bundle artifact(s) missing — non-blocking"
           fi
+
+      - name: Verify Pages builder artifact contract
+        run: python3 scripts/test_pages_builder_artifact_contract.py --site-dir _site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3

--- a/scripts/smoke_live_discovery_contract.py
+++ b/scripts/smoke_live_discovery_contract.py
@@ -14,6 +14,7 @@ live JSON, prints HTTP cache headers, detects CDN/edge inconsistency.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import socket
 import sys
@@ -190,6 +191,71 @@ def validate_well_known_contract(label: str, well_known: dict[str, Any], errors:
             errors.append(f"{label} well-known agent_entrypoints missing {key}")
 
 
+
+def validate_builder_contract(label: str, site: str, timeout: int, errors: list[str]) -> None:
+    """Verify live canonical builder matches API contract."""
+    contract_url = f"{site}/api/record-chain-builder-bundles.v1.json"
+    try:
+        contract = fetch_json(contract_url, timeout)
+    except RuntimeError as e:
+        errors.append(f"{label} builder contract fetch failed: {e}")
+        return
+
+    builder = contract.get("canonical_builder", {})
+    canonical_url = builder.get("url")
+    if not canonical_url:
+        errors.append(f"{label} builder contract missing canonical_builder.url")
+        return
+
+    if canonical_url != "/downloads/record-chain-builder.mjs":
+        errors.append(f"{label} unexpected canonical builder URL: {canonical_url!r}")
+        return
+
+    expected_sha = builder.get("sha256")
+    expected_size = builder.get("size_bytes")
+
+    # Fetch canonical builder
+    full_url = f"{site}{canonical_url}"
+    try:
+        req = urllib.request.Request(
+            full_url,
+            headers={"User-Agent": "trinity-accord-live-discovery-smoke/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read()
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        errors.append(f"{label} canonical builder fetch failed: {e}")
+        return
+
+    actual_sha = hashlib.sha256(body).hexdigest()
+    actual_size = len(body)
+
+    if expected_sha and actual_sha != expected_sha:
+        errors.append(
+            f"{label} canonical builder SHA-256 mismatch: "
+            f"expected={expected_sha!r}, actual={actual_sha!r}"
+        )
+    if expected_size and actual_size != expected_size:
+        errors.append(
+            f"{label} canonical builder size mismatch: "
+            f"expected={expected_size}, actual={actual_size}"
+        )
+
+    # Optionally verify mirror
+    mirror_url = f"{site}/builder-bundles/record-chain-builder.mjs"
+    try:
+        req2 = urllib.request.Request(
+            mirror_url,
+            headers={"User-Agent": "trinity-accord-live-discovery-smoke/1.0"},
+        )
+        with urllib.request.urlopen(req2, timeout=timeout) as resp2:
+            mirror_body = resp2.read()
+        if mirror_body != body:
+            errors.append(f"{label} builder mirror differs from canonical")
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        pass  # mirror is optional
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--site", default=DEFAULT_SITE)
@@ -275,6 +341,9 @@ def main() -> int:
                     f"live={live_digest!r}, repo={repo_digest!r}; "
                     "this usually means Pages/CDN/custom-domain is serving an older artifact"
                 )
+
+    # Verify builder contract
+    validate_builder_contract("canonical", site, args.timeout, errors)
 
     if errors:
         print("FAIL: live discovery contract errors:")

--- a/scripts/test_pages_builder_artifact_contract.py
+++ b/scripts/test_pages_builder_artifact_contract.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--site-dir", required=True)
+    args = parser.parse_args()
+
+    site_dir = Path(args.site_dir)
+    contract = json.loads(
+        (ROOT / "api/record-chain-builder-bundles.v1.json").read_text(encoding="utf-8")
+    )
+    builder = contract["canonical_builder"]
+
+    if builder["url"] != "/downloads/record-chain-builder.mjs":
+        fail(f"unexpected canonical builder URL: {builder['url']}")
+
+    canonical = site_dir / builder["url"].lstrip("/")
+    mirror = site_dir / "builder-bundles/record-chain-builder.mjs"
+
+    if not canonical.is_file():
+        fail(f"missing canonical builder: {canonical}")
+    if not mirror.is_file():
+        fail(f"missing compatibility builder mirror: {mirror}")
+
+    canonical_bytes = canonical.read_bytes()
+    if canonical_bytes != mirror.read_bytes():
+        fail("canonical builder and compatibility mirror differ")
+
+    if hashlib.sha256(canonical_bytes).hexdigest() != builder["sha256"]:
+        fail("canonical builder SHA-256 differs from API contract")
+    if len(canonical_bytes) != builder["size_bytes"]:
+        fail("canonical builder size differs from API contract")
+
+    subprocess.run(["node", "--check", str(canonical)], check=True)
+    print("PASS: Pages builder artifact contract")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the canonical Builder publish chain so `/downloads/record-chain-builder.mjs` is reliably published to Pages.

### Changes

- `.github/workflows/deploy-pages.yml`: Copy `record-chain-builder.mjs` to both `_site/downloads/` (canonical) and `_site/builder-bundles/` (mirror); add contract verification step before artifact upload; add canonical path to built agent discovery checks.
- `scripts/test_pages_builder_artifact_contract.py` (new): Verifies canonical builder exists in Pages artifact, matches mirror, and conforms to API contract (SHA-256, size_bytes, node --check).
- `scripts/smoke_live_discovery_contract.py`: Adds live builder contract verification — fetches canonical builder from live site, verifies SHA-256 and size, optionally verifies mirror.

### Contract checks

- Canonical builder URL: `/downloads/record-chain-builder.mjs` ✅
- Mirror at `/builder-bundles/record-chain-builder.mjs` ✅
- SHA-256 and size_bytes match API contract ✅
- `node --check` syntax verification ✅

### Verification

```bash
python3 scripts/test_record_chain_builder_bundle_contract.py
node downloads/test-record-chain-builder.mjs
python3 scripts/run_current_system_tests.py
python3 scripts/test_pages_builder_artifact_contract.py --site-dir _site
```

### Deployment smoke

```bash
curl -fsS https://www.trinityaccord.org/downloads/record-chain-builder.mjs -o /tmp/record-chain-builder.mjs
node --check /tmp/record-chain-builder.mjs
sha256sum /tmp/record-chain-builder.mjs
```

### Rollback

Revert this PR. The previous workflow still published to `_site/builder-bundles/` — the canonical path was simply missing.