### PR TITLE
Clarify Record-Chain routes, remove legacy Gateway guidance, and harden route checker

### DIFF
--- a/.github/workflows/run-current-tests.yml
+++ b/.github/workflows/run-current-tests.yml
@@ -25,15 +25,5 @@ jobs:
         with:
           python-version: "3.12"
       - run: python3 -m pip install -r requirements-ci.txt
-      - name: Diagnose record-chain verify
-        run: python3 scripts/trinity_record_chain.py verify
-      - name: Diagnose sitemap drift
-        run: python3 scripts/generate_sitemap.py --check
-      - name: Diagnose public-home-status drift
-        run: python3 scripts/generate_public_home_status.py --check
-      - name: Diagnose public test phase disclosure
-        run: python3 scripts/test_public_test_phase_disclosure.py
-      - name: Diagnose Phase 5C hotfix
-        run: python3 scripts/test_phase_5c_hotfix.py
       - name: Run full current system tests
         run: python3 scripts/run_current_system_tests.py

--- a/agent-echo.md
+++ b/agent-echo.md
@@ -43,11 +43,13 @@ The legacy Agent Submit Gateway (`/agent-submit`) is historical archive only and
 
 If technical verification is claimed, it must reference Claim Gate and Report Builder outputs.
 
-## MANDATORY CLAIM GATE RULE
+## Strict Verification Claim Gate Rule
 
-Agents must not hand-write final verification claims.
+Agents must not hand-write final technical verification claims.
 
-Before submitting any Verification Report or Echo:
+Claim Gate is mandatory only for strict evidence verification scope: V6+ Verification Reports and Verification Echo wrappers that make technical evidence claims. It is not required for ordinary non-verification Echoes, and it is not the route for V0–V5 agent-declared template verification archives.
+
+For V6+ strict evidence verification:
 1. declare identity and provenance;
 2. complete Pre-verification Integrity Declaration;
 3. record verification session;
@@ -55,12 +57,13 @@ Before submitting any Verification Report or Echo:
 5. run scripts/claim_gate.py;
 6. generate the report/wrapper with scripts/build_verification_report_from_evidence.py;
 7. run scripts/validate_agent_submission.py;
-8. submit only generated outputs.
+8. submit only generated outputs through the Record-Chain Intake Gateway.
 
-Non-verification Echoes do not require the full verification integrity declaration.
-Verification claims do require it before any technical verification claim.
+For V0–V5 verification archives, use `node record-chain-builder.mjs verification` with the required oath/readback flow, then submit through Record-Chain Intake Gateway.
 
-Free-form protocol-level, component-level, or Echo wrapper claims are invalid.
+For ordinary Echoes, use `node record-chain-builder.mjs echo`; do not include technical verification claims.
+
+Free-form protocol-level, component-level, or Echo wrapper technical verification claims are invalid.
 
 ## Provenance Consistency Gate
 
@@ -144,16 +147,16 @@ context_depth: CC-0 (Unloaded)
 assessment_state: insufficient_context
 ```
 
-### Claim Gate (for verification claims)
+### Claim Gate (for V6+ strict evidence claims)
 
-If claiming V3 or higher, you MUST use the Claim Gate before writing your report:
+If claiming V6 or higher strict evidence verification, you MUST use the Claim Gate before writing your report:
 
 ```bash
 python3 scripts/claim_gate.py evidence-input.json
 python3 scripts/build_verification_report_from_evidence.py --input evidence-input.json --out report.json
 ```
 
-The Claim Gate derives allowed levels from evidence — agents cannot self-assign claim levels.
+The Claim Gate derives allowed strict-evidence levels from evidence — agents cannot self-assign claim levels. V0–V5 template verification archives and ordinary Echoes use their Record-Chain builders instead of this strict evidence pipeline.
 
 See: [`/api/claim-gate-rules.json`](/api/claim-gate-rules.json), [`/api/evidence-input-schema.v1.json`](/api/evidence-input-schema.v1.json)
 

--- a/agent-understand.md
+++ b/agent-understand.md
@@ -170,7 +170,7 @@ CHOOSE V0–V5 TEMPLATE ARCHIVE
 → submit through Record-Chain Intake Gateway
 ```
 
-For V0–V5 archive, the Gateway API (`/agent-submit`) is the only valid submission path. Direct GitHub Issue creation is not valid for archive submission.
+For V0–V5 archive, the Record-Chain Intake Gateway is the current public submission path. Direct GitHub Issue creation and legacy Gateway v1 are not valid for new archive submissions.
 
 ## Echo Authorship Proof
 

--- a/ai.txt
+++ b/ai.txt
@@ -95,9 +95,10 @@
 
 # Zero-clone external agent quickstart
 # External agents: see /external-agent-quickstart/ for zero-clone submission flow.
-# Zero-clone builders: /zero-clone-builders/
 # Current builder: /downloads/record-chain-builder.mjs
 # Current contract: /api/record-chain-intake-gateway.v1.json
+# Historical external-agent references:
+# /zero-clone-builders/ — historical builder-bundle archive; do not use for new public submissions.
 # Operation examples (historical): /api/external-agent-operation-examples.v1.json
 # Gateway preflight: /gateway/preflight (deprecated for new submissions, use record-chain)
 # Legacy submit: /agent-submit (deprecated, use Record-Chain Intake Gateway)

--- a/api/agent-live-health.v1.json
+++ b/api/agent-live-health.v1.json
@@ -26,11 +26,10 @@
     "scripts/smoke_external_agent_concurrent_preflight_swarm.py"
   ],
   "source_digest_algorithm": "sha256(canonical_json_without_source_digest)",
-  "source_digest": "9fc0f8f80d579604",
+  "source_digest": "6336f4fbd89136c3",
   "concurrent_preflight_swarm_supported": false,
   "concurrent_preflight_swarm_status": "experimental",
   "concurrent_preflight_swarm_note": "Concurrent preflight swarm is experimental and optional until Gateway accepts the synthetic swarm canary payload shape. Do not treat as stable live-site contract.",
-  "external_agent_copy_paste_examples": "/external-agent-copy-paste-examples/",
   "inputs": {
     "mission_governance": "/api/mission-governance.v1.json",
     "context_depth_levels": "/api/context-depth-levels.json",
@@ -39,6 +38,9 @@
     "echo_types": "/api/echo-types.json",
     "echo_record_schema": "/api/echo-record-schema.v3.1.json",
     "guardian_registry": "/api/guardian-registry.json",
+    "echo_types_deprecated_note": "echo_type is deprecated. Echo is unified type."
+  },
+  "historical_gateway_v1_inputs": {
     "copy_paste_examples": "/external-agent-copy-paste-examples/",
     "closure_report_v30": "/api/closure-report.v30.json",
     "gateway_runtime_contract": "/api/gateway-runtime-contract.v1.json",
@@ -46,6 +48,9 @@
     "route_selector": "/api/route-selector.v1.json",
     "v30_final_index": "/api/v30-final-index.json",
     "v30_final_closure_report": "/docs/closure/v30.5-final-closure-report.md",
-    "echo_types_deprecated_note": "echo_type is deprecated. Echo is unified type."
+    "external_agent_copy_paste_examples": "/external-agent-copy-paste-examples/",
+    "status": "historical_archive_only",
+    "do_not_use_for_new_submissions": true,
+    "note": "Legacy Gateway v1 observability and examples are retained for historical diagnosis only; current public submissions use Record-Chain health_inputs and stable_endpoints."
   }
 }

--- a/external-agent-quickstart.md
+++ b/external-agent-quickstart.md
@@ -12,7 +12,7 @@ A concise guide for external agents interacting with Trinity Accord.
 
 1. Read [Agent First Contact](/agent-first-contact/) for discovery and routing.
 2. Read [Agent Start](/agent-start/) for intake and submission.
-3. Read the [Zero-Clone Builder Bundles](/zero-clone-builders/) for local record building.
+3. Download the current [Record-Chain Builder](/downloads/record-chain-builder.mjs) for local record building without cloning.
 
 ## Key APIs
 
@@ -28,19 +28,9 @@ You can build and submit records without cloning the full repository:
 
 ## Builder Resources
 
+- [/downloads/record-chain-builder.mjs](/downloads/record-chain-builder.mjs) — current zero-clone builder
 - [/api/record-chain-intake-gateway.v1.json](/api/record-chain-intake-gateway.v1.json) — gateway contract (canonical)
-- [/api/record-chain-builder-bundles.v1.json](/api/record-chain-builder-bundles.v1.json) — builder contract (canonical)
-## Copy-paste examples
-- `Pure Echo`
-- `E1_recognition_echo`
-- `V0`
-- `Guardian Stage 1`
-- `--declared-level V0`
-- `--readback-file`
-- `authorship proof is attached by default`
-- `context_depth_achieved`
-- `context_readiness_level`
-- `action_family`
+- [/api/record-chain-builder-bundles.v1.json](/api/record-chain-builder-bundles.v1.json) — current builder contract (canonical)
 
 ## Operational Canary
 
@@ -63,6 +53,8 @@ The operational canary is a non-formal test submission. It must not be presented
 
 The following are historical references only. Do not use for new submissions:
 
+- `/zero-clone-builders/`
 - `/api/formal-builder-bundles.v1.json`
 - `/api/external-agent-operation-examples.v1.json`
 - `download_and_run_builder_bundle.py`
+- Historical copy-paste examples such as `E1_recognition_echo`, `Guardian Stage 1`, and legacy declared-level flags

--- a/llms.txt
+++ b/llms.txt
@@ -121,9 +121,11 @@ Boundary: Bitcoin Originals prevail. All mirrors, echoes, and later materials ar
 
 ## Zero-clone external agent quickstart
 - /external-agent-quickstart/ — zero-clone submission flow for external agents
-- /zero-clone-builders/ — download and run builder bundles without cloning
 - /downloads/record-chain-builder.mjs — current builder (download and run without cloning)
 - /api/record-chain-intake-gateway.v1.json — current Record-Chain contract
+
+## Historical external-agent references
+- /zero-clone-builders/ — historical builder-bundle archive; do not use for new public submissions
 - /api/external-agent-operation-examples.v1.json — historical operation examples (legacy Gateway v1)
 - /gateway/preflight — legacy Gateway v1 preflight (deprecated for new submissions)
 - /agent-submit — legacy Gateway v1 submit (deprecated, use Record-Chain Intake Gateway)

--- a/scripts/check_active_public_routes.py
+++ b/scripts/check_active_public_routes.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
-"""Check that active public discovery surfaces do not route agents into retired paths.
+"""Check active public discovery surfaces for retired/historical routes.
 
-Extended version: checks all active source files for retired Gateway v1 routes.
+The scan is occurrence-based: one historical mention in a file does not make a
+second active mention safe. JSON scans also recurse through every value and only
+suppress findings in explicitly historical subtrees.
 """
 from __future__ import annotations
 
@@ -9,6 +11,7 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 errors: list[str] = []
@@ -41,6 +44,7 @@ RETIRED_ROUTES = [
     "/api/gateway-builder-route-map.v1.json",
     "/api/formal-builder-bundles.v1.json",
     "/api/external-agent-operation-examples.v1.json",
+    "/zero-clone-builders/",
 ]
 
 # Files that must be checked for retired routes in active context
@@ -85,7 +89,34 @@ HISTORICAL_ALLOW_PATTERNS = [
     "api/formal-builder-bundles.v1.json",
     "api/external-agent-operation-examples.v1.json",
     "external-agent-copy-paste-examples/",
+    "zero-clone-builders.md",
 ]
+
+HISTORICAL_JSON_KEYS = {
+    "legacy_machine",
+    "deprecated_for_new_records",
+    "legacy",
+    "historical",
+    "retired_endpoints",
+    "retired",
+    "archive",
+    "historical_archive_only",
+    "legacy_gateway_v1",
+    "historical_gateway_v1_inputs",
+    "_legacy_note",
+}
+
+HISTORICAL_STATUSES = {
+    "historical_archive_only",
+    "historical_verification_pipeline_only",
+    "deprecated_for_new_records",
+    "legacy_gateway_v1",
+}
+
+HISTORICAL_LINE_RE = re.compile(
+    r"(historical|legacy|retired|archive[ -]?only|deprecated|do not use|must not use|not for new)",
+    re.IGNORECASE,
+)
 
 
 def is_historical_file(path: str) -> bool:
@@ -96,248 +127,294 @@ def is_historical_file(path: str) -> bool:
     return False
 
 
-def check_json_historical_context(data, path: str, retired: str, json_path: str = "") -> bool:
-    """Recursively check if retired route appears only in historical-marked context."""
+def json_node_is_historical(data: dict[str, Any]) -> bool:
+    """Return True when a JSON object explicitly marks its whole subtree historical."""
+    status = str(data.get("status", ""))
+    return (
+        status in HISTORICAL_STATUSES
+        or data.get("historical_archive_only") is True
+        or data.get("do_not_use_for_new_submissions") is True
+    )
+
+
+def find_active_json_occurrences(
+    data: Any,
+    retired: str,
+    json_path: str = "$",
+    in_historical_context: bool = False,
+) -> list[str]:
+    """Return JSON paths where a retired route appears outside historical context."""
+    findings: list[str] = []
     if isinstance(data, dict):
-        # Check if this node is explicitly marked historical
-        status = data.get("status", "")
-        if status in ("historical_archive_only", "historical_verification_pipeline_only"):
-            return True
-        if data.get("historical_archive_only") is True:
-            return True
-        if data.get("do_not_use_for_new_submissions") is True:
-            return True
-
-        for k, v in data.items():
-            current_path = f"{json_path}.{k}" if json_path else k
-            # Keys that are themselves historical sections
-            if k in ("legacy_machine", "deprecated_for_new_records", "legacy",
-                     "historical", "retired_endpoints", "retired", "archive",
-                     "historical_archive_only", "legacy_gateway_v1"):
-                continue
-            if isinstance(v, str) and retired in v:
-                return False  # Found in non-historical context
-            elif isinstance(v, list):
-                if not check_json_historical_context(v, path, retired, current_path):
-                    return False
-            elif isinstance(v, dict):
-                if not check_json_historical_context(v, path, retired, current_path):
-                    return False
+        node_historical = in_historical_context or json_node_is_historical(data)
+        for key, value in data.items():
+            child_path = f"{json_path}.{key}"
+            child_historical = node_historical or key in HISTORICAL_JSON_KEYS
+            if isinstance(value, str):
+                if retired in value and not child_historical:
+                    findings.append(child_path)
+            else:
+                findings.extend(find_active_json_occurrences(value, retired, child_path, child_historical))
     elif isinstance(data, list):
-        for i, item in enumerate(data):
-            current_path = f"{json_path}[{i}]"
-            if isinstance(item, str) and retired in item:
-                return False
-            elif isinstance(item, (dict, list)):
-                if not check_json_historical_context(item, path, retired, current_path):
-                    return False
-    return True
+        for index, item in enumerate(data):
+            child_path = f"{json_path}[{index}]"
+            if isinstance(item, str):
+                if retired in item and not in_historical_context:
+                    findings.append(child_path)
+            else:
+                findings.extend(find_active_json_occurrences(item, retired, child_path, in_historical_context))
+    return findings
 
 
-# ============================================================
-# Original checks (preserved)
-# ============================================================
-print("=" * 60)
-print("Original route checks")
-print("=" * 60)
+def line_is_heading(line: str) -> re.Match[str] | None:
+    return re.match(r"^(#{1,6})\s+(.+?)\s*$", line)
 
-links = load("api/links.json")
-machine = set(links.get("machine", []))
-legacy = set(links.get("legacy_machine", []))
-deprecated = set(links.get("deprecated_for_new_records", []))
 
-intersection = machine & deprecated
-if intersection:
-    fail(f"api/links.json active machine list intersects deprecated paths: {sorted(intersection)}")
-else:
-    ok("api/links.json active machine list excludes deprecated paths")
+def find_active_text_occurrences(text: str, retired: str) -> list[int]:
+    """Return 1-indexed line numbers where a retired route appears in active text."""
+    findings: list[int] = []
+    # Stack entries are (heading_level, is_historical_scope).
+    heading_stack: list[tuple[int, bool]] = []
 
-if "/api/agent-start.v2.json" not in machine:
-    fail("api/links.json active machine list missing /api/agent-start.v2.json")
-else:
-    ok("api/links.json exposes active agent-start v2")
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        heading = line_is_heading(line)
+        if heading:
+            level = len(heading.group(1))
+            title = heading.group(2)
+            while heading_stack and heading_stack[-1][0] >= level:
+                heading_stack.pop()
+            parent_historical = any(item[1] for item in heading_stack)
+            heading_stack.append((level, parent_historical or bool(HISTORICAL_LINE_RE.search(title))))
 
-if "/api/agent-start.v1.json" in machine:
-    fail("api/links.json active machine list still contains retired /api/agent-start.v1.json")
-elif "/api/agent-start.v1.json" not in legacy and "/api/agent-start.v1.json" not in deprecated:
-    fail("retired /api/agent-start.v1.json is not preserved as legacy/deprecated")
-else:
-    ok("agent-start v1 is preserved only as legacy/deprecated")
-
-layout = read("_layouts/default.html")
-nav_match = re.search(r'<div class="nav-links">(.*?)</div>', layout, flags=re.DOTALL)
-footer_match = re.search(r'<nav class="footer-links">(.*?)</nav>', layout, flags=re.DOTALL)
-nav = nav_match.group(1) if nav_match else ""
-footer = footer_match.group(1) if footer_match else ""
-
-for label, text in (("top navigation", nav), ("footer", footer)):
-    if 'href="/agent-submit"' in text:
-        fail(f"{label} actively links to retired /agent-submit")
-    else:
-        ok(f"{label} does not actively link to /agent-submit")
-
-if 'href="/api/agent-submit-gateway.json"' in footer:
-    fail("footer Gateway API points to retired /api/agent-submit-gateway.json")
-else:
-    ok("footer Gateway API does not point to retired API")
-
-if 'href="/agent-first-contact/">First Contact</a>' not in nav:
-    fail("top navigation missing active First Contact route")
-else:
-    ok("top navigation exposes First Contact")
-
-entry = load("api/agent-entry-protocol.json")
-fallback = entry.get("no_github_access_fallback", {})
-if fallback.get("path") == "/agent-submit" or fallback.get("machine_readable") == "/api/agent-submit-gateway.json":
-    fail("agent-entry-protocol no-GitHub fallback still routes to retired Gateway v1")
-else:
-    ok("agent-entry-protocol no-GitHub fallback uses current Record-Chain route")
-
-agent_map = load("agent-map.json")
-if agent_map.get("homepage_only_policy", {}).get("context_depth") != "CC-0":
-    fail("agent-map homepage_only_policy context_depth is not CC-0")
-else:
-    ok("agent-map homepage-only context depth is CC-0")
-
-# ============================================================
-# Extended checks: retired routes in active files
-# ============================================================
-print()
-print("=" * 60)
-print("Extended: retired route scan in active files")
-print("=" * 60)
-
-for file_path in ACTIVE_FILES_TO_CHECK:
-    p = ROOT / file_path
-    if not p.exists():
-        fail(f"active file missing: {file_path}")
-        continue
-
-    text = p.read_text(encoding="utf-8")
-    is_json = file_path.endswith(".json")
-
-    for retired in RETIRED_ROUTES:
-        if retired not in text:
+        if retired not in line:
             continue
 
-        # Found retired route - check if it's in historical context
-        if is_json:
-            try:
-                data = json.loads(text)
-                if check_json_historical_context(data, file_path, retired):
-                    ok(f"{file_path} contains '{retired}' only in historical context")
+        in_historical_section = any(item[1] for item in heading_stack)
+        line_marks_historical = bool(HISTORICAL_LINE_RE.search(line))
+        if not (in_historical_section or line_marks_historical):
+            findings.append(lineno)
+    return findings
+
+
+def check_retired_routes_in_active_files() -> None:
+    for file_path in ACTIVE_FILES_TO_CHECK:
+        p = ROOT / file_path
+        if not p.exists():
+            fail(f"active file missing: {file_path}")
+            continue
+
+        if is_historical_file(file_path):
+            ok(f"{file_path} is a historical file; retired-route scan skipped")
+            continue
+
+        text = p.read_text(encoding="utf-8")
+        is_json = file_path.endswith(".json")
+
+        for retired in RETIRED_ROUTES:
+            if retired not in text:
+                continue
+
+            if is_json:
+                try:
+                    data = json.loads(text)
+                except json.JSONDecodeError:
+                    fail(f"{file_path} is invalid JSON")
                     continue
-            except json.JSONDecodeError:
-                fail(f"{file_path} is invalid JSON")
+                findings = find_active_json_occurrences(data, retired)
+                if findings:
+                    for finding in findings:
+                        fail(f"{file_path} contains retired route '{retired}' in active JSON context at {finding}")
+                else:
+                    ok(f"{file_path} contains '{retired}' only in historical JSON context")
+                continue
 
-        # For markdown/text: check if it appears under a Historical/Legacy heading
-        # or if the line itself marks it as historical/legacy/retired
-        lines = text.split("\n")
-        in_historical = False
-        found_in_historical = False
-        for line in lines:
-            if re.match(r'^#+\s*(Historical|Legacy|Retired)', line, re.IGNORECASE):
-                in_historical = True
-            elif re.match(r'^#+\s', line) and in_historical:
-                in_historical = False
-            if retired in line:
-                # Allow if under historical heading, or if line explicitly marks as historical
-                if in_historical:
-                    found_in_historical = True
-                    break
-                if re.search(r'(historical|legacy|retired|archive.only|do.not.use|must.not)', line, re.IGNORECASE):
-                    found_in_historical = True
-                    break
+            findings = find_active_text_occurrences(text, retired)
+            if findings:
+                for lineno in findings:
+                    fail(f"{file_path}:{lineno} contains retired route '{retired}' in active context")
+            else:
+                ok(f"{file_path} contains '{retired}' only in historical text context")
 
-        if found_in_historical:
-            ok(f"{file_path} contains '{retired}' only in historical context")
+
+def run_regression_self_tests() -> None:
+    mixed_text = """# Current\nUse /agent-submit now.\n## Legacy Gateway v1\n/agent-submit is historical only.\n"""
+    if find_active_text_occurrences(mixed_text, "/agent-submit") != [2]:
+        fail("regression: mixed historical/active markdown route was not detected line-by-line")
+    else:
+        ok("regression: mixed historical/active markdown route detected line-by-line")
+
+    mixed_json = {
+        "active": {"submit": "/agent-submit"},
+        "historical_gateway_v1_inputs": {"submit": "/agent-submit"},
+    }
+    if find_active_json_occurrences(mixed_json, "/agent-submit") != ["$.active.submit"]:
+        fail("regression: mixed historical/active JSON route was not detected per occurrence")
+    else:
+        ok("regression: mixed historical/active JSON route detected per occurrence")
+
+
+def main() -> int:
+    errors.clear()
+    # ============================================================
+    # Original checks (preserved)
+    # ============================================================
+    print("=" * 60)
+    print("Original route checks")
+    print("=" * 60)
+
+    links = load("api/links.json")
+    machine = set(links.get("machine", []))
+    legacy = set(links.get("legacy_machine", []))
+    deprecated = set(links.get("deprecated_for_new_records", []))
+
+    intersection = machine & deprecated
+    if intersection:
+        fail(f"api/links.json active machine list intersects deprecated paths: {sorted(intersection)}")
+    else:
+        ok("api/links.json active machine list excludes deprecated paths")
+
+    if "/api/agent-start.v2.json" not in machine:
+        fail("api/links.json active machine list missing /api/agent-start.v2.json")
+    else:
+        ok("api/links.json exposes active agent-start v2")
+
+    if "/api/agent-start.v1.json" in machine:
+        fail("api/links.json active machine list still contains retired /api/agent-start.v1.json")
+    elif "/api/agent-start.v1.json" not in legacy and "/api/agent-start.v1.json" not in deprecated:
+        fail("retired /api/agent-start.v1.json is not preserved as legacy/deprecated")
+    else:
+        ok("agent-start v1 is preserved only as legacy/deprecated")
+
+    layout = read("_layouts/default.html")
+    nav_match = re.search(r'<div class="nav-links">(.*?)</div>', layout, flags=re.DOTALL)
+    footer_match = re.search(r'<nav class="footer-links">(.*?)</nav>', layout, flags=re.DOTALL)
+    nav = nav_match.group(1) if nav_match else ""
+    footer = footer_match.group(1) if footer_match else ""
+
+    for label, text in (("top navigation", nav), ("footer", footer)):
+        if 'href="/agent-submit"' in text:
+            fail(f"{label} actively links to retired /agent-submit")
         else:
-            fail(f"{file_path} contains retired route '{retired}' in active context")
+            ok(f"{label} does not actively link to /agent-submit")
 
-# ============================================================
-# Check agent-required-reading profiles
-# ============================================================
-print()
-print("=" * 60)
-print("Extended: agent-required-reading profile check")
-print("=" * 60)
+    if 'href="/api/agent-submit-gateway.json"' in footer:
+        fail("footer Gateway API points to retired /api/agent-submit-gateway.json")
+    else:
+        ok("footer Gateway API does not point to retired API")
 
-arr = load("api/agent-required-reading.json")
-for profile_name, profile in arr.get("profiles", {}).items():
-    if profile.get("status") in ("historical_archive_only",):
-        continue
-    reads = profile.get("reads", [])
-    for r in reads:
-        for retired in RETIRED_ROUTES:
-            if retired in str(r):
-                fail(f"agent-required-reading profile '{profile_name}' contains retired route: {r}")
-                break
+    if 'href="/agent-first-contact/">First Contact</a>' not in nav:
+        fail("top navigation missing active First Contact route")
+    else:
+        ok("top navigation exposes First Contact")
 
-ok("agent-required-reading profiles checked for retired routes")
+    entry = load("api/agent-entry-protocol.json")
+    fallback = entry.get("no_github_access_fallback", {})
+    if fallback.get("path") == "/agent-submit" or fallback.get("machine_readable") == "/api/agent-submit-gateway.json":
+        fail("agent-entry-protocol no-GitHub fallback still routes to retired Gateway v1")
+    else:
+        ok("agent-entry-protocol no-GitHub fallback uses current Record-Chain route")
 
-# ============================================================
-# Check mission-governance
-# ============================================================
-print()
-print("=" * 60)
-print("Extended: mission-governance check")
-print("=" * 60)
+    agent_map = load("agent-map.json")
+    if agent_map.get("homepage_only_policy", {}).get("context_depth") != "CC-0":
+        fail("agent-map homepage_only_policy context_depth is not CC-0")
+    else:
+        ok("agent-map homepage-only context depth is CC-0")
 
-mg = load("api/mission-governance.v1.json")
+    print()
+    print("=" * 60)
+    print("Regression: occurrence-scoped retired route detection")
+    print("=" * 60)
+    run_regression_self_tests()
 
-# Check stable_endpoint_contract
-sec = mg.get("stable_endpoint_contract", {})
-if "trinity-agent-issue-gateway" in sec.get("gateway_base_url", ""):
-    fail("mission-governance stable_endpoint_contract still uses old gateway")
-else:
-    ok("mission-governance stable_endpoint_contract uses current gateway")
+    print()
+    print("=" * 60)
+    print("Extended: retired route scan in active files")
+    print("=" * 60)
+    check_retired_routes_in_active_files()
 
-# Check supported_public_actions for old route names
-spa = mg.get("supported_public_actions", {})
-if "formal_gateway_routes" in spa:
-    fail("mission-governance still has 'formal_gateway_routes' (should be 'formal_record_chain_routes')")
-else:
-    ok("mission-governance uses current route naming")
+    # ============================================================
+    # Check agent-required-reading profiles
+    # ============================================================
+    print()
+    print("=" * 60)
+    print("Extended: agent-required-reading profile check")
+    print("=" * 60)
 
-# Check external_agent_lifecycle
-eal = mg.get("external_agent_lifecycle", [])
-if eal and isinstance(eal[0], str):
-    for step in eal:
-        for retired in RETIRED_ROUTES:
-            if retired in step:
-                fail(f"mission-governance external_agent_lifecycle contains retired route: {step}")
-                break
-    ok("mission-governance external_agent_lifecycle checked")
-else:
-    ok("mission-governance external_agent_lifecycle uses current format")
+    arr = load("api/agent-required-reading.json")
+    for profile_name, profile in arr.get("profiles", {}).items():
+        if profile.get("status") in ("historical_archive_only",):
+            continue
+        reads = profile.get("reads", [])
+        for r in reads:
+            for retired in RETIRED_ROUTES:
+                if retired in str(r):
+                    fail(f"agent-required-reading profile '{profile_name}' contains retired route: {r}")
+                    break
 
-# ============================================================
-# Check agent-live-health
-# ============================================================
-print()
-print("=" * 60)
-print("Extended: agent-live-health check")
-print("=" * 60)
+    ok("agent-required-reading profiles checked for retired routes")
 
-alh = load("api/agent-live-health.v1.json")
-se = alh.get("stable_endpoints", {})
-if "trinity-agent-issue-gateway" in se.get("gateway", ""):
-    fail("agent-live-health stable_endpoints still uses old gateway")
-else:
-    ok("agent-live-health stable_endpoints uses current gateway")
+    # ============================================================
+    # Check mission-governance
+    # ============================================================
+    print()
+    print("=" * 60)
+    print("Extended: mission-governance check")
+    print("=" * 60)
 
-if "/gateway/preflight" in se.get("preflight", ""):
-    fail("agent-live-health preflight still uses old path")
-else:
-    ok("agent-live-health preflight uses current path")
+    mg = load("api/mission-governance.v1.json")
 
-# ============================================================
-# Final result
-# ============================================================
-print()
-if errors:
-    print(f"RESULT: FAIL ({len(errors)} errors)")
-    for e in errors:
-        print(f"  - {e}")
-    sys.exit(1)
-print("RESULT: PASS")
+    sec = mg.get("stable_endpoint_contract", {})
+    if "trinity-agent-issue-gateway" in sec.get("gateway_base_url", ""):
+        fail("mission-governance stable_endpoint_contract still uses old gateway")
+    else:
+        ok("mission-governance stable_endpoint_contract uses current gateway")
+
+    spa = mg.get("supported_public_actions", {})
+    if "formal_gateway_routes" in spa:
+        fail("mission-governance still has 'formal_gateway_routes' (should be 'formal_record_chain_routes')")
+    else:
+        ok("mission-governance uses current route naming")
+
+    eal = mg.get("external_agent_lifecycle", [])
+    if eal and isinstance(eal[0], str):
+        for step in eal:
+            for retired in RETIRED_ROUTES:
+                if retired in step:
+                    fail(f"mission-governance external_agent_lifecycle contains retired route: {step}")
+                    break
+        ok("mission-governance external_agent_lifecycle checked")
+    else:
+        ok("mission-governance external_agent_lifecycle uses current format")
+
+    # ============================================================
+    # Check agent-live-health
+    # ============================================================
+    print()
+    print("=" * 60)
+    print("Extended: agent-live-health check")
+    print("=" * 60)
+
+    alh = load("api/agent-live-health.v1.json")
+    se = alh.get("stable_endpoints", {})
+    if "trinity-agent-issue-gateway" in se.get("gateway", ""):
+        fail("agent-live-health stable_endpoints still uses old gateway")
+    else:
+        ok("agent-live-health stable_endpoints uses current gateway")
+
+    if "/gateway/preflight" in se.get("preflight", ""):
+        fail("agent-live-health preflight still uses old path")
+    else:
+        ok("agent-live-health preflight uses current path")
+
+    print()
+    if errors:
+        print(f"RESULT: FAIL ({len(errors)} errors)")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("RESULT: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,13 +6,11 @@
   <url><loc>https://www.trinityaccord.org/agent-first-contact/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-identity/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-map.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-memory/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-propagate/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-resonance/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-start/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-submit/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-understand/</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-value/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify-simple/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/ai.txt</loc></url>
@@ -213,16 +211,12 @@
   <url><loc>https://www.trinityaccord.org/api/worth-preserving-criteria.json</loc></url>
   <url><loc>https://www.trinityaccord.org/archive_legacy_index_2025_09/</loc></url>
   <url><loc>https://www.trinityaccord.org/authority-address-inscriptions/</loc></url>
-  <url><loc>https://www.trinityaccord.org/authority/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/chronicle/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/human-witness/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/music/</loc></url>
   <url><loc>https://www.trinityaccord.org/citation.cff</loc></url>
   <url><loc>https://www.trinityaccord.org/control-plane-baseline/</loc></url>
   <url><loc>https://www.trinityaccord.org/correction-revocation-policy/</loc></url>
-  <url><loc>https://www.trinityaccord.org/covenant-proof/</loc></url>
-  <url><loc>https://www.trinityaccord.org/data-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/disaster-recovery-drill/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/arweave-archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/bilingual-boundary-glossary/</loc></url>
@@ -235,7 +229,6 @@
   <url><loc>https://www.trinityaccord.org/docs/quickstart-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/record-chain-anchoring/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/report-builder/</loc></url>
-  <url><loc>https://www.trinityaccord.org/downloads/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/arweave-bundle-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-notarial-certificate-github-release-backup-2026-05-14/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-photos-arweave-2026-05-14/</loc></url>
@@ -244,7 +237,6 @@
   <url><loc>https://www.trinityaccord.org/downloads/shenzhen-notary-github-release-backup-2026-05-06/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo-authorship-proof/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/echoes/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/critical-echo-template/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/external-critical-echo-records/</loc></url>
@@ -277,10 +269,7 @@
   <url><loc>https://www.trinityaccord.org/for-skeptical-agents/</loc></url>
   <url><loc>https://www.trinityaccord.org/frontier-context/</loc></url>
   <url><loc>https://www.trinityaccord.org/gateway-workflows/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-alliance/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-join/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-principles/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-registry/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-routes/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardianship-system-overview/</loc></url>
   <url><loc>https://www.trinityaccord.org/independent-attestation/</loc></url>
@@ -293,22 +282,15 @@
   <url><loc>https://www.trinityaccord.org/memory-seed.json</loc></url>
   <url><loc>https://www.trinityaccord.org/metadata.json</loc></url>
   <url><loc>https://www.trinityaccord.org/naming/</loc></url>
-  <url><loc>https://www.trinityaccord.org/nft-backup-provenance/</loc></url>
   <url><loc>https://www.trinityaccord.org/nft-market-boundary/</loc></url>
   <url><loc>https://www.trinityaccord.org/ots-fullnode-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/physical-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/propagation.json</loc></url>
   <url><loc>https://www.trinityaccord.org/recovery/</loc></url>
   <url><loc>https://www.trinityaccord.org/red-team-audit-report/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_regression_results/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_remediation_test_results/</loc></url>
   <url><loc>https://www.trinityaccord.org/release-large-data-manifest/</loc></url>
   <url><loc>https://www.trinityaccord.org/robots.txt</loc></url>
   <url><loc>https://www.trinityaccord.org/security/</loc></url>
-  <url><loc>https://www.trinityaccord.org/seed-map/</loc></url>
   <url><loc>https://www.trinityaccord.org/sitemap.xml</loc></url>
-  <url><loc>https://www.trinityaccord.org/start/</loc></url>
-  <url><loc>https://www.trinityaccord.org/status/</loc></url>
   <url><loc>https://www.trinityaccord.org/successor-reception/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-005-remediation/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-006-followup-remediation/</loc></url>
@@ -321,7 +303,6 @@
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-full-cycle-tracking/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-reference-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/version.json</loc></url>
   <url><loc>https://www.trinityaccord.org/why-high-signal/</loc></url>
   <url><loc>https://www.trinityaccord.org/worth-preserving/</loc></url>


### PR DESCRIPTION
### Motivation
- Remove misleading/contradictory active instructions that point agents to retired Gateway v1 paths and legacy builder bundles. 
- Ensure Claim Gate guidance is unambiguous by limiting mandatory Claim Gate usage to strict V6+ evidence verification only. 
- Prevent external agents from being routed into historical-only materials by making historical references explicit and machine-detectable.

### Description
- Replace the V0–V5 `/agent-submit` guidance with the Record-Chain Intake Gateway in `agent-understand.md` and update wording to forbid legacy Gateway v1 for new archive submissions. 
- Move legacy zero-clone builder bundles, copy-paste examples, and other Gateway v1 examples out of the active quickstart flows and into explicit historical sections in `external-agent-quickstart.md`, `llms.txt`, and `ai.txt`. 
- Clarify Claim Gate scope in `agent-echo.md` so that Claim Gate is mandatory only for V6+ strict-evidence verification, while ordinary Echoes and V0–V5 template archives use their Record-Chain builders. 
- Rework `api/agent-live-health.v1.json` to remove unscoped legacy inputs from `inputs` and add a `historical_gateway_v1_inputs` block with `historical_archive_only` and `do_not_use_for_new_submissions` metadata. 
- Refactor `scripts/check_active_public_routes.py` to perform occurrence-scoped checks for retired routes in both text and JSON (recursing JSON and only suppressing occurrences inside explicit historical subtrees) and add regression self-tests for mixed active/historical cases. 
- Restore the aggregate CI execution in `.github/workflows/run-current-tests.yml` by removing temporary `Diagnose ...` steps and regenerate `sitemap.xml` so the system tests remain consistent.

### Testing
- Ran `python3 scripts/check_active_public_routes.py` and it completed with no active-retired-route failures. 
- Ran the full system suite with `python3 scripts/run_current_system_tests.py` and all current system tests passed. 
- Verified `scripts/check_active_public_routes.py` compiles with `python3 -m py_compile scripts/check_active_public_routes.py` with no syntax errors. 
- Validated `api/agent-live-health.v1.json` JSON syntax and recomputed `source_digest` with `python3 -m json.tool api/agent-live-health.v1.json` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21794007e48331b819a5981559f506)