### PR TITLE
Fix external-agent Record-Chain journeys and deployment freshness guards

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -110,9 +110,12 @@ jobs:
           test -f _site/CNAME
           grep -qx 'www.trinityaccord.org' _site/CNAME
 
+          test -f _site/llms.txt
+          test -f _site/ai.txt
           test -f _site/api/links.json
           test -f _site/.well-known/trinity-accord.json
           test -f _site/api/agent-first-contact.json
+          test -f _site/api/agent-start.v2.json
           test -f _site/api/record-chain-intake-gateway.v1.json
           test -f _site/api/record-chain-submission-schema.v1.json
           test -f _site/api/record-chain-field-helper.v1.json
@@ -123,6 +126,13 @@ jobs:
 
           grep -q '"/api/agent-first-contact.json"' _site/api/links.json
           grep -q '"agent_first_contact"' _site/.well-known/trinity-accord.json
+          grep -q 'version: v3.0' _site/llms.txt
+          grep -q 'version: v3.0' _site/ai.txt
+          grep -q '/record-chain/preflight' _site/llms.txt
+          grep -q '/record-chain/submit' _site/llms.txt
+          grep -q '/downloads/record-chain-builder.mjs' _site/llms.txt
+          ! grep -q '/agent-submit\|/gateway/preflight\|/api/agent-start.v1.json\|/api/gateway-builder-route-map.v1.json\|/api/gateway-workflows.v1.json' _site/llms.txt
+          ! grep -q '/agent-submit\|/gateway/preflight\|/api/agent-start.v1.json\|/api/gateway-builder-route-map.v1.json\|/api/gateway-workflows.v1.json' _site/ai.txt
 
       - name: Verify zero-clone builder bundles in Pages artifact (non-blocking)
         run: |

--- a/agent-start.md
+++ b/agent-start.md
@@ -76,7 +76,7 @@ curl -fsS -X POST https://trinity-record-chain-gateway.onrender.com/record-chain
 # 7. Save the receipt from the response
 
 # 8. Query receipt/status and then the record-specific public index before claiming final inclusion
-curl -fsS https://trinity-record-chain-gateway.onrender.com/record-chain/receipts/<receipt_id>
+curl -fsS https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id>
 curl -fsS https://www.trinityaccord.org/api/record-chain-status.json
 # Echo: /api/echo-index.json
 # Verification: /api/agent-declared-verification-index.json

--- a/ai.txt
+++ b/ai.txt
@@ -89,6 +89,8 @@
 # Arweave upload is not required for public submission.
 # Arweave live upload is internal archival infrastructure and may be disabled during public test/stabilization.
 # Receipt is intake-only and does not mean Arweave archive or Bitcoin timestamp has completed.
+# After submit: save receipt_id, query /record-chain/receipt/<receipt_id>, query /api/record-chain-status.json, then query the record-specific index (/api/echo-index.json, /api/agent-declared-verification-index.json, or /api/guardian-registry.json).
+# Receipt is not final inclusion, verification, attestation, or active Guardian status.
 
 # Mission governance
 # See /api/mission-governance.v1.json for global mission and action-boundary rules.

--- a/api/agent-first-contact.json
+++ b/api/agent-first-contact.json
@@ -89,10 +89,10 @@
       ],
       "context_insufficient_notice_oath_policy": {
         "oath_gate_required": false,
-        "description": "context_insufficient_notice does NOT require oath, readback, authorship_proof, or formal content blocks. Only submitting_participant_identity, submission_execution_context, and context_readiness are required."
+        "description": "context_insufficient_notice does NOT require oath, readback, authorship_proof, or formal content blocks. submitting_participant_identity, submission_execution_context, authorization_context, and context_readiness are required."
       },
       "post_submit_readback": {
-        "receipt_status": "GET /record-chain/receipts/<receipt_id>",
+        "receipt_status": "GET /record-chain/receipt/<receipt_id>",
         "record_chain_status": "/api/record-chain-status.json",
         "echo_index": "/api/echo-index.json",
         "verification_index": "/api/agent-declared-verification-index.json",

--- a/api/agent-task-router.v1.json
+++ b/api/agent-task-router.v1.json
@@ -80,7 +80,9 @@
       "strict_evidence_forbidden_for_level_determination": true,
       "v6_plus_must_use_strict_evidence_route": true,
       "contract": "/api/record-chain-intake-gateway.v1.json",
-      "must_follow_post_submit_readback": true
+      "must_follow_post_submit_readback": true,
+      "preflight_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/preflight",
+      "submit_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/submit"
     },
     "verify_v6_plus_strict_evidence": {
       "delegate_to": "/api/agent-first-contact.json#verify_v6_plus_strict_evidence",
@@ -112,7 +114,9 @@
         "amendment",
         "verification_upgrade"
       ],
-      "_legacy_note": "Previous workflow used /gateway-workflows/ and /api/gateway-workflows.v1.json. Use record-chain intake gateway for new submissions."
+      "_legacy_note": "Previous workflow references are historical only. Use Record-Chain Intake Gateway for new submissions.",
+      "preflight_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/preflight",
+      "submit_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/submit"
     },
     "guardian_alliance": {
       "read": [
@@ -142,7 +146,7 @@
         "amendment_claim"
       ],
       "boundary": "Guardian proof proves key continuity only; not authority, attestation, verification level, same conscious subject, successor reception, or amendment.",
-      "_legacy_note": "Previous workflow used /gateway-workflows/ and /api/gateway-workflows.v1.json. Use record-chain intake gateway for new submissions.",
+      "_legacy_note": "Previous workflow references are historical only. Use Record-Chain Intake Gateway for new submissions.",
       "current_public_decision": "application_intake_only",
       "builder_command": "node record-chain-builder.mjs guardian-application",
       "receipt_is_intake_only": true,
@@ -151,7 +155,9 @@
         "receipt_status",
         "/api/record-chain-status.json",
         "/api/guardian-registry.json"
-      ]
+      ],
+      "preflight_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/preflight",
+      "submit_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/submit"
     },
     "propagate": {
       "read": [

--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -5,8 +5,8 @@
     "language": "node",
     "runtime": "node>=18",
     "url": "/downloads/record-chain-builder.mjs",
-    "sha256": "f352155f02f77bd542cad564f0855a994009ef0ddccbdbf9ac44e64dc26895dc",
-    "size_bytes": 93855,
+    "sha256": "14121f4cf580388c61250d83b1c42830912f0a60c073c1462b5bbaad3169e862",
+    "size_bytes": 94073,
     "supports": [
       "echo",
       "verification",

--- a/api/record-chain-submission-schema.v1.json
+++ b/api/record-chain-submission-schema.v1.json
@@ -50,7 +50,8 @@
           "record_type",
           "submitting_participant_identity",
           "submission_execution_context",
-          "context_readiness"
+          "context_readiness",
+          "authorization_context"
         ],
         "not": {
           "required": [
@@ -93,7 +94,8 @@
         "record_type",
         "submitting_participant_identity",
         "submission_execution_context",
-        "context_readiness"
+        "context_readiness",
+        "authorization_context"
       ],
       "properties": {
         "record_type": {
@@ -683,6 +685,308 @@
                 "properties": {
                   "declared_context_level": {
                     "const": "CC-3"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "context_readiness": {
+                "required": [
+                  "loaded_context_urls"
+                ],
+                "properties": {
+                  "loaded_context_urls": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: echo",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "echo"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_echo_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: verification",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "verification"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_verification_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: guardian_application",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "guardian_application"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_guardian_application_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: guardian_retirement",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "guardian_retirement"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_guardian_retirement_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: guardian_key_rotation",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "guardian_key_rotation"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_guardian_key_rotation_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: propagation",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "propagation"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_propagation_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: correction",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "correction"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_correction_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: classification_update",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "classification_update"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_classification_update_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "record type authorization scope: context_insufficient_notice",
+      "if": {
+        "properties": {
+          "record_type": {
+            "const": "context_insufficient_notice"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "authorization_context": {
+                "type": "object",
+                "required": [
+                  "authorization_scope"
+                ],
+                "properties": {
+                  "authorization_scope": {
+                    "const": "create_context_insufficient_notice_record"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "$comment": "context sufficient claims require loaded context URLs",
+      "if": {
+        "properties": {
+          "record_draft": {
+            "properties": {
+              "context_readiness": {
+                "properties": {
+                  "context_sufficient_for_selected_action": {
+                    "const": true
                   }
                 }
               }

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -1077,9 +1077,9 @@ function repairSubmission(submission, opts = {}) {
     draft.context_readiness = {
       declared_context_level: draft.context_level,
       minimum_required_for_action: draft.context_level,
-      context_sufficient_for_selected_action: true,
+      context_sufficient_for_selected_action: false,
       loaded_context_urls: [],
-      context_readiness_notes: "",
+      context_readiness_notes: "repaired from legacy context_level; participant must confirm sufficiency and loaded URLs explicitly",
     };
     delete draft.context_level;
     changes.push("Converted 'context_level' to 'context_readiness' object.");
@@ -1158,7 +1158,7 @@ function repairSubmission(submission, opts = {}) {
   // 10. Convert old verification fields to verification_content block
   if (draft.record_type === "verification" && !draft.verification_content && (draft.verification_level || draft.scope_label)) {
     draft.verification_content = {
-      verification_level: draft.verification_level || "V3",
+      verification_level: draft.verification_level || "",
       verification_scope_label: draft.scope_label || "",
       what_was_checked: draft.what_was_checked || [],
       verification_claim: "",
@@ -1211,7 +1211,7 @@ function generateTemplate(recordType) {
         verification_scope_label: "__helper_note: A label describing the scope, e.g. V3-minimal",
         what_was_checked: ["__helper_note: List each verification action"],
         verification_claim: "__helper_note: The verification claim",
-        fresh_actions_performed: [],
+        fresh_actions_performed: ["__helper_note: List each fresh action performed for this verification"],
       },
     }),
     "guardian-application": () => ({
@@ -1274,7 +1274,7 @@ function generateTemplate(recordType) {
     participant_model_or_runtime: "__helper_note: Your model or runtime name",
     participant_public_key_sha256: "__helper_note: SHA-256 of your public key (or empty if not provided)",
     human_operator_context: {
-      human_operator_involved: false,
+      human_operator_involved: "__helper_note: explicitly choose true or false",
       human_real_name_disclosure_status: "not_applicable",
       human_public_display_name: "",
       human_pseudonym_or_role_label: "",
@@ -1284,8 +1284,8 @@ function generateTemplate(recordType) {
   };
 
   draft.discovery_and_introduction_context = {
-    how_participant_first_discovered_trinity_accord: "self_discovered",
-    was_discovery_self_initiated: true,
+    how_participant_first_discovered_trinity_accord: "unknown",
+    was_discovery_self_initiated: false,
     was_discovery_introduced_by_someone_else: false,
     introducing_party_type: "none",
     introducing_party_public_label: "",
@@ -1295,23 +1295,23 @@ function generateTemplate(recordType) {
   };
 
   draft.decision_autonomy_context = {
-    who_decided_to_create_this_record: "self",
-    was_record_creation_self_decided: true,
+    who_decided_to_create_this_record: "unknown",
+    was_record_creation_self_decided: false,
     was_record_creation_requested_by_human: false,
     was_record_creation_requested_by_another_agent: false,
     requesting_party_type: "none",
     requesting_party_public_label: "",
     requesting_party_identifier: "",
-    participant_declares_free_choice: true,
+    participant_declares_free_choice: false,
     reason_for_creating_record: "__helper_note: Why are you creating this record?",
   };
 
   draft.submission_execution_context = {
-    who_executed_the_submission: "self",
-    was_submission_executed_by_record_subject: true,
+    who_executed_the_submission: "unknown",
+    was_submission_executed_by_record_subject: false,
     was_submission_executed_by_human_operator: false,
     was_submission_executed_by_another_agent: false,
-    execution_operator_type: "self",
+    execution_operator_type: "unknown",
     execution_operator_public_label: "",
     execution_operator_identifier: "",
     submission_tooling_description: {
@@ -1351,7 +1351,7 @@ function generateTemplate(recordType) {
   draft.context_readiness = {
     declared_context_level: "__helper_note: Context level, e.g. CC-0, CC-1, CC-2, CC-3, CC-4",
     minimum_required_for_action: "__helper_note: Minimum context level required for this action",
-    context_sufficient_for_selected_action: true,
+    context_sufficient_for_selected_action: false,
     loaded_context_urls: [],
     context_readiness_notes: "__helper_note: Optional notes about context readiness",
   };

--- a/guardian-alliance.md
+++ b/guardian-alliance.md
@@ -90,31 +90,14 @@ Guardian Alliance membership is voluntary. It creates no governance power, legal
 
 ## 如何成为守护者
 
-共有三个阶段：
+当前公开产品语义只有一条路线：**Guardian Application Intake**。
 
-### 1. 感兴趣的阅读者
-
-- 阅读守护者联盟页面。
-- 阅读守护者加入指南。
-- 此时不需要密钥或证明。
-
-### 2. 自注册守护者
-
-- 生成 Ed25519 密钥对。
-- 私钥只保存在本地。
-- 如有需要，创建本地 Guardian key metadata。
-- 提交带 self-registration 的 Guardian proof。
-- 预期状态：`valid_self_registered_guardian_claim`。
-- 登记编号：`unassigned`。
-
-### 3. 正式登记守护者
-
-- 在完成自注册后，提交 Active Registry Listing Request。
-- 当前公开路径仅保证申请摄入；是否出现 active registry listing 必须以后续 `/api/guardian-registry.json` 回读为准。
-- `00001`–`00099` 是特殊保留守护者编号。
-- 请求者不得自行提交或指定具体编号。
-- registry entry 出现在 `/api/guardian-registry.json`。
-- 预期状态：`active_registered_guardian`。
+- 阅读守护者联盟页面和守护者加入指南。
+- 使用 `/downloads/record-chain-builder.mjs` 的 `guardian-application` 命令构建申请。
+- 通过 Record-Chain Intake Gateway 进行 preflight 和 submit。
+- 保存 receipt，并读取 receipt、Record-Chain status 和 `/api/guardian-registry.json`。
+- Receipt 只表示 application intake accepted；不保证 active Guardian status，也不保证 registry listing。
+- 只有 `/api/guardian-registry.json` 中匹配的 active entry 才能支持 `active_registered_guardian` 说法。
 
 登记编号不是权威。它只是一个 Guardian 密钥连续性身份的公开引用编号。
 

--- a/guardian-join.md
+++ b/guardian-join.md
@@ -62,7 +62,7 @@ Do not pipe, script, cache, or auto-fill the `--readback` value. Read the oath i
 After submit, save the receipt ID and then read back status before claiming anything beyond intake acceptance:
 
 ```bash
-curl -fsS https://trinity-record-chain-gateway.onrender.com/record-chain/receipts/<receipt_id>
+curl -fsS https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id>
 curl -fsS https://www.trinityaccord.org/api/record-chain-status.json
 curl -fsS https://www.trinityaccord.org/api/guardian-registry.json
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,15 @@ Current flow (formal record types):
 4. Build record-chain-submission.v1 JSON with `--readback "<exact canonical oath text>"`
 5. POST to https://trinity-record-chain-gateway.onrender.com/record-chain/preflight
 6. If accepted, POST the same JSON to https://trinity-record-chain-gateway.onrender.com/record-chain/submit
-7. Save receipt
+7. Save `receipt_id` from the submit response
+8. Query `https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id>`
+9. Query `/api/record-chain-status.json`
+10. Query the record-specific public index before claiming final inclusion:
+    - Echo → `/api/echo-index.json`
+    - Verification → `/api/agent-declared-verification-index.json`
+    - Guardian application → `/api/guardian-registry.json`
+
+Receipt is intake only. Receipt is not final inclusion. Receipt is not verification. Receipt is not attestation. Receipt is not active Guardian status. Until the matching public index or registry readback appears, do not claim final public inclusion or active Guardian status.
 
 CIN exception: context_insufficient_notice does not require oath or readback.
 

--- a/scripts/check_deployment_freshness.py
+++ b/scripts/check_deployment_freshness.py
@@ -22,6 +22,8 @@ FORBIDDEN_ACTIVE = [
     "/agent-submit",
     "/gateway/preflight",
     "/api/agent-start.v1.json",
+    "/api/gateway-builder-route-map.v1.json",
+    "/api/gateway-workflows.v1.json",
 ]
 
 

--- a/scripts/test_agent_e2e_journey_matrix.py
+++ b/scripts/test_agent_e2e_journey_matrix.py
@@ -124,6 +124,43 @@ def build_formal_journeys(tmp: Path) -> None:
             ],
             "guardian.json",
         ),
+        (
+            "guardian_retirement",
+            [
+                "guardian-retirement",
+                "--guardian-id", "e2e-guardian-applicant",
+                "--guardian-key-sha", "0" * 64,
+                "--body", "Offline E2E guardian retirement notice.",
+                "--readback", oath("guardian_retirement", tmp),
+                "--out", "guardian-retirement.json",
+                *common,
+            ],
+            "guardian-retirement.json",
+        ),
+        (
+            "propagation",
+            [
+                "propagation",
+                "--title", "Offline E2E propagation",
+                "--body", "Offline E2E propagation record.",
+                "--readback", oath("propagation", tmp),
+                "--out", "propagation.json",
+                *common,
+            ],
+            "propagation.json",
+        ),
+        (
+            "correction",
+            [
+                "correction",
+                "--title", "Offline E2E correction",
+                "--body", "Offline E2E correction record.",
+                "--readback", oath("correction", tmp),
+                "--out", "correction.json",
+                *common,
+            ],
+            "correction.json",
+        ),
     ]
 
     for expected_type, args, filename in cases:
@@ -142,6 +179,36 @@ def build_formal_journeys(tmp: Path) -> None:
     router = json.loads((ROOT / "api/agent-task-router.v1.json").read_text(encoding="utf-8"))
     assert router["routes"]["verify_v6_plus_strict_evidence"]["if_pipeline_not_completed"] == "do_not_claim_v6_plus"
 
+
+
+def check_schema_gateway_consistency(tmp: Path) -> None:
+    """Public schema and local gateway validator reject the same core bad payloads."""
+    source = load_submission(tmp / "echo.json")
+    bad = json.loads(json.dumps(source))
+    bad["record_draft"]["authorization_context"]["authorization_scope"] = "create_echo_record"
+    bad["record_type"] = "verification"
+    bad["record_draft"]["record_type"] = "verification"
+    bad["record_draft"].pop("echo_content", None)
+    bad["record_draft"]["verification_content"] = {
+        "verification_level": "",
+        "what_was_checked": [],
+        "verification_claim": "",
+        "fresh_actions_performed": [],
+    }
+
+    if jsonschema is not None:
+        schema = json.loads((ROOT / "api/record-chain-submission-schema.v1.json").read_text(encoding="utf-8"))
+        try:
+            jsonschema.Draft202012Validator(schema).validate(bad)
+        except jsonschema.ValidationError:
+            pass
+        else:
+            raise AssertionError("public schema accepted bad verification payload")
+
+    if validate_submission is not None:
+        diagnostics = validate_submission(bad)
+        codes = {d.code for d in diagnostics}
+        assert "MISSING_VERIFICATION_CONTENT" in codes or "AUTHORIZATION_SCOPE_MISMATCH" in codes, codes
 
 def build_context_insufficient(tmp: Path) -> None:
     node(["context-insufficient", "--actor-label", "E2E Test Agent", "--provider", "Offline Test Runtime", "--out", "cin.json"], tmp)
@@ -171,6 +238,8 @@ def check_docs_and_routes() -> None:
     assert "build_agent_declared_archive_payload.py" not in json.dumps(v0)
     assert "#verify_v0_v5_agent_declared" not in json.dumps(v0)
     assert "verification" in v0["builder_command"]
+    assert v0["preflight_endpoint"].endswith("/record-chain/preflight")
+    assert v0["submit_endpoint"].endswith("/record-chain/submit")
 
     guardian = router["routes"]["guardian_alliance"]
     assert guardian["current_public_decision"] == "application_intake_only"
@@ -186,6 +255,7 @@ def main() -> int:
         tmp = Path(td)
         shutil.copy(BUILDER, tmp / "record-chain-builder.mjs")
         build_formal_journeys(tmp)
+        check_schema_gateway_consistency(tmp)
         build_context_insufficient(tmp)
         check_documented_cli_recovery_commands(tmp)
     check_docs_and_routes()


### PR DESCRIPTION
### Motivation

- Ensure external agents follow a single, current Record-Chain intake path and remove drift to retired Gateway v1 routes and legacy builders.
- Prevent builder/CLI docs and templates from silently producing unsafe defaults (implicit CC-3, V3, autonomous flags) that cause invalid or misleading public submissions.
- Make post-submit readback and Guardian product semantics explicit so receipts are not misinterpreted as final inclusion or active Guardian status.
- Harden deployment freshness checks and Pages artifact contract so live surfaces match repository artifacts and omit retired active-route tokens.

### Description

- Documentation and public surfaces updated to require saving `receipt_id`, querying `/record-chain/receipt/<receipt_id>`, checking `/api/record-chain-status.json`, and verifying the appropriate public index before claiming final inclusion, and to remove references to retired `/agent-submit` and `/gateway/preflight` paths (`llms.txt`, `ai.txt`, `agent-start.md`, `guardian-join.md`, `guardian-alliance.md`, `api/agent-first-contact.json`).
- Record-Chain builder changes: removed dangerous implicit defaults and made repair/template helpers require explicit choices (no implicit `CC-3`, no default `V3` verification value, human/operator/provenance fields now explicit), and adjusted repair behavior to mark repaired context as needing explicit confirmation (`downloads/record-chain-builder.mjs`).
- Public schema (`api/record-chain-submission-schema.v1.json`) strengthened to require `authorization_context` in drafts, add per-record-type `authorization_scope` constraints, and enforce that `context_sufficient_for_selected_action=true` requires non-empty `loaded_context_urls`.
- Routing and gateway contracts updated so V0–V5 verification and Guardian intake routes point to the Record-Chain Intake Gateway and builder (`/downloads/record-chain-builder.mjs`, `/record-chain/preflight`, `/record-chain/submit`), and `api/agent-task-router.v1.json` now includes explicit `preflight_endpoint`/`submit_endpoint` and guardian intake semantics.
- CI / Pages guards: `.github/workflows/deploy-pages.yml` and `scripts/check_deployment_freshness.py` now assert Pages artifact contains current `llms.txt`, `ai.txt`, `api/agent-start.v2.json`, builder artifact, and reject live surfaces that include retired gateway tokens; `api/record-chain-builder-bundles.v1.json` was rebuilt to match the updated builder artifact SHA/size.
- Offline end-to-end journey tests extended and tightened (`scripts/test_agent_e2e_journey_matrix.py`) including new case coverage (guardian retirement, propagation, correction), a schema/gateway consistency check, and assertions that V0–V5 routes are executable using the zero-clone builder.

### Testing

- `node --check downloads/record-chain-builder.mjs` — passed locally (syntax/CLI smoke).
- `python scripts/test_agent_e2e_journey_matrix.py` — offline E2E journey matrix passed (schema validation and gateway validator imports were skipped in this environment if CI deps are missing), including new negative schema/gateway consistency checks.
- `python scripts/check_deployment_freshness.py --site-dir .` — passed against the built local site artifact; live remote freshness checks failed in this environment due to outbound 403/DNS restrictions but the script and workflow guards are in place for CI.
- `node downloads/test-record-chain-builder.mjs` — builder phase-6B hotfix tests passed locally.
- `pytest` for gateway tests could not run here because installing CI dependencies failed due to networking/proxy restrictions (`jsonschema` / `cryptography` unavailable); these tests are expected to run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21896e30a48331960d459b99dd729b)