### PR TITLE
fix: add Node dependency lockfile gate to CI (PR-4)

### DIFF
--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Install Python dependencies
         run: python3 -m pip install -r requirements-ci.txt
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+
+      - name: Verify Node dependency lockfile
+        run: npm ci
+
       - name: Validate JSON
         run: find . -name "*.json" -print0 | xargs -0 -n1 python3 -m json.tool > /dev/null
 


### PR DESCRIPTION
## Summary

Adds `npm ci` to the repository-integrity CI workflow to prevent `package-lock.json` drift.

### Changes

- `.github/workflows/repository-integrity.yml`: Add `actions/setup-node` (pinned SHA) with `.node-version` file and `npm ci` step.

### Why

`package.json` and `package-lock.json` are currently in sync. This gate ensures future PRs that modify `package.json` without updating the lockfile will fail CI.

### Verification

```bash
npm ci
python3 scripts/run_current_system_tests.py
```

### Rollback

Revert this PR.