### PR TITLE
chore: publish record-chain testnet genesis

### DIFF
--- a/api/record-chain-testnet/ots-arweave-registry.json
+++ b/api/record-chain-testnet/ots-arweave-registry.json
@@ -2,7 +2,7 @@
   "authority": "registry of Arweave archives for TESTNET OTS head anchors; testnet.chain.jsonl remains authoritative",
   "chain_id": "trinity-record-chain-testnet",
   "entries": [],
-  "generated_at": "2026-06-06T01:51:27Z",
+  "generated_at": "2026-06-06T02:56:31Z",
   "latest_by_head": {},
   "schema": "trinity_record_chain_ots_arweave_registry.v1"
 }

--- a/api/record-chain-testnet/ots-latest.json
+++ b/api/record-chain-testnet/ots-latest.json
@@ -6,5 +6,5 @@
   "latest_ots_file": null,
   "ots_status": "dry_run",
   "schema": "trinity_record_chain_ots_latest.v1",
-  "updated_at": "2026-06-06T01:51:27Z"
+  "updated_at": "2026-06-06T02:56:31Z"
 }

--- a/api/record-chain-testnet/record-chain-head.json
+++ b/api/record-chain-testnet/record-chain-head.json
@@ -2,7 +2,7 @@
   "chain_id": "trinity-record-chain-testnet",
   "chain_version": "1.0.0",
   "entry_count": 0,
-  "generated_at": "2026-06-06T01:51:27Z",
+  "generated_at": "2026-06-06T02:56:31Z",
   "head_entry_hash": null,
   "schema": "trinity_record_chain_head.v1"
 }

--- a/api/record-chain-testnet/status.json
+++ b/api/record-chain-testnet/status.json
@@ -1,0 +1,14 @@
+{
+  "chain_id": "trinity-record-chain-testnet",
+  "chain_version": "1.0.0",
+  "environment": "testnet",
+  "test_only": true,
+  "not_mainnet": true,
+  "status": "initialized",
+  "entry_count": 0,
+  "height": 0,
+  "head_entry_hash": null,
+  "initialized_at": "2026-06-06T02:56:31Z",
+  "schema": "trinityaccord.record-chain-testnet-status.v1",
+  "description": "Isolated testnet Record-Chain for Phase 7B external agent testing. This is NOT the mainnet chain."
+}


### PR DESCRIPTION
Publishes testnet genesis state and scripts so that `api/record-chain-testnet/status.json` is publicly accessible.

Includes:
- `api/record-chain-testnet/status.json` (new)
- Testnet head, OTS latest, registry
- Testnet genesis ledger (empty)
- All Phase 7B scripts (init, finalize, testnet contract test, etc.)
- `arweave_cost_gate.mjs` with extra tags support

Required for Phase 7B external agent finalization flow.