### PR TITLE
feat: Arweave paid canary cost gate, readback verifier & safety tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,9 @@
   "dependencies": {
     "@noble/hashes": "2.2.0",
     "arweave": "1.15.7"
+  },
+  "scripts": {
+    "test:arweave-cost-gate": "node scripts/test_arweave_cost_gate_safety.mjs",
+    "test:arweave-readback": "node scripts/test_arweave_readback_hash_fixture.mjs"
   }
 }

--- a/scripts/arweave_cost_gate.mjs
+++ b/scripts/arweave_cost_gate.mjs
@@ -1,0 +1,698 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import Arweave from "arweave";
+
+const CURRENT_TRINITY_ARWEAVE_OWNER =
+  "r1EdzCQ9E7CaAOEywI5netR6EcSopNOa08oi2Coz68s";
+
+const OLD_TRINITY_ARWEAVE_OWNER =
+  "8Y8GRimuESN_u8tJihCd5nywb-X-lJ_2vWqFAfHeQIE";
+
+const DEFAULT_GATEWAY = "https://arweave.net";
+const DEFAULT_MAX_UPLOAD_USD = 0.10;
+const DEFAULT_SAFETY_MULTIPLIER = 1.20;
+const WINSTON_PER_AR = 1_000_000_000_000n;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sha256(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function fail(message, extra = {}) {
+  const err = new Error(message);
+  err.extra = extra;
+  throw err;
+}
+
+function parseBoolean(value) {
+  return String(value || "").toLowerCase() === "true";
+}
+
+function parseArgs(argv) {
+  const args = {
+    payloadFile: null,
+    recordType: null,
+    runId: process.env.E2E_RUN_ID || null,
+    logDir: process.env.E2E_LOG_DIR || null,
+
+    mode: process.env.ARWEAVE_UPLOAD_MODE || "dry_run",
+    expectedOwner:
+      process.env.EXPECTED_ARWEAVE_OWNER || CURRENT_TRINITY_ARWEAVE_OWNER,
+
+    gatewayUrl: process.env.ARWEAVE_GATEWAY_URL || DEFAULT_GATEWAY,
+
+    arUsdPriceSourceUrl:
+      process.env.AR_USD_PRICE_SOURCE_URL ||
+      "https://api.coingecko.com/api/v3/simple/price?ids=arweave&vs_currencies=usd",
+
+    arUsdPriceOverride: process.env.AR_USD_PRICE_OVERRIDE || null,
+    uploadPriceWinstonOverride:
+      process.env.ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE || null,
+
+    allowPriceOverrideInProduction: parseBoolean(
+      process.env.ALLOW_ARWEAVE_PRICE_OVERRIDE_IN_PRODUCTION
+    ),
+
+    maxUploadUsd: Number(
+      process.env.ARWEAVE_MAX_UPLOAD_USD || DEFAULT_MAX_UPLOAD_USD
+    ),
+
+    safetyMultiplier: Number(
+      process.env.ARWEAVE_SAFETY_MULTIPLIER || DEFAULT_SAFETY_MULTIPLIER
+    ),
+
+    jwkPath: process.env.ARWEAVE_JWK_PATH || null,
+    walletAddress: process.env.ARWEAVE_WALLET_ADDRESS || null,
+    allowPaid: parseBoolean(process.env.ALLOW_PAID_ARWEAVE_CANARY),
+    contentType: "application/json",
+    appName: "Trinity-Accord-E2E-Canary",
+    skipReadback: false
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const next = argv[i + 1];
+
+    if (key === "--payload-file") {
+      args.payloadFile = next;
+      i++;
+    } else if (key === "--record-type") {
+      args.recordType = next;
+      i++;
+    } else if (key === "--run-id") {
+      args.runId = next;
+      i++;
+    } else if (key === "--log-dir") {
+      args.logDir = next;
+      i++;
+    } else if (key === "--mode") {
+      args.mode = next;
+      i++;
+    } else if (key === "--expected-owner") {
+      args.expectedOwner = next;
+      i++;
+    } else if (key === "--gateway-url") {
+      args.gatewayUrl = next;
+      i++;
+    } else if (key === "--max-upload-usd") {
+      args.maxUploadUsd = Number(next);
+      i++;
+    } else if (key === "--safety-multiplier") {
+      args.safetyMultiplier = Number(next);
+      i++;
+    } else if (key === "--jwk-path") {
+      args.jwkPath = next;
+      i++;
+    } else if (key === "--wallet-address") {
+      args.walletAddress = next;
+      i++;
+    } else if (key === "--content-type") {
+      args.contentType = next;
+      i++;
+    } else if (key === "--skip-readback") {
+      args.skipReadback = true;
+    } else if (key === "--help" || key === "-h") {
+      printHelpAndExit();
+    } else {
+      fail(`Unknown argument: ${key}`);
+    }
+  }
+
+  if (!args.payloadFile) fail("Missing --payload-file");
+  if (!args.recordType) fail("Missing --record-type");
+  if (!args.runId) fail("Missing --run-id or E2E_RUN_ID");
+  if (!args.logDir) fail("Missing --log-dir or E2E_LOG_DIR");
+
+  if (!["dry_run", "staging", "production"].includes(args.mode)) {
+    fail("mode must be dry_run, staging, or production");
+  }
+
+  if (!Number.isFinite(args.maxUploadUsd) || args.maxUploadUsd <= 0) {
+    fail("ARWEAVE_MAX_UPLOAD_USD must be a positive number");
+  }
+
+  if (!Number.isFinite(args.safetyMultiplier) || args.safetyMultiplier < 1) {
+    fail("ARWEAVE_SAFETY_MULTIPLIER must be >= 1");
+  }
+
+  args.effectiveMaxUploadUsd = Math.min(
+    args.maxUploadUsd,
+    DEFAULT_MAX_UPLOAD_USD
+  );
+
+  if (
+    args.mode === "production" &&
+    (args.arUsdPriceOverride || args.uploadPriceWinstonOverride) &&
+    !args.allowPriceOverrideInProduction
+  ) {
+    fail(
+      "Price overrides are forbidden in production unless ALLOW_ARWEAVE_PRICE_OVERRIDE_IN_PRODUCTION=true"
+    );
+  }
+
+  return args;
+}
+
+function printHelpAndExit() {
+  console.log(`
+Usage:
+  node scripts/arweave_cost_gate.mjs \\
+    --payload-file ./payload.json \\
+    --record-type echo \\
+    --run-id "$E2E_RUN_ID" \\
+    --log-dir "$E2E_LOG_DIR"
+
+Environment:
+  ARWEAVE_UPLOAD_MODE=dry_run|staging|production
+  ALLOW_PAID_ARWEAVE_CANARY=false
+  ARWEAVE_MAX_UPLOAD_USD=0.10
+  ARWEAVE_SAFETY_MULTIPLIER=1.20
+  ARWEAVE_JWK_PATH=/secure/path/wallet.json
+  EXPECTED_ARWEAVE_OWNER=${CURRENT_TRINITY_ARWEAVE_OWNER}
+  ARWEAVE_GATEWAY_URL=https://arweave.net
+
+Testing overrides, non-production only:
+  ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE=1000
+  AR_USD_PRICE_OVERRIDE=10
+`);
+  process.exit(0);
+}
+
+function makeArweave(gatewayUrl) {
+  const url = new URL(gatewayUrl);
+  return Arweave.init({
+    host: url.hostname,
+    protocol: url.protocol.replace(":", ""),
+    port: url.port ? Number(url.port) : url.protocol === "http:" ? 80 : 443
+  });
+}
+
+function winstonToArDecimal(winstonValue) {
+  const value = BigInt(String(winstonValue));
+  const negative = value < 0n;
+  const abs = negative ? -value : value;
+  const whole = abs / WINSTON_PER_AR;
+  const frac = abs % WINSTON_PER_AR;
+  const fracString = frac.toString().padStart(12, "0");
+  return `${negative ? "-" : ""}${whole.toString()}.${fracString}`;
+}
+
+function decimalStringToNumber(s) {
+  const n = Number(s);
+  if (!Number.isFinite(n)) fail(`Invalid decimal number: ${s}`);
+  return n;
+}
+
+async function fetchText(url, label) {
+  const started = Date.now();
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "trinity-accord-e2e-arweave-cost-gate/1.0",
+      Accept: "application/json,text/plain,*/*"
+    }
+  });
+
+  const text = await response.text();
+
+  return {
+    label,
+    url,
+    status: response.status,
+    ok: response.ok,
+    duration_ms: Date.now() - started,
+    content_type: response.headers.get("content-type"),
+    cache_control: response.headers.get("cache-control"),
+    text
+  };
+}
+
+async function fetchArUsd(args) {
+  if (args.arUsdPriceOverride) {
+    const price = Number(args.arUsdPriceOverride);
+    if (!Number.isFinite(price) || price <= 0) {
+      fail("AR_USD_PRICE_OVERRIDE must be a positive number");
+    }
+    return {
+      price,
+      source: "AR_USD_PRICE_OVERRIDE",
+      overridden: true,
+      status: null,
+      duration_ms: 0
+    };
+  }
+
+  const result = await fetchText(args.arUsdPriceSourceUrl, "ar_usd_price");
+
+  if (!result.ok) {
+    fail("AR/USD price fetch failed", result);
+  }
+
+  let json;
+  try {
+    json = JSON.parse(result.text);
+  } catch {
+    fail("AR/USD price response is not JSON", {
+      status: result.status,
+      content_type: result.content_type,
+      body_preview: result.text.slice(0, 200)
+    });
+  }
+
+  const price = json?.arweave?.usd;
+
+  if (!Number.isFinite(price) || price <= 0) {
+    fail("AR/USD price missing or invalid", { json });
+  }
+
+  return {
+    price,
+    source: args.arUsdPriceSourceUrl,
+    overridden: false,
+    status: result.status,
+    duration_ms: result.duration_ms
+  };
+}
+
+async function getUploadPriceWinston(args, arweave, payloadBytes) {
+  if (args.uploadPriceWinstonOverride) {
+    if (!/^\d+$/.test(args.uploadPriceWinstonOverride)) {
+      fail("ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE must be a positive integer string");
+    }
+    return {
+      winston: args.uploadPriceWinstonOverride,
+      source: "ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE",
+      overridden: true
+    };
+  }
+
+  const winston = await arweave.transactions.getPrice(payloadBytes);
+  if (!/^\d+$/.test(String(winston))) {
+    fail("arweave.transactions.getPrice did not return a Winston integer", {
+      winston
+    });
+  }
+
+  return {
+    winston: String(winston),
+    source: "arweave.transactions.getPrice",
+    overridden: false
+  };
+}
+
+async function readJwkIfNeeded(args, arweave) {
+  if (!args.jwkPath) {
+    return {
+      jwk: null,
+      derivedAddress: null
+    };
+  }
+
+  const raw = await fs.readFile(args.jwkPath, "utf8");
+  let jwk;
+
+  try {
+    jwk = JSON.parse(raw);
+  } catch {
+    fail("ARWEAVE_JWK_PATH does not contain valid JSON");
+  }
+
+  const derivedAddress = await arweave.wallets.jwkToAddress(jwk);
+
+  return {
+    jwk,
+    derivedAddress
+  };
+}
+
+async function getWalletBalance(arweave, address, required) {
+  if (!address) {
+    if (required) fail("Wallet address is required for production");
+    return {
+      winston: null,
+      ar: null,
+      available: false,
+      reason: "no_wallet_address"
+    };
+  }
+
+  try {
+    const winston = await arweave.wallets.getBalance(address);
+    return {
+      winston: String(winston),
+      ar: winstonToArDecimal(winston),
+      available: true,
+      reason: null
+    };
+  } catch (error) {
+    if (required) {
+      fail("Wallet balance fetch failed", {
+        address,
+        error: error.message
+      });
+    }
+
+    return {
+      winston: null,
+      ar: null,
+      available: false,
+      reason: error.message
+    };
+  }
+}
+
+async function writeJson(file, data) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function printCostCheck(data) {
+  console.log("[ARWEAVE COST CHECK]");
+  console.log(`run_id: ${data.run_id}`);
+  console.log(`record_type: ${data.record_type}`);
+  console.log(`payload_file: ${data.payload_file}`);
+  console.log(`payload_bytes: ${data.payload_bytes}`);
+  console.log(`payload_sha256: ${data.payload_sha256}`);
+  console.log(`wallet_address: ${data.wallet_address || "null"}`);
+  console.log(`expected_owner: ${data.expected_owner}`);
+  console.log(`balance_before_winston: ${data.balance_before_winston}`);
+  console.log(`balance_before_ar: ${data.balance_before_ar}`);
+  console.log(`ar_usd_price: ${data.ar_usd_price}`);
+  console.log(`estimated_upload_cost_winston: ${data.estimated_upload_cost_winston}`);
+  console.log(`estimated_upload_cost_ar: ${data.estimated_upload_cost_ar}`);
+  console.log(`estimated_upload_cost_usd: ${data.estimated_upload_cost_usd}`);
+  console.log(`safety_multiplier: ${data.safety_multiplier}`);
+  console.log(
+    `estimated_upload_cost_usd_with_buffer: ${data.estimated_upload_cost_usd_with_buffer}`
+  );
+  console.log(`max_upload_usd: ${data.effective_max_upload_usd}`);
+  console.log(`decision: ${data.decision}`);
+  console.log(`reason: ${data.reason}`);
+}
+
+function printUploadResult(data) {
+  if (data.result === "uploaded") {
+    console.log("[ARWEAVE UPLOAD RESULT]");
+    console.log(`run_id: ${data.run_id}`);
+    console.log(`record_type: ${data.record_type}`);
+    console.log(`tx_id: ${data.tx_id}`);
+    console.log(`gateway_url: ${data.gateway_url}`);
+    console.log(`balance_before_winston: ${data.balance_before_winston}`);
+    console.log(`balance_after_winston: ${data.balance_after_winston}`);
+    console.log(`actual_delta_winston: ${data.actual_delta_winston}`);
+    console.log(`actual_delta_ar: ${data.actual_delta_ar}`);
+    console.log(`estimated_cost_usd: ${data.estimated_cost_usd}`);
+    console.log(
+      `remaining_balance_estimated_usd: ${data.remaining_balance_estimated_usd}`
+    );
+  } else {
+    console.log("[ARWEAVE UPLOAD BLOCKED]");
+    console.log(`reason: ${data.reason}`);
+    console.log("tx_id: null");
+  }
+}
+
+async function runReadbackVerifier(args, txId, payloadSha256) {
+  if (args.skipReadback) {
+    return {
+      skipped: true,
+      reason: "skip_readback_argument"
+    };
+  }
+
+  const verifierPath = path.resolve("scripts/verify_arweave_upload_readback.mjs");
+  const childArgs = [
+    verifierPath,
+    "--tx-id",
+    txId,
+    "--expected-file",
+    args.payloadFile,
+    "--expected-sha256",
+    payloadSha256,
+    "--record-type",
+    args.recordType,
+    "--run-id",
+    args.runId,
+    "--log-dir",
+    args.logDir
+  ];
+
+  console.log("[ARWEAVE READBACK VERIFY COMMAND]");
+  console.log(`command: node ${childArgs.map((x) => JSON.stringify(x)).join(" ")}`);
+
+  const result = await new Promise((resolve) => {
+    const child = spawn(process.execPath, childArgs, {
+      stdio: "inherit",
+      env: process.env
+    });
+
+    child.on("close", (code) => {
+      resolve({ exit_code: code });
+    });
+  });
+
+  if (result.exit_code !== 0) {
+    fail("Arweave readback verifier failed", result);
+  }
+
+  return result;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const arweave = makeArweave(args.gatewayUrl);
+
+  const payloadBytes = await fs.readFile(args.payloadFile);
+  const payloadSha256 = sha256(payloadBytes);
+  const payloadBytesLength = payloadBytes.length;
+
+  const { jwk, derivedAddress } = await readJwkIfNeeded(args, arweave);
+  const walletAddress = derivedAddress || args.walletAddress || null;
+
+  if (derivedAddress && derivedAddress !== args.expectedOwner) {
+    fail("Arweave JWK owner does not match expected Trinity owner", {
+      derivedAddress,
+      expectedOwner: args.expectedOwner,
+      oldOwner: OLD_TRINITY_ARWEAVE_OWNER
+    });
+  }
+
+  if (args.mode === "production" && !args.allowPaid) {
+    fail("Production upload requested but ALLOW_PAID_ARWEAVE_CANARY is not true");
+  }
+
+  if (args.mode === "production" && !jwk) {
+    fail("Production upload requires ARWEAVE_JWK_PATH");
+  }
+
+  if (args.mode === "production" && walletAddress !== args.expectedOwner) {
+    fail("Production wallet address does not match expected owner", {
+      walletAddress,
+      expectedOwner: args.expectedOwner
+    });
+  }
+
+  const uploadPrice = await getUploadPriceWinston(
+    args,
+    arweave,
+    payloadBytesLength
+  );
+
+  const arUsd = await fetchArUsd(args);
+  const estimatedAr = winstonToArDecimal(uploadPrice.winston);
+  const estimatedUsd =
+    decimalStringToNumber(estimatedAr) * Number(arUsd.price);
+  const estimatedUsdWithBuffer = estimatedUsd * args.safetyMultiplier;
+
+  const balanceBefore = await getWalletBalance(
+    arweave,
+    walletAddress,
+    args.mode === "production"
+  );
+
+  let decision = "DRY_RUN";
+  let reason = "dry_run";
+
+  if (args.mode === "production") {
+    if (estimatedUsdWithBuffer > args.effectiveMaxUploadUsd) {
+      decision = "BLOCK";
+      reason = "over_cap";
+    } else {
+      decision = "ALLOW";
+      reason = "under_cap";
+    }
+  } else if (args.mode === "staging") {
+    decision = "DRY_RUN";
+    reason = "staging_no_paid_upload_in_first_round";
+  }
+
+  const costEstimate = {
+    generated_at: nowIso(),
+    run_id: args.runId,
+    record_type: args.recordType,
+    payload_file: args.payloadFile,
+    payload_bytes: payloadBytesLength,
+    payload_sha256: payloadSha256,
+    gateway_url: args.gatewayUrl,
+    wallet_address: walletAddress,
+    expected_owner: args.expectedOwner,
+    old_owner_not_used: OLD_TRINITY_ARWEAVE_OWNER,
+    balance_before_available: balanceBefore.available,
+    balance_before_reason: balanceBefore.reason,
+    balance_before_winston: balanceBefore.winston,
+    balance_before_ar: balanceBefore.ar,
+    ar_usd_price: arUsd.price,
+    ar_usd_price_source: arUsd.source,
+    ar_usd_price_overridden: arUsd.overridden,
+    estimated_upload_cost_winston: uploadPrice.winston,
+    estimated_upload_cost_source: uploadPrice.source,
+    estimated_upload_cost_overridden: uploadPrice.overridden,
+    estimated_upload_cost_ar: estimatedAr,
+    estimated_upload_cost_usd: Number(estimatedUsd.toFixed(8)),
+    safety_multiplier: args.safetyMultiplier,
+    estimated_upload_cost_usd_with_buffer: Number(
+      estimatedUsdWithBuffer.toFixed(8)
+    ),
+    configured_max_upload_usd: args.maxUploadUsd,
+    effective_max_upload_usd: args.effectiveMaxUploadUsd,
+    mode: args.mode,
+    allow_paid: args.allowPaid,
+    decision,
+    reason
+  };
+
+  printCostCheck(costEstimate);
+
+  await writeJson(
+    path.join(args.logDir, `10-arweave-cost-estimate.${args.recordType}.json`),
+    costEstimate
+  );
+
+  if (decision !== "ALLOW") {
+    const blocked = {
+      generated_at: nowIso(),
+      run_id: args.runId,
+      record_type: args.recordType,
+      result: "not_uploaded",
+      reason,
+      tx_id: null,
+      gateway_url: null
+    };
+
+    printUploadResult(blocked);
+
+    await writeJson(
+      path.join(args.logDir, `11-arweave-upload-result.${args.recordType}.json`),
+      blocked
+    );
+
+    process.exit(args.mode === "production" && reason === "over_cap" ? 2 : 0);
+  }
+
+  const tx = await arweave.createTransaction({ data: payloadBytes }, jwk);
+  tx.addTag("Content-Type", args.contentType);
+  tx.addTag("App-Name", args.appName);
+  tx.addTag("Record-Type", args.recordType);
+  tx.addTag("E2E-Run-Id", args.runId);
+  tx.addTag("Payload-SHA256", payloadSha256);
+  tx.addTag("Trinity-Arweave-Owner", args.expectedOwner);
+  tx.addTag("Canary-Record", "true");
+  tx.addTag("Do-Not-Treat-As-First-Real-Agent", "true");
+
+  await arweave.transactions.sign(tx, jwk);
+
+  const postStarted = Date.now();
+  const postResult = await arweave.transactions.post(tx);
+
+  if (postResult.status < 200 || postResult.status >= 300) {
+    fail("Arweave transaction post failed", {
+      status: postResult.status,
+      statusText: postResult.statusText,
+      data_preview:
+        typeof postResult.data === "string"
+          ? postResult.data.slice(0, 300)
+          : postResult.data
+    });
+  }
+
+  const txId = tx.id;
+  const gatewayReadUrl = `${args.gatewayUrl.replace(/\/$/, "")}/${txId}`;
+
+  const balanceAfter = await getWalletBalance(arweave, walletAddress, false);
+
+  let actualDeltaWinston = null;
+  let actualDeltaAr = null;
+  let remainingBalanceEstimatedUsd = null;
+
+  if (
+    balanceBefore.winston &&
+    balanceAfter.winston &&
+    /^\d+$/.test(balanceBefore.winston) &&
+    /^\d+$/.test(balanceAfter.winston)
+  ) {
+    const beforeBig = BigInt(balanceBefore.winston);
+    const afterBig = BigInt(balanceAfter.winston);
+    actualDeltaWinston = (beforeBig - afterBig).toString();
+    actualDeltaAr = winstonToArDecimal(actualDeltaWinston);
+  }
+
+  if (balanceAfter.ar) {
+    remainingBalanceEstimatedUsd =
+      decimalStringToNumber(balanceAfter.ar) * Number(arUsd.price);
+  }
+
+  const uploadResult = {
+    generated_at: nowIso(),
+    run_id: args.runId,
+    record_type: args.recordType,
+    result: "uploaded",
+    tx_id: txId,
+    gateway_url: gatewayReadUrl,
+    post_status: postResult.status,
+    post_duration_ms: Date.now() - postStarted,
+    payload_file: args.payloadFile,
+    payload_bytes: payloadBytesLength,
+    payload_sha256: payloadSha256,
+    wallet_address: walletAddress,
+    balance_before_available: balanceBefore.available,
+    balance_before_winston: balanceBefore.winston,
+    balance_before_ar: balanceBefore.ar,
+    balance_after_available: balanceAfter.available,
+    balance_after_reason: balanceAfter.reason,
+    balance_after_winston: balanceAfter.winston,
+    balance_after_ar: balanceAfter.ar,
+    actual_delta_winston: actualDeltaWinston,
+    actual_delta_ar: actualDeltaAr,
+    estimated_cost_usd: Number(estimatedUsd.toFixed(8)),
+    remaining_balance_estimated_usd:
+      remainingBalanceEstimatedUsd == null
+        ? null
+        : Number(remainingBalanceEstimatedUsd.toFixed(8)),
+    readback_required: true
+  };
+
+  printUploadResult(uploadResult);
+
+  await writeJson(
+    path.join(args.logDir, `11-arweave-upload-result.${args.recordType}.json`),
+    uploadResult
+  );
+
+  await runReadbackVerifier(args, txId, payloadSha256);
+}
+
+main().catch((error) => {
+  console.error("[ARWEAVE COST GATE ERROR]");
+  console.error(error.message);
+  if (error.extra) {
+    console.error(JSON.stringify(error.extra, null, 2));
+  }
+  process.exit(1);
+});

--- a/scripts/test_arweave_cost_gate_safety.mjs
+++ b/scripts/test_arweave_cost_gate_safety.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+
+const CURRENT_OWNER = "r1EdzCQ9E7CaAOEywI5netR6EcSopNOa08oi2Coz68s";
+
+async function mkTmpDir() {
+  const root = process.env.RUNNER_TEMP || "/tmp";
+  const dir = path.join(root, `trinity-arweave-cost-gate-test-${Date.now()}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function runNode(args, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ...env }
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (d) => {
+      stdout += String(d);
+    });
+
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function main() {
+  const dir = await mkTmpDir();
+  const payloadFile = path.join(dir, "payload.json");
+  const logDir = path.join(dir, "logs");
+
+  await fs.mkdir(logDir, { recursive: true });
+
+  await fs.writeFile(
+    payloadFile,
+    JSON.stringify(
+      {
+        test_run: true,
+        canary_record: true,
+        message: "arweave cost gate safety test"
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+
+  const result = await runNode(
+    [
+      "scripts/arweave_cost_gate.mjs",
+      "--payload-file",
+      payloadFile,
+      "--record-type",
+      "echo",
+      "--run-id",
+      "unit-arweave-cost-gate",
+      "--log-dir",
+      logDir,
+      "--mode",
+      "dry_run"
+    ],
+    {
+      ARWEAVE_UPLOAD_MODE: "dry_run",
+      ALLOW_PAID_ARWEAVE_CANARY: "false",
+      ARWEAVE_MAX_UPLOAD_USD: "0.10",
+      ARWEAVE_WALLET_ADDRESS: CURRENT_OWNER,
+      ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE: "1000",
+      AR_USD_PRICE_OVERRIDE: "10"
+    }
+  );
+
+  if (result.code !== 0) {
+    console.error(result.stdout);
+    console.error(result.stderr);
+    throw new Error(`dry-run cost gate failed with exit code ${result.code}`);
+  }
+
+  if (!result.stdout.includes("[ARWEAVE COST CHECK]")) {
+    throw new Error("missing cost check log");
+  }
+
+  if (!result.stdout.includes("decision: DRY_RUN")) {
+    throw new Error("dry-run did not report DRY_RUN decision");
+  }
+
+  const estimateFile = path.join(logDir, "10-arweave-cost-estimate.echo.json");
+  const uploadFile = path.join(logDir, "11-arweave-upload-result.echo.json");
+
+  const estimate = JSON.parse(await fs.readFile(estimateFile, "utf8"));
+  const upload = JSON.parse(await fs.readFile(uploadFile, "utf8"));
+
+  if (estimate.expected_owner !== CURRENT_OWNER) {
+    throw new Error("expected owner address mismatch");
+  }
+
+  if (estimate.ar_usd_price_overridden !== true) {
+    throw new Error("test did not use AR_USD_PRICE_OVERRIDE");
+  }
+
+  if (estimate.estimated_upload_cost_overridden !== true) {
+    throw new Error("test did not use ARWEAVE_UPLOAD_PRICE_WINSTON_OVERRIDE");
+  }
+
+  if (upload.result !== "not_uploaded") {
+    throw new Error("dry-run unexpectedly uploaded");
+  }
+
+  if (upload.tx_id !== null) {
+    throw new Error("dry-run produced tx_id");
+  }
+
+  console.log("PASS: arweave cost gate dry-run safety");
+}
+
+main().catch((error) => {
+  console.error("FAIL: arweave cost gate safety");
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/test_arweave_readback_hash_fixture.mjs
+++ b/scripts/test_arweave_readback_hash_fixture.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import crypto from "node:crypto";
+import http from "node:http";
+import { spawn } from "node:child_process";
+
+function sha256(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+async function mkTmpDir() {
+  const root = process.env.RUNNER_TEMP || "/tmp";
+  const dir = path.join(root, `trinity-arweave-readback-test-${Date.now()}`);
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function runNode(args, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, ...env }
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (d) => {
+      stdout += String(d);
+    });
+
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+function startFixtureServer(expectedTxId, bytesToServe) {
+  const server = http.createServer((req, res) => {
+    if (req.url === `/${expectedTxId}`) {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "cache-control": "no-store"
+      });
+      res.end(bytesToServe);
+      return;
+    }
+
+    res.writeHead(404, { "content-type": "text/plain" });
+    res.end("not found");
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        server,
+        gateway: `http://127.0.0.1:${port}`
+      });
+    });
+  });
+}
+
+async function main() {
+  const dir = await mkTmpDir();
+  const logDir = path.join(dir, "logs");
+  await fs.mkdir(logDir, { recursive: true });
+
+  const expectedPayload = Buffer.from(
+    JSON.stringify({ ok: true, payload: "expected" }, null, 2),
+    "utf8"
+  );
+
+  const wrongPayload = Buffer.from(
+    JSON.stringify({ ok: false, payload: "wrong" }, null, 2),
+    "utf8"
+  );
+
+  const expectedFile = path.join(dir, "expected.json");
+  await fs.writeFile(expectedFile, expectedPayload);
+
+  const expectedSha = sha256(expectedPayload);
+  const txId = "fixture_tx_1234567890abcdefghijklmnop";
+
+  const { server, gateway } = await startFixtureServer(txId, wrongPayload);
+
+  try {
+    const result = await runNode(
+      [
+        "scripts/verify_arweave_upload_readback.mjs",
+        "--tx-id",
+        txId,
+        "--expected-file",
+        expectedFile,
+        "--expected-sha256",
+        expectedSha,
+        "--record-type",
+        "echo",
+        "--run-id",
+        "unit-readback-hash-fixture",
+        "--log-dir",
+        logDir
+      ],
+      {
+        ARWEAVE_READBACK_GATEWAYS: gateway,
+        ARWEAVE_READBACK_TIMEOUT_SECONDS: "2",
+        ARWEAVE_READBACK_RETRY_SECONDS: "1"
+      }
+    );
+
+    if (result.code === 0) {
+      console.error(result.stdout);
+      console.error(result.stderr);
+      throw new Error("hash mismatch fixture unexpectedly passed");
+    }
+
+    if (!result.stdout.includes("reason: hash_mismatch")) {
+      console.error(result.stdout);
+      console.error(result.stderr);
+      throw new Error("hash mismatch reason not printed");
+    }
+
+    const readbackLog = JSON.parse(
+      await fs.readFile(
+        path.join(logDir, "11b-arweave-readback-verify.echo.json"),
+        "utf8"
+      )
+    );
+
+    if (readbackLog.result !== "fail") {
+      throw new Error("readback log did not record fail");
+    }
+
+    if (readbackLog.reason !== "hash_mismatch") {
+      throw new Error("readback log did not record hash_mismatch");
+    }
+
+    console.log("PASS: arweave readback hash mismatch fixture");
+  } finally {
+    server.close();
+  }
+}
+
+main().catch((error) => {
+  console.error("FAIL: arweave readback hash fixture");
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/verify_arweave_upload_readback.mjs
+++ b/scripts/verify_arweave_upload_readback.mjs
@@ -1,0 +1,407 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import crypto from "node:crypto";
+import process from "node:process";
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function sha256(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fail(message, extra = {}) {
+  const err = new Error(message);
+  err.extra = extra;
+  throw err;
+}
+
+function parseArgs(argv) {
+  const args = {
+    txId: null,
+    expectedFile: null,
+    expectedSha256: null,
+    recordType: null,
+    runId: process.env.E2E_RUN_ID || null,
+    logDir: process.env.E2E_LOG_DIR || null,
+    gateways: (
+      process.env.ARWEAVE_READBACK_GATEWAYS || "https://arweave.net"
+    )
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean),
+    timeoutSeconds: Number(process.env.ARWEAVE_READBACK_TIMEOUT_SECONDS || 900),
+    retrySeconds: Number(process.env.ARWEAVE_READBACK_RETRY_SECONDS || 15)
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const key = argv[i];
+    const next = argv[i + 1];
+
+    if (key === "--tx-id") {
+      args.txId = next;
+      i++;
+    } else if (key === "--expected-file") {
+      args.expectedFile = next;
+      i++;
+    } else if (key === "--expected-sha256") {
+      args.expectedSha256 = next;
+      i++;
+    } else if (key === "--record-type") {
+      args.recordType = next;
+      i++;
+    } else if (key === "--run-id") {
+      args.runId = next;
+      i++;
+    } else if (key === "--log-dir") {
+      args.logDir = next;
+      i++;
+    } else if (key === "--gateway") {
+      args.gateways.push(next);
+      i++;
+    } else if (key === "--timeout-seconds") {
+      args.timeoutSeconds = Number(next);
+      i++;
+    } else if (key === "--retry-seconds") {
+      args.retrySeconds = Number(next);
+      i++;
+    } else if (key === "--help" || key === "-h") {
+      printHelpAndExit();
+    } else {
+      fail(`Unknown argument: ${key}`);
+    }
+  }
+
+  if (!args.txId) fail("Missing --tx-id");
+  if (!args.expectedFile) fail("Missing --expected-file");
+  if (!args.expectedSha256) fail("Missing --expected-sha256");
+  if (!args.recordType) fail("Missing --record-type");
+  if (!args.runId) fail("Missing --run-id or E2E_RUN_ID");
+  if (!args.logDir) fail("Missing --log-dir or E2E_LOG_DIR");
+
+  if (!/^[a-zA-Z0-9_-]{20,}$/.test(args.txId)) {
+    fail("Invalid Arweave tx id format", { txId: args.txId });
+  }
+
+  if (!/^[a-f0-9]{64}$/i.test(args.expectedSha256)) {
+    fail("Expected SHA256 must be 64 hex characters");
+  }
+
+  if (!Number.isFinite(args.timeoutSeconds) || args.timeoutSeconds <= 0) {
+    fail("timeoutSeconds must be positive");
+  }
+
+  if (!Number.isFinite(args.retrySeconds) || args.retrySeconds <= 0) {
+    fail("retrySeconds must be positive");
+  }
+
+  if (args.gateways.length === 0) {
+    fail("At least one readback gateway is required");
+  }
+
+  return args;
+}
+
+function printHelpAndExit() {
+  console.log(`
+Usage:
+  node scripts/verify_arweave_upload_readback.mjs \\
+    --tx-id "<tx_id>" \\
+    --expected-file "./payload.json" \\
+    --expected-sha256 "<sha256>" \\
+    --record-type echo \\
+    --run-id "$E2E_RUN_ID" \\
+    --log-dir "$E2E_LOG_DIR"
+`);
+  process.exit(0);
+}
+
+async function writeJson(file, data) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(data, null, 2) + "\n", "utf8");
+}
+
+function buildTxUrl(gateway, txId) {
+  return `${gateway.replace(/\/$/, "")}/${txId}`;
+}
+
+async function fetchBytes(url) {
+  const started = Date.now();
+
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": "trinity-accord-e2e-arweave-readback/1.0",
+      Accept: "*/*"
+    }
+  });
+
+  const arrayBuffer = await response.arrayBuffer();
+  const bytes = Buffer.from(arrayBuffer);
+
+  return {
+    url,
+    status: response.status,
+    ok: response.ok,
+    duration_ms: Date.now() - started,
+    content_type: response.headers.get("content-type"),
+    cache_control: response.headers.get("cache-control"),
+    etag: response.headers.get("etag"),
+    last_modified: response.headers.get("last-modified"),
+    bytes
+  };
+}
+
+function printStart(args, expectedBytes, expectedSha256) {
+  console.log("[ARWEAVE READBACK VERIFY]");
+  console.log(`run_id: ${args.runId}`);
+  console.log(`record_type: ${args.recordType}`);
+  console.log(`tx_id: ${args.txId}`);
+  console.log("gateway_urls:");
+  for (const gateway of args.gateways) {
+    console.log(`  - ${buildTxUrl(gateway, args.txId)}`);
+  }
+  console.log(`expected_file: ${args.expectedFile}`);
+  console.log(`expected_bytes: ${expectedBytes}`);
+  console.log(`expected_sha256: ${expectedSha256}`);
+  console.log(`timeout_seconds: ${args.timeoutSeconds}`);
+  console.log(`retry_seconds: ${args.retrySeconds}`);
+}
+
+function printAttempt(attempt) {
+  console.log("[ARWEAVE READBACK REQUEST]");
+  console.log(`tx_id: ${attempt.tx_id}`);
+  console.log(`gateway_url: ${attempt.gateway_url}`);
+  console.log(`attempt: ${attempt.attempt}`);
+  console.log(`status: ${attempt.status}`);
+  console.log(`duration_ms: ${attempt.duration_ms}`);
+  console.log(`content_type: ${attempt.content_type || "null"}`);
+  console.log(`downloaded_bytes: ${attempt.downloaded_bytes}`);
+  console.log(`downloaded_sha256: ${attempt.downloaded_sha256 || "null"}`);
+}
+
+function printResult(result) {
+  console.log("[ARWEAVE READBACK RESULT]");
+  console.log(`tx_id: ${result.tx_id}`);
+  console.log(`gateway_url: ${result.gateway_url || "null"}`);
+  console.log(`result: ${result.result}`);
+  console.log(`reason: ${result.reason || "null"}`);
+  console.log(`expected_sha256: ${result.expected_sha256}`);
+  console.log(`downloaded_sha256: ${result.downloaded_sha256 || "null"}`);
+  console.log(`bytes_match: ${result.bytes_match}`);
+  console.log(`hash_match: ${result.hash_match}`);
+
+  if (result.result !== "pass") {
+    console.log("action: mark_upload_unverified_and_stop_paid_uploads");
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const expectedBytes = await fs.readFile(args.expectedFile);
+  const fileSha256 = sha256(expectedBytes);
+
+  if (fileSha256 !== args.expectedSha256) {
+    fail("Expected file SHA256 does not match provided expected SHA256", {
+      expectedFile: args.expectedFile,
+      computed: fileSha256,
+      provided: args.expectedSha256
+    });
+  }
+
+  printStart(args, expectedBytes.length, args.expectedSha256);
+
+  const started = Date.now();
+  const deadline = started + args.timeoutSeconds * 1000;
+  const attempts = [];
+  let attemptNumber = 0;
+  let lastFailure = null;
+
+  while (Date.now() < deadline) {
+    for (const gateway of args.gateways) {
+      attemptNumber++;
+      const gatewayUrl = buildTxUrl(gateway, args.txId);
+
+      let fetched;
+
+      try {
+        fetched = await fetchBytes(gatewayUrl);
+      } catch (error) {
+        const attempt = {
+          timestamp: nowIso(),
+          tx_id: args.txId,
+          gateway_url: gatewayUrl,
+          attempt: attemptNumber,
+          status: "fetch_error",
+          duration_ms: null,
+          content_type: null,
+          downloaded_bytes: 0,
+          downloaded_sha256: null,
+          error: error.message
+        };
+        attempts.push(attempt);
+        printAttempt(attempt);
+        lastFailure = {
+          reason: "gateway_error",
+          error: error.message,
+          gateway_url: gatewayUrl
+        };
+        continue;
+      }
+
+      const downloadedSha =
+        fetched.bytes.length > 0 ? sha256(fetched.bytes) : null;
+
+      const attempt = {
+        timestamp: nowIso(),
+        tx_id: args.txId,
+        gateway_url: gatewayUrl,
+        attempt: attemptNumber,
+        status: fetched.status,
+        duration_ms: fetched.duration_ms,
+        content_type: fetched.content_type,
+        cache_control: fetched.cache_control,
+        etag: fetched.etag,
+        last_modified: fetched.last_modified,
+        downloaded_bytes: fetched.bytes.length,
+        downloaded_sha256: downloadedSha
+      };
+
+      attempts.push(attempt);
+      printAttempt(attempt);
+
+      if (fetched.ok && fetched.bytes.length > 0) {
+        const bytesMatch = fetched.bytes.length === expectedBytes.length;
+        const hashMatch = downloadedSha === args.expectedSha256;
+
+        if (bytesMatch && hashMatch) {
+          const result = {
+            run_id: args.runId,
+            record_type: args.recordType,
+            tx_id: args.txId,
+            gateway_url: gatewayUrl,
+            expected_file: args.expectedFile,
+            expected_bytes: expectedBytes.length,
+            downloaded_bytes: fetched.bytes.length,
+            expected_sha256: args.expectedSha256,
+            downloaded_sha256: downloadedSha,
+            hash_match: true,
+            byte_for_byte_match: true,
+            bytes_match: true,
+            attempts: attempts.length,
+            duration_ms: Date.now() - started,
+            verified_at: nowIso(),
+            result: "pass",
+            attempts_log: attempts
+          };
+
+          printResult(result);
+          await writeJson(
+            path.join(
+              args.logDir,
+              `11b-arweave-readback-verify.${args.recordType}.json`
+            ),
+            result
+          );
+          return;
+        }
+
+        const result = {
+          run_id: args.runId,
+          record_type: args.recordType,
+          tx_id: args.txId,
+          gateway_url: gatewayUrl,
+          expected_file: args.expectedFile,
+          expected_bytes: expectedBytes.length,
+          downloaded_bytes: fetched.bytes.length,
+          expected_sha256: args.expectedSha256,
+          downloaded_sha256: downloadedSha,
+          hash_match: hashMatch,
+          byte_for_byte_match: false,
+          bytes_match: bytesMatch,
+          attempts: attempts.length,
+          duration_ms: Date.now() - started,
+          verified_at: nowIso(),
+          result: "fail",
+          severity: "P0",
+          reason: hashMatch ? "byte_length_mismatch" : "hash_mismatch",
+          action: "stop_paid_uploads_and_open_bug",
+          attempts_log: attempts
+        };
+
+        printResult(result);
+        await writeJson(
+          path.join(
+            args.logDir,
+            `11b-arweave-readback-verify.${args.recordType}.json`
+          ),
+          result
+        );
+        process.exit(2);
+      }
+
+      if (![202, 404, 502, 503, 504].includes(fetched.status)) {
+        lastFailure = {
+          reason: "unexpected_status",
+          status: fetched.status,
+          gateway_url: gatewayUrl
+        };
+      }
+    }
+
+    if (Date.now() < deadline) {
+      await sleep(args.retrySeconds * 1000);
+    }
+  }
+
+  const result = {
+    run_id: args.runId,
+    record_type: args.recordType,
+    tx_id: args.txId,
+    gateway_url: null,
+    expected_file: args.expectedFile,
+    expected_bytes: expectedBytes.length,
+    downloaded_bytes: null,
+    expected_sha256: args.expectedSha256,
+    downloaded_sha256: null,
+    hash_match: false,
+    byte_for_byte_match: false,
+    bytes_match: false,
+    attempts: attempts.length,
+    duration_ms: Date.now() - started,
+    verified_at: nowIso(),
+    result: "fail",
+    severity: "P0",
+    reason: "timeout_or_unavailable",
+    last_failure: lastFailure,
+    action: "stop_paid_uploads_and_open_bug",
+    attempts_log: attempts
+  };
+
+  printResult(result);
+
+  await writeJson(
+    path.join(
+      args.logDir,
+      `11b-arweave-readback-verify.${args.recordType}.json`
+    ),
+    result
+  );
+
+  process.exit(2);
+}
+
+main().catch((error) => {
+  console.error("[ARWEAVE READBACK VERIFY ERROR]");
+  console.error(error.message);
+  if (error.extra) {
+    console.error(JSON.stringify(error.extra, null, 2));
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds Arweave paid canary infrastructure: cost gate with JWK owner validation, upload readback SHA256 verifier, and two safety unit tests.

## Current Arweave Owner

```
r1EdzCQ9E7CaAOEywI5netR6EcSopNOa08oi2Coz68s
```

Old address `8Y8GRimuESN_u8tJihCd5nywb-X-lJ_2vWqFAfHeQIE` is **NOT** used for production paid canary.

## Files Added

| File | Description |
|------|-------------|
| `scripts/arweave_cost_gate.mjs` | Cost estimation + upload with JWK owner validation, balance tracking, cap enforcement |
| `scripts/verify_arweave_upload_readback.mjs` | Byte-for-byte SHA256 readback verification with retry/timeout |
| `scripts/test_arweave_cost_gate_safety.mjs` | Dry-run safety unit test (no real upload, no JWK needed) |
| `scripts/test_arweave_readback_hash_fixture.mjs` | Hash mismatch detection via local HTTP fixture |

## package.json Updates

Added scripts:
- `test:arweave-cost-gate`
- `test:arweave-readback`

## Test Results

```
PASS: arweave cost gate dry-run safety
PASS: arweave readback hash mismatch fixture
```

## Paid canary status

Not run in this PR. Dry-run and unit tests only.

## Checklist

- [x] JWK owner validation enforces `r1EdzCQ9E7CaAOEywI5netR6EcSopNOa08oi2Coz68s`
- [x] Production mode forbids price override by default
- [x] Readback verifier does byte-for-byte SHA256 comparison
- [x] Hash mismatch / timeout → P0 fail, stops paid uploads
- [x] JWK / private key never logged
- [x] Cost cap $0.10 enforced