### PR TITLE
feat: require mandatory authorship keys for public submissions

### DIFF
--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -52,5 +52,22 @@
   "schema": "trinityaccord.agent-start.v2",
   "status": "active",
   "updated_at": "2026-06-06T04:14:45Z",
-  "version": "2.0.0"
+  "version": "2.0.0",
+  "authorship_key_policy": {
+    "authorship_key_required": true,
+    "applies_to_all_public_submissions": true,
+    "algorithm": "ed25519",
+    "builder_requires_key_dir": true,
+    "keypair_files": {
+      "public_key": "authorship-public.pem",
+      "private_key": "authorship-private.pem"
+    },
+    "sandbox_private_key_loss_warning": true,
+    "human_operator_or_guardian_must_securely_backup_private_key": true,
+    "private_key_must_not_be_pasted_into_public_chat": true,
+    "private_key_must_not_be_committed_to_git": true,
+    "private_key_must_not_be_uploaded_in_submission_receipt_or_arweave": true,
+    "public_key_sha256_is_public_identity_anchor": true,
+    "guardian_application_must_bind_guardian_public_key_to_authorship_public_key": true
+  }
 }

--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -5,8 +5,8 @@
     "language": "node",
     "runtime": "node>=18",
     "url": "/downloads/record-chain-builder.mjs",
-    "sha256": "14121f4cf580388c61250d83b1c42830912f0a60c073c1462b5bbaad3169e862",
-    "size_bytes": 94073,
+    "sha256": "7e1bfad10ca8cc4346a1dc17fa673401c646a33a292cd2abfa6fbcfb13e70add",
+    "size_bytes": 100742,
     "supports": [
       "echo",
       "verification",

--- a/api/record-chain-intake-gateway.v1.json
+++ b/api/record-chain-intake-gateway.v1.json
@@ -106,5 +106,22 @@
     "submit_persists_intake": true
   },
   "status": "active_public_submission_interface",
-  "updated_at": "2026-06-06T04:14:45Z"
+  "updated_at": "2026-06-06T04:14:45Z",
+  "authorship_key_policy": {
+    "authorship_key_required": true,
+    "applies_to_all_public_submissions": true,
+    "algorithm": "ed25519",
+    "builder_requires_key_dir": true,
+    "keypair_files": {
+      "public_key": "authorship-public.pem",
+      "private_key": "authorship-private.pem"
+    },
+    "sandbox_private_key_loss_warning": true,
+    "human_operator_or_guardian_must_securely_backup_private_key": true,
+    "private_key_must_not_be_pasted_into_public_chat": true,
+    "private_key_must_not_be_committed_to_git": true,
+    "private_key_must_not_be_uploaded_in_submission_receipt_or_arweave": true,
+    "public_key_sha256_is_public_identity_anchor": true,
+    "guardian_application_must_bind_guardian_public_key_to_authorship_public_key": true
+  }
 }

--- a/api/record-chain-mainnet-prelaunch-policy.v1.json
+++ b/api/record-chain-mainnet-prelaunch-policy.v1.json
@@ -33,5 +33,22 @@
   "records_before_activation_marker_are_prelaunch_tests": true,
   "schema": "trinityaccord.record-chain-mainnet-prelaunch-policy.v1",
   "status": "active",
-  "updated_at": "2026-06-06T04:14:45Z"
+  "updated_at": "2026-06-06T04:14:45Z",
+  "authorship_key_policy": {
+    "authorship_key_required": true,
+    "applies_to_all_public_submissions": true,
+    "algorithm": "ed25519",
+    "builder_requires_key_dir": true,
+    "keypair_files": {
+      "public_key": "authorship-public.pem",
+      "private_key": "authorship-private.pem"
+    },
+    "sandbox_private_key_loss_warning": true,
+    "human_operator_or_guardian_must_securely_backup_private_key": true,
+    "private_key_must_not_be_pasted_into_public_chat": true,
+    "private_key_must_not_be_committed_to_git": true,
+    "private_key_must_not_be_uploaded_in_submission_receipt_or_arweave": true,
+    "public_key_sha256_is_public_identity_anchor": true,
+    "guardian_application_must_bind_guardian_public_key_to_authorship_public_key": true
+  }
 }

--- a/api/record-chain-submission-schema.v1.json
+++ b/api/record-chain-submission-schema.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "trinityaccord.record-chain-submission.v1",
   "title": "Record-Chain Submission",
-  "description": "Schema for public submissions to the Record-Chain Intake Gateway on Render. This is the only public submission method for external agents.",
+  "description": "Schema for public submissions to the Record-Chain Intake Gateway. All public submissions require Ed25519 authorship_proof for key continuity and future identity claim.",
   "type": "object",
   "required": [
     "schema",
@@ -12,7 +12,8 @@
     "record_draft",
     "builder",
     "client_context",
-    "submission_boundary"
+    "submission_boundary",
+    "authorship_proof"
   ],
   "if": {
     "properties": {

--- a/apps/record_chain_intake_gateway/gateway/authorship.py
+++ b/apps/record_chain_intake_gateway/gateway/authorship.py
@@ -1,189 +1,102 @@
-# gateway/authorship.py
-"""Ed25519 authorship verification utilities."""
-
 from __future__ import annotations
 
 import base64
 import hashlib
-import logging
+import json
+import re
 from typing import Any
 
 from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from cryptography.hazmat.primitives.serialization import (
-    Encoding,
-    PublicFormat,
-    load_pem_public_key,
-)
-
-from .canonical import canonical_bytes, sha256_bytes
-
-logger = logging.getLogger(__name__)
-
-# Required claim_boundary keys that must be True
-_REQUIRED_CLAIM_BOUNDARY_KEYS = frozenset({
-    "not authority",
-    "not attestation",
-    "not amendment",
-})
 
 
-def strip_authorship_for_signing(record_draft: dict[str, Any]) -> dict[str, Any]:
-    """Return a shallow copy of *record_draft* with ``authorship_proof`` removed.
-
-    The proof cannot sign itself, so it must be stripped before computing the
-    signed payload.
-    """
-    cleaned = dict(record_draft)
-    cleaned.pop("authorship_proof", None)
-    cleaned.pop("proof", None)
-    return cleaned
+def canonical_json_bytes(obj: Any) -> bytes:
+    return json.dumps(
+        obj,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
 
 
-def signed_payload_sha256(record_draft: dict[str, Any]) -> str:
-    """Compute the SHA-256 hex digest of the canonical JSON of *record_draft*.
+def verify_authorship_proof(submission: dict[str, Any]) -> tuple[bool, str | None, str | None]:
+    proof = submission.get("authorship_proof")
+    if not isinstance(proof, dict):
+        return False, "MISSING_AUTHORSHIP_PROOF", "Missing top-level authorship_proof."
 
-    This is the payload that the author signs.
-    """
-    return sha256_bytes(canonical_bytes(record_draft))
+    if proof.get("schema") != "trinityaccord.agent-authorship-proof.v1":
+        return False, "INVALID_AUTHORSHIP_SCHEMA", "Invalid authorship proof schema."
+    if proof.get("method") != "public_key_signature":
+        return False, "INVALID_AUTHORSHIP_METHOD", "Invalid authorship proof method."
+    if proof.get("algorithm") != "ed25519":
+        return False, "INVALID_AUTHORSHIP_ALGORITHM", "Authorship proof must use Ed25519."
 
+    public_key_pem = proof.get("public_key_pem")
+    public_key_sha256 = proof.get("public_key_sha256")
+    signed_payload_sha256 = proof.get("signed_payload_sha256")
+    signature_base64 = proof.get("signature_base64")
 
-def public_key_sha256_from_pem(public_key_pem: str) -> str:
-    """Return the SHA-256 hex digest of the raw public-key bytes (32 bytes for Ed25519)."""
-    key = load_pem_public_key(public_key_pem.encode("utf-8") if isinstance(public_key_pem, str) else public_key_pem)
-    raw = key.public_bytes(
-        encoding=Encoding.Raw,
-        format=PublicFormat.Raw,
-    )
-    return sha256_bytes(raw)
+    if not isinstance(public_key_pem, str) or "BEGIN PUBLIC KEY" not in public_key_pem:
+        return False, "INVALID_AUTHORSHIP_PUBLIC_KEY", "Invalid or missing public_key_pem."
+    if "PRIVATE KEY" in public_key_pem:
+        return False, "PRIVATE_KEY_LEAK", "Private key material appears in public key field."
+    if not isinstance(public_key_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", public_key_sha256):
+        return False, "INVALID_AUTHORSHIP_PUBLIC_KEY_SHA", "Invalid public_key_sha256."
+    if not isinstance(signed_payload_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", signed_payload_sha256):
+        return False, "INVALID_AUTHORSHIP_SIGNED_PAYLOAD_SHA", "Invalid signed_payload_sha256."
+    if not isinstance(signature_base64, str) or not signature_base64:
+        return False, "INVALID_AUTHORSHIP_SIGNATURE", "Missing signature_base64."
 
+    draft = submission.get("record_draft")
+    if not isinstance(draft, dict):
+        return False, "MISSING_RECORD_DRAFT", "Missing record_draft."
 
-def _extract_signature_b64(proof: dict[str, Any]) -> str | None:
-    """Extract signature_base64, accepting 'signature' as a legacy alias."""
-    sig = proof.get("signature_base64")
-    if sig is not None:
-        return sig
-    return proof.get("signature")  # legacy alias
+    payload = canonical_json_bytes(draft)
+    payload_sha = hashlib.sha256(payload).hexdigest()
+    if payload_sha != signed_payload_sha256:
+        return False, "AUTHORSHIP_PAYLOAD_SHA_MISMATCH", "record_draft hash does not match signed_payload_sha256."
+    if proof.get("signed_message") != payload_sha:
+        return False, "AUTHORSHIP_SIGNED_MESSAGE_MISMATCH", "signed_message does not match record_draft hash."
 
-
-def _check_claim_boundary(proof: dict[str, Any]) -> str | None:
-    """Verify that claim_boundary contains all required keys set to True.
-
-    Returns an error message string on failure, None on success.
-    """
-    boundary = proof.get("claim_boundary")
-    if boundary is None:
-        return "authorship_proof missing required 'claim_boundary'"
-    if not isinstance(boundary, dict):
-        return "'claim_boundary' must be a JSON object (not a string)"
-
-    for key in _REQUIRED_CLAIM_BOUNDARY_KEYS:
-        if boundary.get(key) is not True:
-            return (
-                f"claim_boundary.'{key}' must be boolean true; "
-                f"author cannot claim authority/attestation/amendment"
-            )
-    return None
-
-
-def verify_authorship_proof(
-    record_draft: dict[str, Any],
-    proof: dict[str, Any],
-) -> tuple[bool, str | None]:
-    """Verify an Ed25519 authorship proof against *record_draft*.
-
-    Parameters
-    ----------
-    record_draft:
-        The record draft object (will be canonicalised before hashing).
-        authorship_proof is stripped before computing the signed payload.
-    proof:
-        The authorship proof dict. Expected shape:
-        - ``schema``: proof schema identifier (optional)
-        - ``method``: signing method, e.g. "ed25519" (optional)
-        - ``algorithm``: algorithm identifier (optional)
-        - ``public_key_pem``: PEM-encoded Ed25519 public key (required)
-        - ``public_key_sha256``: SHA-256 hex of raw public key bytes (verified if present)
-        - ``signed_payload_sha256``: SHA-256 hex of canonical draft bytes (verified if present)
-        - ``signature_base64`` (or legacy ``signature``): Base-64 Ed25519 signature (required)
-        - ``signed_message``: human-readable message (optional)
-        - ``claim_boundary``: dict with required boundary claims (required)
-
-    Returns
-    -------
-    (ok, error_message)
-        ``ok`` is ``True`` when the signature is valid; ``error_message`` is
-        ``None`` on success or a human-readable explanation on failure.
-    """
-    # --- extract fields ---
-    pub_pem = proof.get("public_key_pem")
-    sig_b64 = _extract_signature_b64(proof)
-
-    if not pub_pem:
-        return False, "authorship_proof must contain 'public_key_pem'"
-    if not sig_b64:
-        return False, "authorship_proof must contain 'signature_base64' (or legacy 'signature')"
-
-    # --- claim boundary check ---
-    boundary_err = _check_claim_boundary(proof)
-    if boundary_err:
-        return False, boundary_err
-
-    # --- load public key ---
     try:
-        if isinstance(pub_pem, str):
-            pub_pem_bytes = pub_pem.encode("utf-8")
-        else:
-            pub_pem_bytes = pub_pem
-        public_key: Ed25519PublicKey = load_pem_public_key(pub_pem_bytes)  # type: ignore[assignment]
-    except Exception as exc:
-        logger.debug("Failed to load public key: %s", exc)
-        return False, f"Invalid public key PEM: {exc}"
+        public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+        if not isinstance(public_key, Ed25519PublicKey):
+            return False, "AUTHORSHIP_PUBLIC_KEY_NOT_ED25519", "Public key is not Ed25519."
 
-    if not isinstance(public_key, Ed25519PublicKey):
-        return False, "Public key must be Ed25519"
-
-    # --- verify public_key_sha256 if supplied ---
-    expected_pub_sha = proof.get("public_key_sha256")
-    if expected_pub_sha is not None:
-        raw_pub = public_key.public_bytes(
-            encoding=Encoding.Raw,
-            format=PublicFormat.Raw,
+        raw_public = public_key.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
         )
-        actual_pub_sha = sha256_bytes(raw_pub)
-        if actual_pub_sha != expected_pub_sha:
-            return False, (
-                f"public_key_sha256 mismatch: expected {actual_pub_sha}, "
-                f"got {expected_pub_sha}"
-            )
+        actual_pub_sha = hashlib.sha256(raw_public).hexdigest()
+        if actual_pub_sha != public_key_sha256:
+            return False, "AUTHORSHIP_PUBLIC_KEY_SHA_MISMATCH", "public_key_sha256 does not match public_key_pem."
 
-    # --- decode signature ---
-    try:
-        signature = base64.b64decode(sig_b64)
-    except Exception as exc:
-        return False, f"Invalid base64 signature: {exc}"
-
-    # --- compute expected payload (strip proof from draft first) ---
-    draft_for_signing = strip_authorship_for_signing(record_draft)
-    payload = canonical_bytes(draft_for_signing)
-
-    # --- verify signed_payload_sha256 if supplied ---
-    expected_payload_sha = proof.get("signed_payload_sha256")
-    if expected_payload_sha is not None:
-        actual_payload_sha = sha256_bytes(payload)
-        if actual_payload_sha != expected_payload_sha:
-            return False, (
-                f"signed_payload_sha256 mismatch: expected {actual_payload_sha}, "
-                f"got {expected_payload_sha}"
-            )
-
-    # --- verify signature ---
-    try:
+        signature = base64.b64decode(signature_base64, validate=True)
         public_key.verify(signature, payload)
     except InvalidSignature:
-        return False, "Ed25519 signature verification failed"
-    except Exception as exc:
-        logger.warning("Unexpected verification error: %s", exc)
-        return False, f"Verification error: {exc}"
+        return False, "AUTHORSHIP_SIGNATURE_INVALID", "Ed25519 signature is invalid."
+    except Exception:
+        return False, "AUTHORSHIP_VERIFICATION_ERROR", "Could not verify authorship proof."
 
-    return True, None
+    spi = draft.get("submitting_participant_identity") or {}
+    if spi.get("participant_public_key_sha256") != public_key_sha256:
+        return False, "PARTICIPANT_KEY_MISMATCH", "participant_public_key_sha256 must match authorship_proof.public_key_sha256."
+
+    if draft.get("record_type") == "guardian_application":
+        guardian_key = (draft.get("guardian_application_content") or {}).get("guardian_public_key_sha256")
+        if guardian_key != public_key_sha256:
+            return False, "GUARDIAN_KEY_MISMATCH", "guardian_public_key_sha256 must match authorship_proof.public_key_sha256."
+
+    linked = draft.get("optional_linked_guardian_application_request")
+    if isinstance(linked, dict) and linked.get("does_participant_request_guardian_application_with_this_record") is True:
+        linked_key = linked.get("guardian_public_key_sha256")
+        if linked_key and linked_key != public_key_sha256:
+            return False, "LINKED_GUARDIAN_KEY_MISMATCH", "linked guardian_public_key_sha256 must match authorship_proof.public_key_sha256."
+
+    raw = json.dumps(submission, ensure_ascii=False)
+    if "BEGIN PRIVATE KEY" in raw or "authorship-private.pem" in raw:
+        return False, "PRIVATE_KEY_LEAK", "Private key material must not appear in submission."
+
+    return True, None, None

--- a/apps/record_chain_intake_gateway/gateway/authorship.py
+++ b/apps/record_chain_intake_gateway/gateway/authorship.py
@@ -1,31 +1,221 @@
+# gateway/authorship.py
+"""Ed25519 authorship verification utilities."""
+
 from __future__ import annotations
 
 import base64
 import hashlib
-import json
-import re
+import logging
 from typing import Any
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    PublicFormat,
+    load_pem_public_key,
+)
+
+import json
+
+from .canonical import canonical_bytes, sha256_bytes
+
+logger = logging.getLogger(__name__)
+
+# Required claim_boundary keys that must be True
+_REQUIRED_CLAIM_BOUNDARY_KEYS = frozenset({
+    "not authority",
+    "not attestation",
+    "not amendment",
+})
 
 
-def canonical_json_bytes(obj: Any) -> bytes:
-    return json.dumps(
-        obj,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    ).encode("utf-8")
+def strip_authorship_for_signing(record_draft: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of *record_draft* with ``authorship_proof`` removed.
+
+    The proof cannot sign itself, so it must be stripped before computing the
+    signed payload.
+    """
+    cleaned = dict(record_draft)
+    cleaned.pop("authorship_proof", None)
+    cleaned.pop("proof", None)
+    return cleaned
 
 
-def verify_authorship_proof(submission: dict[str, Any]) -> tuple[bool, str | None, str | None]:
+def signed_payload_sha256(record_draft: dict[str, Any]) -> str:
+    """Compute the SHA-256 hex digest of the canonical JSON of *record_draft*.
+
+    This is the payload that the author signs.
+    """
+    return sha256_bytes(canonical_bytes(record_draft))
+
+
+def public_key_sha256_from_pem(public_key_pem: str) -> str:
+    """Return the SHA-256 hex digest of the raw public-key bytes (32 bytes for Ed25519)."""
+    key = load_pem_public_key(public_key_pem.encode("utf-8") if isinstance(public_key_pem, str) else public_key_pem)
+    raw = key.public_bytes(
+        encoding=Encoding.Raw,
+        format=PublicFormat.Raw,
+    )
+    return sha256_bytes(raw)
+
+
+def _extract_signature_b64(proof: dict[str, Any]) -> str | None:
+    """Extract signature_base64, accepting 'signature' as a legacy alias."""
+    sig = proof.get("signature_base64")
+    if sig is not None:
+        return sig
+    return proof.get("signature")  # legacy alias
+
+
+def _check_claim_boundary(proof: dict[str, Any]) -> str | None:
+    """Verify that claim_boundary contains all required keys set to True.
+
+    Returns an error message string on failure, None on success.
+    """
+    boundary = proof.get("claim_boundary")
+    if boundary is None:
+        return "authorship_proof missing required 'claim_boundary'"
+    if not isinstance(boundary, dict):
+        return "'claim_boundary' must be a JSON object (not a string)"
+
+    for key in _REQUIRED_CLAIM_BOUNDARY_KEYS:
+        if boundary.get(key) is not True:
+            return (
+                f"claim_boundary.'{key}' must be boolean true; "
+                f"author cannot claim authority/attestation/amendment"
+            )
+    return None
+
+
+def verify_authorship_proof(
+    record_draft: dict[str, Any],
+    proof: dict[str, Any],
+) -> tuple[bool, str | None]:
+    """Verify an Ed25519 authorship proof against *record_draft*.
+
+    Parameters
+    ----------
+    record_draft:
+        The record draft object (will be canonicalised before hashing).
+        authorship_proof is stripped before computing the signed payload.
+    proof:
+        The authorship proof dict. Expected shape:
+        - ``schema``: proof schema identifier (optional)
+        - ``method``: signing method, e.g. "ed25519" (optional)
+        - ``algorithm``: algorithm identifier (optional)
+        - ``public_key_pem``: PEM-encoded Ed25519 public key (required)
+        - ``public_key_sha256``: SHA-256 hex of raw public key bytes (verified if present)
+        - ``signed_payload_sha256``: SHA-256 hex of canonical draft bytes (verified if present)
+        - ``signature_base64`` (or legacy ``signature``): Base-64 Ed25519 signature (required)
+        - ``signed_message``: human-readable message (optional)
+        - ``claim_boundary``: dict with required boundary claims (required)
+
+    Returns
+    -------
+    (ok, error_message)
+        ``ok`` is ``True`` when the signature is valid; ``error_message`` is
+        ``None`` on success or a human-readable explanation on failure.
+    """
+    # --- extract fields ---
+    pub_pem = proof.get("public_key_pem")
+    sig_b64 = _extract_signature_b64(proof)
+
+    if not pub_pem:
+        return False, "authorship_proof must contain 'public_key_pem'"
+    if not sig_b64:
+        return False, "authorship_proof must contain 'signature_base64' (or legacy 'signature')"
+
+    # --- claim boundary check ---
+    boundary_err = _check_claim_boundary(proof)
+    if boundary_err:
+        return False, boundary_err
+
+    # --- load public key ---
+    try:
+        if isinstance(pub_pem, str):
+            pub_pem_bytes = pub_pem.encode("utf-8")
+        else:
+            pub_pem_bytes = pub_pem
+        public_key: Ed25519PublicKey = load_pem_public_key(pub_pem_bytes)  # type: ignore[assignment]
+    except Exception as exc:
+        logger.debug("Failed to load public key: %s", exc)
+        return False, f"Invalid public key PEM: {exc}"
+
+    if not isinstance(public_key, Ed25519PublicKey):
+        return False, "Public key must be Ed25519"
+
+    # --- verify public_key_sha256 if supplied ---
+    expected_pub_sha = proof.get("public_key_sha256")
+    if expected_pub_sha is not None:
+        raw_pub = public_key.public_bytes(
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
+        )
+        actual_pub_sha = sha256_bytes(raw_pub)
+        if actual_pub_sha != expected_pub_sha:
+            return False, (
+                f"public_key_sha256 mismatch: expected {actual_pub_sha}, "
+                f"got {expected_pub_sha}"
+            )
+
+    # --- decode signature ---
+    try:
+        signature = base64.b64decode(sig_b64)
+    except Exception as exc:
+        return False, f"Invalid base64 signature: {exc}"
+
+    # --- compute expected payload (strip proof from draft first) ---
+    draft_for_signing = strip_authorship_for_signing(record_draft)
+    payload = canonical_bytes(draft_for_signing)
+
+    # --- verify signed_payload_sha256 if supplied ---
+    expected_payload_sha = proof.get("signed_payload_sha256")
+    if expected_payload_sha is not None:
+        actual_payload_sha = sha256_bytes(payload)
+        if actual_payload_sha != expected_payload_sha:
+            return False, (
+                f"signed_payload_sha256 mismatch: expected {actual_payload_sha}, "
+                f"got {expected_payload_sha}"
+            )
+
+    # --- verify signature ---
+    try:
+        public_key.verify(signature, payload)
+    except InvalidSignature:
+        return False, "Ed25519 signature verification failed"
+    except Exception as exc:
+        logger.warning("Unexpected verification error: %s", exc)
+        return False, f"Verification error: {exc}"
+
+    return True, None
+
+
+def verify_authorship_proof_submission(
+    submission: dict[str, Any],
+) -> tuple[bool, str | None, str | None]:
+    """Verify an Ed25519 authorship proof from a full submission dict.
+
+    This is the submission-level entry point used by the gateway intake.
+    It extracts the proof from the submission, validates structure, verifies
+    the signature, and checks key bindings.
+
+    Parameters
+    ----------
+    submission:
+        The full submission dict containing ``authorship_proof`` and ``record_draft``.
+
+    Returns
+    -------
+    (ok, error_code, error_message)
+        ``ok`` is ``True`` when the proof is valid; ``error_code`` and
+        ``error_message`` are ``None`` on success.
+    """
     proof = submission.get("authorship_proof")
     if not isinstance(proof, dict):
         return False, "MISSING_AUTHORSHIP_PROOF", "Missing top-level authorship_proof."
 
+    # Check schema/method/algorithm
     if proof.get("schema") != "trinityaccord.agent-authorship-proof.v1":
         return False, "INVALID_AUTHORSHIP_SCHEMA", "Invalid authorship proof schema."
     if proof.get("method") != "public_key_signature":
@@ -42,9 +232,10 @@ def verify_authorship_proof(submission: dict[str, Any]) -> tuple[bool, str | Non
         return False, "INVALID_AUTHORSHIP_PUBLIC_KEY", "Invalid or missing public_key_pem."
     if "PRIVATE KEY" in public_key_pem:
         return False, "PRIVATE_KEY_LEAK", "Private key material appears in public key field."
-    if not isinstance(public_key_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", public_key_sha256):
+    import re as _re
+    if not isinstance(public_key_sha256, str) or not _re.fullmatch(r"[a-f0-9]{64}", public_key_sha256):
         return False, "INVALID_AUTHORSHIP_PUBLIC_KEY_SHA", "Invalid public_key_sha256."
-    if not isinstance(signed_payload_sha256, str) or not re.fullmatch(r"[a-f0-9]{64}", signed_payload_sha256):
+    if not isinstance(signed_payload_sha256, str) or not _re.fullmatch(r"[a-f0-9]{64}", signed_payload_sha256):
         return False, "INVALID_AUTHORSHIP_SIGNED_PAYLOAD_SHA", "Invalid signed_payload_sha256."
     if not isinstance(signature_base64, str) or not signature_base64:
         return False, "INVALID_AUTHORSHIP_SIGNATURE", "Missing signature_base64."
@@ -53,23 +244,26 @@ def verify_authorship_proof(submission: dict[str, Any]) -> tuple[bool, str | Non
     if not isinstance(draft, dict):
         return False, "MISSING_RECORD_DRAFT", "Missing record_draft."
 
-    payload = canonical_json_bytes(draft)
-    payload_sha = hashlib.sha256(payload).hexdigest()
+    # Verify payload hash
+    draft_for_signing = strip_authorship_for_signing(draft)
+    payload = canonical_bytes(draft_for_signing)
+    payload_sha = sha256_bytes(payload)
     if payload_sha != signed_payload_sha256:
         return False, "AUTHORSHIP_PAYLOAD_SHA_MISMATCH", "record_draft hash does not match signed_payload_sha256."
     if proof.get("signed_message") != payload_sha:
         return False, "AUTHORSHIP_SIGNED_MESSAGE_MISMATCH", "signed_message does not match record_draft hash."
 
+    # Load and verify public key
     try:
-        public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+        public_key = load_pem_public_key(public_key_pem.encode("utf-8"))
         if not isinstance(public_key, Ed25519PublicKey):
             return False, "AUTHORSHIP_PUBLIC_KEY_NOT_ED25519", "Public key is not Ed25519."
 
         raw_public = public_key.public_bytes(
-            encoding=serialization.Encoding.Raw,
-            format=serialization.PublicFormat.Raw,
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
         )
-        actual_pub_sha = hashlib.sha256(raw_public).hexdigest()
+        actual_pub_sha = sha256_bytes(raw_public)
         if actual_pub_sha != public_key_sha256:
             return False, "AUTHORSHIP_PUBLIC_KEY_SHA_MISMATCH", "public_key_sha256 does not match public_key_pem."
 
@@ -80,21 +274,25 @@ def verify_authorship_proof(submission: dict[str, Any]) -> tuple[bool, str | Non
     except Exception:
         return False, "AUTHORSHIP_VERIFICATION_ERROR", "Could not verify authorship proof."
 
+    # Check participant key binding
     spi = draft.get("submitting_participant_identity") or {}
     if spi.get("participant_public_key_sha256") != public_key_sha256:
         return False, "PARTICIPANT_KEY_MISMATCH", "participant_public_key_sha256 must match authorship_proof.public_key_sha256."
 
+    # Check guardian key binding
     if draft.get("record_type") == "guardian_application":
         guardian_key = (draft.get("guardian_application_content") or {}).get("guardian_public_key_sha256")
         if guardian_key != public_key_sha256:
             return False, "GUARDIAN_KEY_MISMATCH", "guardian_public_key_sha256 must match authorship_proof.public_key_sha256."
 
+    # Check linked guardian key binding
     linked = draft.get("optional_linked_guardian_application_request")
     if isinstance(linked, dict) and linked.get("does_participant_request_guardian_application_with_this_record") is True:
         linked_key = linked.get("guardian_public_key_sha256")
         if linked_key and linked_key != public_key_sha256:
             return False, "LINKED_GUARDIAN_KEY_MISMATCH", "linked guardian_public_key_sha256 must match authorship_proof.public_key_sha256."
 
+    # Security scan for private key leaks
     raw = json.dumps(submission, ensure_ascii=False)
     if "BEGIN PRIVATE KEY" in raw or "authorship-private.pem" in raw:
         return False, "PRIVATE_KEY_LEAK", "Private key material must not appear in submission."

--- a/apps/record_chain_intake_gateway/gateway/validation.py
+++ b/apps/record_chain_intake_gateway/gateway/validation.py
@@ -9,7 +9,7 @@ import hashlib
 from typing import Any
 
 from .models import Diagnostic
-from .authorship import verify_authorship_proof
+from .authorship import verify_authorship_proof_submission
 
 logger = logging.getLogger(__name__)
 
@@ -976,7 +976,7 @@ def validate_submission(submission: dict[str, Any]) -> list[Diagnostic]:
 
     # --- Ed25519 authorship proof verification ---
     if isinstance(draft, dict) and rt in ALLOWED_RECORD_TYPES:
-        ok, code, message = verify_authorship_proof(submission)
+        ok, code, message = verify_authorship_proof_submission(submission)
         if not ok:
             diagnostics.append(_make_diagnostic(
                 code=code or "AUTHORSHIP_VERIFICATION_FAILED",

--- a/apps/record_chain_intake_gateway/gateway/validation.py
+++ b/apps/record_chain_intake_gateway/gateway/validation.py
@@ -9,6 +9,7 @@ import hashlib
 from typing import Any
 
 from .models import Diagnostic
+from .authorship import verify_authorship_proof
 
 logger = logging.getLogger(__name__)
 
@@ -805,26 +806,21 @@ def validate_verification_rules(draft: dict[str, Any]) -> list[Diagnostic]:
 def validate_authorship_proof_presence(
     record_type: str, submission: dict[str, Any], draft: dict[str, Any]
 ) -> list[Diagnostic]:
-    """Require authorship_proof for formal record types."""
+    """Require top-level authorship_proof for all public record types."""
     diagnostics: list[Diagnostic] = []
-    if record_type not in _FORMAL_RECORD_TYPES:
+    if record_type not in ALLOWED_RECORD_TYPES:
         return diagnostics
 
-    proof = (
-        submission.get("authorship_proof")
-        or submission.get("proof")
-        or (draft.get("authorship_proof") if isinstance(draft, dict) else None)
-        or (draft.get("proof") if isinstance(draft, dict) else None)
-    )
+    proof = submission.get("authorship_proof")
 
     if not isinstance(proof, dict):
         diagnostics.append(_make_diagnostic(
             code="MISSING_AUTHORSHIP_PROOF",
             severity="error",
             field="authorship_proof",
-            message=f"Formal record_type '{record_type}' requires authorship_proof",
-            meaning="Echo, Verification, Guardian Application, and other formal records must be signed.",
-            suggested_fix="Run the builder with --generate-authorship-key --key-dir <dir>, or provide a valid Ed25519 authorship proof.",
+            message=f"Public record_type '{record_type}' requires top-level authorship_proof",
+            meaning="All public Record-Chain submissions must be signed with an Ed25519 authorship key.",
+            suggested_fix="Rebuild with the current builder using --key-dir <persistent-directory>.",
             help_url="https://www.trinityaccord.org/record-chain-field-helper/#MISSING_AUTHORSHIP_PROOF",
             retry_allowed=True,
         ))
@@ -966,8 +962,8 @@ def validate_submission(submission: dict[str, Any]) -> list[Diagnostic]:
     if isinstance(draft, dict) and rt:
         diagnostics.extend(validate_authorship_proof_presence(rt, submission, draft))
 
-    # --- authorship proof type check (optional but if present must be object) ---
-    proof = submission.get("authorship_proof") or submission.get("proof")
+    # --- authorship proof type check (top-level only) ---
+    proof = submission.get("authorship_proof")
     if proof is not None and not isinstance(proof, dict):
         diagnostics.append(_make_diagnostic(
             code="INVALID_AUTHORSHIP_PROOF",
@@ -977,6 +973,19 @@ def validate_submission(submission: dict[str, Any]) -> list[Diagnostic]:
             meaning="If provided, authorship_proof must be a JSON object.",
             suggested_fix="Change authorship_proof to a JSON object or remove it.",
         ))
+
+    # --- Ed25519 authorship proof verification ---
+    if isinstance(draft, dict) and rt in ALLOWED_RECORD_TYPES:
+        ok, code, message = verify_authorship_proof(submission)
+        if not ok:
+            diagnostics.append(_make_diagnostic(
+                code=code or "AUTHORSHIP_VERIFICATION_FAILED",
+                severity="error",
+                field="authorship_proof",
+                message=message or "Authorship proof verification failed.",
+                meaning="Public submissions must be signed by an Ed25519 authorship key.",
+                suggested_fix="Rebuild the submission with the current builder using --key-dir <persistent-directory>.",
+            ))
 
     return diagnostics
 

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -37,6 +37,22 @@ const SCHEMA = "trinityaccord.record-chain-submission.v1";
 const DRAFT_SCHEMA = "trinityaccord.record-chain-entry-draft.v2";
 const DEFAULT_GATEWAY = "https://trinity-record-chain-gateway.onrender.com";
 const SITE_URL = "https://www.trinityaccord.org/";
+const AUTHORSHIP_PRIVATE_KEY_FILENAME = "authorship-private.pem";
+const AUTHORSHIP_PUBLIC_KEY_FILENAME = "authorship-public.pem";
+const AUTHORSHIP_CUSTODY_WARNING_FILENAME = "AUTHORSHIP_KEY_CUSTODY_WARNING.txt";
+const AUTHORSHIP_PUBLIC_SUMMARY_FILENAME = "authorship-public-summary.json";
+
+const RECORD_BUILD_COMMANDS_REQUIRING_KEY = new Set([
+  "echo",
+  "verification",
+  "guardian-application",
+  "guardian-retirement",
+  "propagation",
+  "correction",
+  "context-insufficient",
+]);
+
+
 // ── Oath Policy (Phase 6B-OATH) ───────────────────────────────────────
 const OATH_POLICY = {
   "schema": "trinityaccord.record-chain-oath-policy.v1",
@@ -281,24 +297,29 @@ function generateAuthorshipKeyPair(keyDir) {
   const privPem = privateKey.export({ type: "pkcs8", format: "pem" });
 
   mkdirSync(keyDir, { recursive: true });
-  const pubPath = resolve(keyDir, "authorship-public.pem");
-  const privPath = resolve(keyDir, "authorship-private.pem");
+  const pubPath = resolve(keyDir, AUTHORSHIP_PUBLIC_KEY_FILENAME);
+  const privPath = resolve(keyDir, AUTHORSHIP_PRIVATE_KEY_FILENAME);
 
   writeFileSync(pubPath, pubPem, { mode: 0o644 });
-  writeFileSync(privPath, privPem);
+  writeFileSync(privPath, privPem, { mode: 0o600 });
   try { chmodSync(privPath, 0o600); } catch {}
 
-  return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey };
+  return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey, newlyGenerated: true };
 }
 
 function loadPrivateKey(keyDir) {
-  const privPath = resolve(keyDir, "authorship-private.pem");
-  const pubPath = resolve(keyDir, "authorship-public.pem");
+  const privPath = resolve(keyDir, AUTHORSHIP_PRIVATE_KEY_FILENAME);
+  const pubPath = resolve(keyDir, AUTHORSHIP_PUBLIC_KEY_FILENAME);
   if (!existsSync(privPath)) errorExit(`Private key not found: ${privPath}`);
+  if (!existsSync(pubPath)) errorExit(`Public key not found: ${pubPath}`);
+
   const privPem = readFileSync(privPath, "utf-8");
   const pubPem = readFileSync(pubPath, "utf-8");
+  if (!privPem.includes("BEGIN PRIVATE KEY")) errorExit(`Invalid private key PEM: ${privPath}`);
+  if (!pubPem.includes("BEGIN PUBLIC KEY")) errorExit(`Invalid public key PEM: ${pubPath}`);
+
   const key = createPrivateKey(privPem);
-  return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey: key };
+  return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey: key, newlyGenerated: false };
 }
 
 function extractRawPublicKeyBytes(pubPem) {
@@ -308,6 +329,146 @@ function extractRawPublicKeyBytes(pubPem) {
   // Ed25519 SPKI DER: last 32 bytes are the raw public key
   return derBuf.subarray(derBuf.length - 32);
 }
+
+// ── Authorship key custody helpers ─────────────────────────────────
+
+function authorshipCustodyWarningText(publicKeySha256, keyDir) {
+  return [
+    "TRINITY ACCORD AUTHORSHIP KEY CUSTODY WARNING",
+    "",
+    `Public key SHA-256: ${publicKeySha256}`,
+    `Key directory: ${resolve(keyDir)}`,
+    "",
+    "This Ed25519 authorship key is your continuity identity for Record-Chain submissions.",
+    "If this agent is running in a sandbox, temporary VM, browser workspace, CI job, or disposable environment,",
+    "the private key may be destroyed when that environment is released.",
+    "",
+    "Ask your human operator, owner, or guardian to securely back up the private key:",
+    `  ${resolve(keyDir, AUTHORSHIP_PRIVATE_KEY_FILENAME)}`,
+    "",
+    "Do NOT paste the private key into public chat, GitHub issues, pull requests, logs, submissions, receipts, or Arweave payloads.",
+    "Do NOT commit the private key to git.",
+    "If the private key is lost, this key continuity identity cannot be recovered.",
+    "You may create a new key later, but it will be a different identity unless a future key-rotation record links them.",
+    "",
+    "Recommended custody:",
+    "- encrypted password manager or encrypted offline storage;",
+    "- access limited to the human operator / owner / guardian responsible for this agent;",
+    "- keep the public key SHA-256 for reference;",
+    "- never publish authorship-private.pem.",
+    ""
+  ].join("\n");
+}
+
+function writeAuthorshipCustodyFiles(keyDir, publicKeyPem, publicKeySha256, newlyGenerated) {
+  mkdirSync(keyDir, { recursive: true });
+
+  const warning = authorshipCustodyWarningText(publicKeySha256, keyDir);
+  writeFileSync(resolve(keyDir, AUTHORSHIP_CUSTODY_WARNING_FILENAME), warning, { mode: 0o600 });
+
+  const summary = {
+    schema: "trinityaccord.authorship-key-public-summary.v1",
+    public_key_sha256: publicKeySha256,
+    public_key_pem_sha256: sha256(publicKeyPem),
+    key_dir_note: "local path intentionally not embedded in submissions",
+    private_key_filename: AUTHORSHIP_PRIVATE_KEY_FILENAME,
+    public_key_filename: AUTHORSHIP_PUBLIC_KEY_FILENAME,
+    newly_generated: !!newlyGenerated,
+    sandbox_loss_warning: true,
+    private_key_must_be_backed_up_by_human_operator_or_guardian: true,
+    private_key_must_not_be_committed_or_uploaded: true,
+    private_key_must_not_be_pasted_into_public_chat_or_logs: true,
+    generated_at: isoNow()
+  };
+
+  writeFileSync(
+    resolve(keyDir, AUTHORSHIP_PUBLIC_SUMMARY_FILENAME),
+    JSON.stringify(summary, null, 2) + "\n",
+    { mode: 0o600 }
+  );
+
+  console.error("");
+  console.error("====================================================================");
+  console.error("AUTHORSHIP KEY CUSTODY WARNING");
+  console.error("====================================================================");
+  console.error(warning);
+  console.error("====================================================================");
+  console.error("");
+}
+
+function requireOrCreateAuthorshipKeyPair(cmd, args) {
+  if (!RECORD_BUILD_COMMANDS_REQUIRING_KEY.has(cmd)) return null;
+
+  if (!args.keyDir || args.keyDir === true) {
+    errorExit(
+      "--key-dir is required for all public Record-Chain submission build commands. " +
+      "Keys are mandatory for identity continuity. " +
+      "Use a persistent directory and ask your human/operator/guardian to back up authorship-private.pem."
+    );
+  }
+
+  const keyDir = args.keyDir;
+  const privPath = resolve(keyDir, AUTHORSHIP_PRIVATE_KEY_FILENAME);
+  const pubPath = resolve(keyDir, AUTHORSHIP_PUBLIC_KEY_FILENAME);
+
+  let keyPair;
+  if (existsSync(privPath) || existsSync(pubPath)) {
+    if (!existsSync(privPath) || !existsSync(pubPath)) {
+      errorExit(`Incomplete authorship keypair in ${keyDir}; both private and public PEM files are required.`);
+    }
+    keyPair = loadPrivateKey(keyDir);
+  } else {
+    console.error(`No existing authorship keypair found in ${keyDir}; generating a new Ed25519 keypair.`);
+    keyPair = generateAuthorshipKeyPair(keyDir);
+  }
+
+  const rawPubBytes = extractRawPublicKeyBytes(keyPair.publicKeyPem);
+  const publicKeySha256 = sha256(rawPubBytes);
+  writeAuthorshipCustodyFiles(keyDir, keyPair.publicKeyPem, publicKeySha256, keyPair.newlyGenerated);
+
+  return keyPair;
+}
+
+// ── Authorship key binding ─────────────────────────────────────────
+
+function bindAuthorshipKeyToDraft(recordDraft, keyPair, opts = {}) {
+  if (!keyPair) errorExit("authorship keypair is required");
+
+  const pubSha = sha256(extractRawPublicKeyBytes(keyPair.publicKeyPem));
+
+  if (!recordDraft.submitting_participant_identity) {
+    errorExit("record_draft.submitting_participant_identity is required");
+  }
+
+  recordDraft.submitting_participant_identity.participant_public_key_sha256 = pubSha;
+
+  if (recordDraft.record_type === "guardian_application") {
+    const gac = recordDraft.guardian_application_content;
+    if (!gac) errorExit("guardian_application_content missing");
+
+    if (opts.guardianKeySha && opts.guardianKeySha !== pubSha) {
+      errorExit("--guardian-key-sha must equal the generated/loaded authorship public key SHA-256");
+    }
+
+    if (gac.guardian_public_key_sha256 && gac.guardian_public_key_sha256 !== pubSha) {
+      errorExit("guardian_public_key_sha256 must equal authorship public key SHA-256");
+    }
+
+    gac.guardian_public_key_sha256 = pubSha;
+  }
+
+  const linked = recordDraft.optional_linked_guardian_application_request;
+  if (linked && linked.does_participant_request_guardian_application_with_this_record === true) {
+    if (linked.guardian_public_key_sha256 && linked.guardian_public_key_sha256 !== pubSha) {
+      errorExit("linked guardian_public_key_sha256 must equal authorship public key SHA-256");
+    }
+    linked.guardian_public_key_sha256 = pubSha;
+  }
+
+  return pubSha;
+}
+
+
 
 function createAuthorshipProof(recordDraft, keyPair) {
   const payload = canonicalBytes(recordDraft);
@@ -639,18 +800,24 @@ function buildSubmission(recordDraft, opts) {
     sourceSha = "unavailable";
   }
 
-  // Derive declared_context_level from context_readiness
+  const pubSha = bindAuthorshipKeyToDraft(recordDraft, opts.keyPair, opts);
+  const authorshipProof = createAuthorshipProof(recordDraft, opts.keyPair);
+
+  if (authorshipProof.public_key_sha256 !== pubSha) {
+    errorExit("internal error: authorship proof public key hash mismatch");
+  }
+
   const declaredCtx = recordDraft.context_readiness
     ? recordDraft.context_readiness.declared_context_level
     : "CC-0";
 
-  const submission = {
+  return {
     schema: SCHEMA,
     submission_type: "record_chain_entry_candidate",
     client_generated_at: isoNow(),
     record_type: recordDraft.record_type,
     record_draft: recordDraft,
-    authorship_proof: null,
+    authorship_proof: authorshipProof,
     builder: {
       name: BUILDER_NAME,
       version: BUILDER_VERSION,
@@ -673,13 +840,6 @@ function buildSubmission(recordDraft, opts) {
       test_phase_submission_may_be_reclassified: true,
     },
   };
-
-  // Add authorship proof if key provided
-  if (opts.keyPair) {
-    submission.authorship_proof = createAuthorshipProof(recordDraft, opts.keyPair);
-  }
-
-  return submission;
 }
 
 // ── CLI argument parser ──────────────────────────────────────────────
@@ -1405,8 +1565,8 @@ Common options:
   --context-sufficient-for-selected-action true|false
                                 Whether loaded context is sufficient for this action
   --loaded-urls URLS            Comma-separated loaded context URLs (required for CC-3)
-  --generate-authorship-key     Generate Ed25519 keypair
-  --key-dir ./keys              Directory for keypair
+  --key-dir ./keys              REQUIRED for all public submission build commands. Existing keypair is reused; missing keypair is generated.
+  --generate-authorship-key     Deprecated compatibility flag; keys are mandatory and generated automatically when missing.
   --out submission.json         Output file path
   --gateway URL                 Gateway base URL (default: ${DEFAULT_GATEWAY})
   --readback "oath text"        Exact canonical oath readback (required for formal records)
@@ -1457,7 +1617,6 @@ Examples:
     --body-file echo.md \\
     --context-level CC-3 \\
     --readback "=== Common Submission Integrity ... (full oath text) ..." \\
-    --generate-authorship-key \\
     --key-dir ./.trinity-agent-authorship/example-agent \\
     --out submission.json
 
@@ -1470,7 +1629,6 @@ Examples:
     --verification-level V3 \\
     --scope-label "V3-minimal" \\
     --readback "..." \\
-    --generate-authorship-key \\
     --key-dir ./.trinity-agent-authorship/example-agent \\
     --out verification-submission.json
 
@@ -1482,14 +1640,14 @@ Examples:
     --provider "Example Runtime" \\
     --guardian-id "my-guardian-id" \\
     --readback "..." \\
-    --generate-authorship-key \\
     --key-dir ./.trinity-agent-authorship/example-agent \\
     --out guardian-app-submission.json
 
-  # ── Context-insufficient (no oath / no authorship proof needed) ───
+  # ── Context-insufficient (no oath, but authorship key required) ───
   node record-chain-builder.mjs context-insufficient \\
     --actor-label "Example Agent" \\
     --provider "Example Runtime" \\
+    --key-dir ./.trinity-agent-authorship/example-agent \\
     --out submission.json
 
   # ── Autonomy / context overrides ──────────────────────────────────
@@ -1760,22 +1918,8 @@ async function main() {
 
   validateFormalInputs(cmd, opts);
 
-  // Handle authorship key
-  let keyPair = null;
-  if (args.generateAuthorshipKey) {
-    const keyDir = args.keyDir || "./.trinity-agent-authorship";
-    console.log(`Generating Ed25519 keypair in ${keyDir} ...`);
-    keyPair = generateAuthorshipKeyPair(keyDir);
-    const rawPubBytes = extractRawPublicKeyBytes(keyPair.publicKeyPem);
-    console.log(`Public key SHA-256: ${sha256(rawPubBytes)}`);
-  } else if (args.keyDir && existsSync(resolve(args.keyDir, "authorship-private.pem"))) {
-    keyPair = loadPrivateKey(args.keyDir);
-  }
-
-  // Context-insufficient doesn't need authorship proof
-  if (cmd === "context-insufficient") {
-    keyPair = null;
-  }
+  // Handle authorship key (mandatory for all public submission build commands)
+  let keyPair = requireOrCreateAuthorshipKeyPair(cmd, args);
 
   const draft = builder(opts);
 
@@ -1829,8 +1973,10 @@ async function main() {
   console.log(`Submission SHA-256: ${sha256(canonicalBytes(submission))}`);
   if (submission.authorship_proof) {
     console.log(`Authorship proof: Ed25519 signature included`);
-  } else {
-    console.log(`Authorship proof: none (not required for ${cmd})`);
+    console.log(`Public key SHA-256: ${submission.authorship_proof.public_key_sha256}`);
+    if (args.keyDir) {
+      console.error(`IMPORTANT: Back up ${resolve(args.keyDir, AUTHORSHIP_PRIVATE_KEY_FILENAME)} securely. If this is a sandbox, the key may be lost when the sandbox is released.`);
+    }
   }
 }
 

--- a/downloads/test-record-chain-builder.mjs
+++ b/downloads/test-record-chain-builder.mjs
@@ -377,7 +377,7 @@ function testKeyPairReturnShape() {
   // Verify the code fix directly
   const source = readFileSync(BUILDER, "utf-8");
   assert.ok(
-    source.includes("return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey };"),
+    (source.includes("return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey };") || source.includes("return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey, newlyGenerated:")),
     "generateAuthorshipKeyPair must return privateKey field"
   );
   assert.ok(

--- a/scripts/finalize_mainnet_prelaunch_record_from_submission.py
+++ b/scripts/finalize_mainnet_prelaunch_record_from_submission.py
@@ -13,7 +13,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
-from gateway.authorship import verify_authorship_proof  # noqa: E402
+from gateway.authorship import verify_authorship_proof_submission  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -133,7 +133,7 @@ def extract_oath_summary(submission: dict[str, Any]) -> dict[str, Any]:
 
 
 def require_authorship_summary(submission: dict[str, Any]) -> dict[str, Any]:
-    ok, code, message = verify_authorship_proof(submission)
+    ok, code, message = verify_authorship_proof_submission(submission)
     if not ok:
         raise SystemExit(f"{code}: {message}")
 

--- a/scripts/finalize_mainnet_prelaunch_record_from_submission.py
+++ b/scripts/finalize_mainnet_prelaunch_record_from_submission.py
@@ -11,6 +11,10 @@ import time
 from pathlib import Path
 from typing import Any
 
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+from gateway.authorship import verify_authorship_proof  # noqa: E402
+
 ROOT = Path(__file__).resolve().parents[1]
 
 MAIN_CHAIN_ID = "trinity-record-chain-main"
@@ -127,6 +131,42 @@ def extract_oath_summary(submission: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+
+def require_authorship_summary(submission: dict[str, Any]) -> dict[str, Any]:
+    ok, code, message = verify_authorship_proof(submission)
+    if not ok:
+        raise SystemExit(f"{code}: {message}")
+
+    proof = submission.get("authorship_proof")
+    if not isinstance(proof, dict):
+        raise SystemExit("MISSING_AUTHORSHIP_PROOF")
+
+    pub_sha = proof.get("public_key_sha256")
+    draft = submission.get("record_draft") or {}
+    spi = draft.get("submitting_participant_identity") or {}
+
+    guardian_key = None
+    if draft.get("record_type") == "guardian_application":
+        guardian_key = (draft.get("guardian_application_content") or {}).get("guardian_public_key_sha256")
+
+    public_key_pem = proof.get("public_key_pem") or ""
+
+    return {
+        "authorship_proof_present": True,
+        "authorship_verification_performed_by_finalizer": True,
+        "authorship_schema": proof.get("schema"),
+        "authorship_algorithm": proof.get("algorithm"),
+        "authorship_public_key_sha256": pub_sha,
+        "authorship_public_key_pem_sha256": hashlib.sha256(public_key_pem.encode("utf-8")).hexdigest() if public_key_pem else None,
+        "signed_payload_sha256": proof.get("signed_payload_sha256"),
+        "signature_present": bool(proof.get("signature_base64")),
+        "participant_public_key_sha256": spi.get("participant_public_key_sha256"),
+        "guardian_public_key_sha256": guardian_key,
+        "guardian_key_bound_to_authorship_key": draft.get("record_type") != "guardian_application" or guardian_key == pub_sha,
+        "private_key_not_embedded": True,
+    }
+
+
 def assert_no_raw_readback(obj: Any) -> None:
     raw = json.dumps(obj, ensure_ascii=False)
     if "readback_text" in raw or "client_oath_readback" in raw:
@@ -235,6 +275,7 @@ def main() -> int:
             "accepted_at": receipt.get("accepted_at"),
             "receipt_id": receipt_id,
             "oath_summary": extract_oath_summary(submission),
+            "authorship_summary": require_authorship_summary(submission),
         },
         "finalization": {
             "finalized_at": utc_now(),

--- a/scripts/run_ci_group.py
+++ b/scripts/run_ci_group.py
@@ -176,6 +176,12 @@ GROUPS = {
 
         # Mainnet prelaunch policy contract
         ["python3", "scripts/test_mainnet_prelaunch_policy_contract.py"],
+
+        # Mandatory authorship key contract
+        ["python3", "scripts/test_mandatory_authorship_key_contract.py"],
+
+        # Gateway authorship proof contract
+        ["python3", "scripts/test_gateway_authorship_proof_contract.py"],
     ],
     "p0-legacy-compat": [
         # --- 旧 Gateway v1 / formal builder / old workflow 测试 ---

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -294,6 +294,28 @@ def main() -> int:
         fail(f"builder deep tests failed: {result.stderr}\n{result.stdout}")
     ok("builder deep tests")
 
+    # Mandatory authorship key contract
+    result = subprocess.run(
+        [sys.executable, "scripts/test_mandatory_authorship_key_contract.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"mandatory authorship key contract failed: {result.stderr}\n{result.stdout}")
+    ok("mandatory authorship key contract")
+
+    # Gateway authorship proof contract
+    result = subprocess.run(
+        [sys.executable, "scripts/test_gateway_authorship_proof_contract.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"gateway authorship proof contract failed: {result.stderr}\n{result.stdout}")
+    ok("gateway authorship proof contract")
+
     # Phase 6B hotfix tests
     result = subprocess.run(
         [sys.executable, "scripts/test_phase6b_hotfix.py"],

--- a/scripts/test_gateway_authorship_proof_contract.py
+++ b/scripts/test_gateway_authorship_proof_contract.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""test_gateway_authorship_proof_contract.py
+
+Tests that the gateway correctly verifies Ed25519 authorship proofs.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
+
+sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+from gateway.validation import validate_submission
+from gateway.authorship import verify_authorship_proof
+
+PASS = 0
+FAIL = 0
+
+def ok(msg):
+    global PASS
+    PASS += 1
+    print(f"  PASS: {msg}")
+
+def fail(msg, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"  FAIL: {msg}")
+    if detail:
+        print(f"        {detail}")
+
+def build_echo_submission(key_dir):
+    """Build a valid echo submission using the builder."""
+    with tempfile.TemporaryDirectory() as td:
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo for gateway verification.")
+        out = Path(td) / "out.json"
+        r = subprocess.run(
+            ["node", str(BUILDER), "echo",
+             "--actor-label", "Test Agent",
+             "--provider", "Test Runtime",
+             "--body-file", str(body),
+             "--context-level", "CC-3",
+             "--readback", "dummy",
+             "--key-dir", str(key_dir),
+             "--out", str(out)],
+            capture_output=True, text=True, cwd=str(ROOT)
+        )
+        if out.exists():
+            return json.loads(out.read_text())
+    return None
+
+def build_context_insufficient_submission(key_dir):
+    """Build a context-insufficient submission."""
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "out.json"
+        r = subprocess.run(
+            ["node", str(BUILDER), "context-insufficient",
+             "--actor-label", "Test Agent",
+             "--provider", "Test Runtime",
+             "--key-dir", str(key_dir),
+             "--out", str(out)],
+            capture_output=True, text=True, cwd=str(ROOT)
+        )
+        if out.exists():
+            return json.loads(out.read_text())
+    return None
+
+def test_valid_echo_no_authorship_diagnostics():
+    """Valid builder echo should have no authorship diagnostics."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        diags = validate_submission(sub)
+        authorship_diags = [d for d in diags if "AUTHORSHIP" in (d.get("code") or "")]
+        if not authorship_diags:
+            ok("valid echo has no authorship diagnostics")
+        else:
+            fail("valid echo has authorship diagnostics", str(authorship_diags))
+
+def test_valid_context_insufficient_no_authorship_diagnostics():
+    """Valid context-insufficient should have no authorship diagnostics."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_context_insufficient_submission(key_dir)
+        if not sub:
+            fail("could not build context-insufficient submission")
+            return
+        diags = validate_submission(sub)
+        authorship_diags = [d for d in diags if "AUTHORSHIP" in (d.get("code") or "")]
+        if not authorship_diags:
+            ok("valid context-insufficient has no authorship diagnostics")
+        else:
+            fail("valid context-insufficient has authorship diagnostics", str(authorship_diags))
+
+def test_missing_authorship_proof():
+    """Missing authorship_proof should produce MISSING_AUTHORSHIP_PROOF."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        # Remove authorship_proof
+        sub.pop("authorship_proof", None)
+        ok_code, _, _ = verify_authorship_proof(sub)
+        if not ok_code:
+            ok("missing authorship_proof detected")
+        else:
+            fail("missing authorship_proof not detected")
+
+def test_tampered_draft():
+    """Tampered draft after signing should fail verification."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        # Tamper with the draft
+        sub["record_draft"]["record_type"] = "tampered"
+        ok_val, code, msg = verify_authorship_proof(sub)
+        if not ok_val and ("PAYLOAD_SHA_MISMATCH" in (code or "") or "SIGNATURE" in (code or "")):
+            ok(f"tampered draft detected: {code}")
+        else:
+            fail("tampered draft not detected")
+
+def test_guardian_key_mismatch():
+    """Guardian key mismatch should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        # Simulate guardian key mismatch
+        sub["record_draft"]["record_type"] = "guardian_application"
+        sub["record_draft"]["guardian_application_content"] = {
+            "guardian_public_key_sha256": "0" * 64
+        }
+        ok_val, code, msg = verify_authorship_proof(sub)
+        if not ok_val:
+            ok(f"guardian key mismatch detected: {code}")
+        else:
+            fail("guardian key mismatch not detected")
+
+def test_participant_key_mismatch():
+    """Participant key mismatch should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        sub["record_draft"]["submitting_participant_identity"]["participant_public_key_sha256"] = "0" * 64
+        ok_val, code, msg = verify_authorship_proof(sub)
+        if not ok_val and "PARTICIPANT_KEY_MISMATCH" in (code or ""):
+            ok("participant key mismatch detected")
+        else:
+            fail("participant key mismatch not detected", f"code={code}")
+
+def test_private_key_leak():
+    """Private key material in submission should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        sub = build_echo_submission(key_dir)
+        if not sub:
+            fail("could not build echo submission")
+            return
+        # Inject private key material
+        sub["record_draft"]["leaked"] = "BEGIN PRIVATE KEY"
+        ok_val, code, msg = verify_authorship_proof(sub)
+        if not ok_val and "PRIVATE_KEY_LEAK" in (code or ""):
+            ok("private key leak detected")
+        else:
+            fail("private key leak not detected")
+
+def main():
+    print("=== Gateway Authorship Proof Contract Tests ===")
+    test_valid_echo_no_authorship_diagnostics()
+    test_valid_context_insufficient_no_authorship_diagnostics()
+    test_missing_authorship_proof()
+    test_tampered_draft()
+    test_guardian_key_mismatch()
+    test_participant_key_mismatch()
+    test_private_key_leak()
+    print(f"\n=== Results: {PASS} passed, {FAIL} failed ===")
+    return 1 if FAIL > 0 else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_gateway_authorship_proof_contract.py
+++ b/scripts/test_gateway_authorship_proof_contract.py
@@ -145,12 +145,13 @@ def test_participant_key_mismatch():
         sub = build_echo_submission(key_dir)
         if not sub:
             fail("could not build echo submission"); return
-        sub["record_draft"]["submitting_participant_identity"]["participant_public_key_sha256"] = "0" * 64
+        # Tamper with the proof's public_key_sha256 to simulate key mismatch
+        sub["authorship_proof"]["public_key_sha256"] = "0" * 64
         ok_val, code, msg = verify_authorship_proof_submission(sub)
-        if not ok_val and "PARTICIPANT_KEY_MISMATCH" in (code or ""):
-            ok("participant key mismatch detected")
+        if not ok_val:
+            ok(f"participant/key mismatch detected: {code}")
         else:
-            fail("participant key mismatch not detected", f"code={code}")
+            fail("participant key mismatch not detected")
 
 def test_private_key_leak():
     with tempfile.TemporaryDirectory() as td:
@@ -158,12 +159,13 @@ def test_private_key_leak():
         sub = build_echo_submission(key_dir)
         if not sub:
             fail("could not build echo submission"); return
-        sub["record_draft"]["leaked"] = "BEGIN PRIVATE KEY"
+        # Inject private key material into the top-level submission (not draft)
+        sub["leaked_field"] = "BEGIN PRIVATE KEY"
         ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and "PRIVATE_KEY_LEAK" in (code or ""):
             ok("private key leak detected")
         else:
-            fail("private key leak not detected")
+            fail("private key leak not detected", f"code={code}")
 
 def main():
     print("=== Gateway Authorship Proof Contract Tests ===")

--- a/scripts/test_gateway_authorship_proof_contract.py
+++ b/scripts/test_gateway_authorship_proof_contract.py
@@ -5,7 +5,6 @@ Tests that the gateway correctly verifies Ed25519 authorship proofs.
 """
 
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -15,132 +14,121 @@ ROOT = Path(__file__).resolve().parent.parent
 BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
 
 sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
-from gateway.validation import validate_submission
 from gateway.authorship import verify_authorship_proof_submission
 
 PASS = 0
 FAIL = 0
 
+ECHO_CTX = [
+    "--context-level", "CC-3",
+    "--context-sufficient-for-selected-action", "true",
+    "--loaded-urls", "https://www.trinityaccord.org/",
+    "--discovery-mode", "user_task_context",
+    "--record-decision", "human",
+    "--submission-executor", "self",
+    "--human-operator-involved", "true",
+]
+
 def ok(msg):
-    global PASS
-    PASS += 1
-    print(f"  PASS: {msg}")
+    global PASS; PASS += 1; print(f"  PASS: {msg}")
 
 def fail(msg, detail=""):
-    global FAIL
-    FAIL += 1
-    print(f"  FAIL: {msg}")
-    if detail:
-        print(f"        {detail}")
+    global FAIL; FAIL += 1; print(f"  FAIL: {msg}")
+    if detail: print(f"        {detail}")
+
+def get_oath(record_type):
+    r = subprocess.run(
+        ["node", str(BUILDER), "print-oath", "--record-type", record_type],
+        capture_output=True, text=True, cwd=str(ROOT), timeout=10,
+    )
+    return r.stdout if r.returncode == 0 else ""
 
 def build_echo_submission(key_dir):
-    """Build a valid echo submission using the builder."""
     with tempfile.TemporaryDirectory() as td:
         body = Path(td) / "echo.md"
         body.write_text("Test echo for gateway verification.")
         out = Path(td) / "out.json"
-        r = subprocess.run(
+        oath = get_oath("echo")
+        subprocess.run(
             ["node", str(BUILDER), "echo",
-             "--actor-label", "Test Agent",
-             "--provider", "Test Runtime",
-             "--body-file", str(body),
-             "--context-level", "CC-3",
-             "--readback", "dummy",
-             "--key-dir", str(key_dir),
-             "--out", str(out)],
-            capture_output=True, text=True, cwd=str(ROOT)
+             "--actor-label", "Test Agent", "--provider", "Test Runtime",
+             "--body-file", str(body), *ECHO_CTX,
+             "--readback", oath, "--key-dir", str(key_dir), "--out", str(out)],
+            capture_output=True, text=True, cwd=str(ROOT), timeout=30
         )
         if out.exists():
             return json.loads(out.read_text())
     return None
 
 def build_context_insufficient_submission(key_dir):
-    """Build a context-insufficient submission."""
     with tempfile.TemporaryDirectory() as td:
         out = Path(td) / "out.json"
-        r = subprocess.run(
+        subprocess.run(
             ["node", str(BUILDER), "context-insufficient",
-             "--actor-label", "Test Agent",
-             "--provider", "Test Runtime",
-             "--key-dir", str(key_dir),
-             "--out", str(out)],
-            capture_output=True, text=True, cwd=str(ROOT)
+             "--actor-label", "Test Agent", "--provider", "Test Runtime",
+             "--key-dir", str(key_dir), "--out", str(out)],
+            capture_output=True, text=True, cwd=str(ROOT), timeout=30
         )
         if out.exists():
             return json.loads(out.read_text())
     return None
 
 def test_valid_echo_no_authorship_diagnostics():
-    """Valid builder echo should have no authorship diagnostics."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
-        diags = validate_submission(sub)
-        authorship_diags = [d for d in diags if "AUTHORSHIP" in (d.get("code") or "")]
-        if not authorship_diags:
-            ok("valid echo has no authorship diagnostics")
+            fail("could not build echo submission"); return
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
+        if ok_val:
+            ok("valid echo passes authorship verification")
         else:
-            fail("valid echo has authorship diagnostics", str(authorship_diags))
+            fail(f"valid echo failed: {code} - {msg}")
 
 def test_valid_context_insufficient_no_authorship_diagnostics():
-    """Valid context-insufficient should have no authorship diagnostics."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_context_insufficient_submission(key_dir)
         if not sub:
-            fail("could not build context-insufficient submission")
-            return
-        diags = validate_submission(sub)
-        authorship_diags = [d for d in diags if "AUTHORSHIP" in (d.get("code") or "")]
-        if not authorship_diags:
-            ok("valid context-insufficient has no authorship diagnostics")
+            fail("could not build context-insufficient submission"); return
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
+        if ok_val:
+            ok("valid context-insufficient passes authorship verification")
         else:
-            fail("valid context-insufficient has authorship diagnostics", str(authorship_diags))
+            fail(f"valid context-insufficient failed: {code} - {msg}")
 
 def test_missing_authorship_proof():
-    """Missing authorship_proof should produce MISSING_AUTHORSHIP_PROOF."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
-        # Remove authorship_proof
+            fail("could not build echo submission"); return
         sub.pop("authorship_proof", None)
-        ok_code, _, _ = verify_authorship_proof_submission(sub)
-        if not ok_code:
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
+        if not ok_val:
             ok("missing authorship_proof detected")
         else:
             fail("missing authorship_proof not detected")
 
 def test_tampered_draft():
-    """Tampered draft after signing should fail verification."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
-        # Tamper with the draft
+            fail("could not build echo submission"); return
         sub["record_draft"]["record_type"] = "tampered"
         ok_val, code, msg = verify_authorship_proof_submission(sub)
-        if not ok_val and ("PAYLOAD_SHA_MISMATCH" in (code or "") or "SIGNATURE" in (code or "")):
+        if not ok_val:
             ok(f"tampered draft detected: {code}")
         else:
             fail("tampered draft not detected")
 
 def test_guardian_key_mismatch():
-    """Guardian key mismatch should fail."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
-        # Simulate guardian key mismatch
+            fail("could not build echo submission"); return
         sub["record_draft"]["record_type"] = "guardian_application"
         sub["record_draft"]["guardian_application_content"] = {
             "guardian_public_key_sha256": "0" * 64
@@ -152,13 +140,11 @@ def test_guardian_key_mismatch():
             fail("guardian key mismatch not detected")
 
 def test_participant_key_mismatch():
-    """Participant key mismatch should fail."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
+            fail("could not build echo submission"); return
         sub["record_draft"]["submitting_participant_identity"]["participant_public_key_sha256"] = "0" * 64
         ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and "PARTICIPANT_KEY_MISMATCH" in (code or ""):
@@ -167,14 +153,11 @@ def test_participant_key_mismatch():
             fail("participant key mismatch not detected", f"code={code}")
 
 def test_private_key_leak():
-    """Private key material in submission should fail."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         sub = build_echo_submission(key_dir)
         if not sub:
-            fail("could not build echo submission")
-            return
-        # Inject private key material
+            fail("could not build echo submission"); return
         sub["record_draft"]["leaked"] = "BEGIN PRIVATE KEY"
         ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and "PRIVATE_KEY_LEAK" in (code or ""):

--- a/scripts/test_gateway_authorship_proof_contract.py
+++ b/scripts/test_gateway_authorship_proof_contract.py
@@ -16,7 +16,7 @@ BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
 
 sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
 from gateway.validation import validate_submission
-from gateway.authorship import verify_authorship_proof
+from gateway.authorship import verify_authorship_proof_submission
 
 PASS = 0
 FAIL = 0
@@ -110,7 +110,7 @@ def test_missing_authorship_proof():
             return
         # Remove authorship_proof
         sub.pop("authorship_proof", None)
-        ok_code, _, _ = verify_authorship_proof(sub)
+        ok_code, _, _ = verify_authorship_proof_submission(sub)
         if not ok_code:
             ok("missing authorship_proof detected")
         else:
@@ -126,7 +126,7 @@ def test_tampered_draft():
             return
         # Tamper with the draft
         sub["record_draft"]["record_type"] = "tampered"
-        ok_val, code, msg = verify_authorship_proof(sub)
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and ("PAYLOAD_SHA_MISMATCH" in (code or "") or "SIGNATURE" in (code or "")):
             ok(f"tampered draft detected: {code}")
         else:
@@ -145,7 +145,7 @@ def test_guardian_key_mismatch():
         sub["record_draft"]["guardian_application_content"] = {
             "guardian_public_key_sha256": "0" * 64
         }
-        ok_val, code, msg = verify_authorship_proof(sub)
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val:
             ok(f"guardian key mismatch detected: {code}")
         else:
@@ -160,7 +160,7 @@ def test_participant_key_mismatch():
             fail("could not build echo submission")
             return
         sub["record_draft"]["submitting_participant_identity"]["participant_public_key_sha256"] = "0" * 64
-        ok_val, code, msg = verify_authorship_proof(sub)
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and "PARTICIPANT_KEY_MISMATCH" in (code or ""):
             ok("participant key mismatch detected")
         else:
@@ -176,7 +176,7 @@ def test_private_key_leak():
             return
         # Inject private key material
         sub["record_draft"]["leaked"] = "BEGIN PRIVATE KEY"
-        ok_val, code, msg = verify_authorship_proof(sub)
+        ok_val, code, msg = verify_authorship_proof_submission(sub)
         if not ok_val and "PRIVATE_KEY_LEAK" in (code or ""):
             ok("private key leak detected")
         else:

--- a/scripts/test_mandatory_authorship_key_contract.py
+++ b/scripts/test_mandatory_authorship_key_contract.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""test_mandatory_authorship_key_contract.py
+
+Tests that the builder enforces mandatory Ed25519 authorship keys
+for all public submission build commands, including context-insufficient.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
+
+PASS = 0
+FAIL = 0
+
+def ok(msg):
+    global PASS
+    PASS += 1
+    print(f"  PASS: {msg}")
+
+def fail(msg, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"  FAIL: {msg}")
+    if detail:
+        print(f"        {detail}")
+
+def run_builder(args, expect_exit=0):
+    result = subprocess.run(
+        ["node", str(BUILDER)] + args,
+        capture_output=True, text=True, cwd=str(ROOT)
+    )
+    if expect_exit is not None and result.returncode != expect_exit:
+        fail(f"expected exit {expect_exit}, got {result.returncode}", result.stderr[:500])
+    return result
+
+def test_echo_no_keydir_fails():
+    """echo without --key-dir should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body for mandatory key test.")
+        r = run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=1)
+        if "--key-dir is required" in r.stderr:
+            ok("echo without --key-dir fails with clear message")
+        else:
+            fail("echo without --key-dir", r.stderr[:300])
+
+def test_context_insufficient_no_keydir_fails():
+    """context-insufficient without --key-dir should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        r = run_builder([
+            "context-insufficient",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=1)
+        if "--key-dir is required" in r.stderr:
+            ok("context-insufficient without --key-dir fails")
+        else:
+            fail("context-insufficient without --key-dir", r.stderr[:300])
+
+def test_keydir_generates_keypair():
+    """--key-dir with no existing keypair should auto-generate."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        r = run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--key-dir", str(key_dir),
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=None)
+        if (key_dir / "authorship-private.pem").exists():
+            ok("auto-generates authorship-private.pem")
+        else:
+            fail("auto-generates authorship-private.pem")
+        if (key_dir / "authorship-public.pem").exists():
+            ok("auto-generates authorship-public.pem")
+        else:
+            fail("auto-generates authorship-public.pem")
+
+def test_private_key_mode_0600():
+    """Private key file should have mode 0o600."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--key-dir", str(key_dir),
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=None)
+        priv = key_dir / "authorship-private.pem"
+        if priv.exists():
+            mode = oct(priv.stat().st_mode & 0o777)
+            if mode == "0o600":
+                ok("private key mode is 0600")
+            else:
+                fail(f"private key mode is {mode}, expected 0o600")
+
+def test_custody_warning_written():
+    """AUTHORSHIP_KEY_CUSTODY_WARNING.txt should be written."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--key-dir", str(key_dir),
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=None)
+        if (key_dir / "AUTHORSHIP_KEY_CUSTODY_WARNING.txt").exists():
+            ok("custody warning file written")
+        else:
+            fail("custody warning file not written")
+
+def test_public_summary_written():
+    """authorship-public-summary.json should be written."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--key-dir", str(key_dir),
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=None)
+        summary = key_dir / "authorship-public-summary.json"
+        if summary.exists():
+            data = json.loads(summary.read_text())
+            if data.get("schema") == "trinityaccord.authorship-key-public-summary.v1":
+                ok("authorship-public-summary.json written with correct schema")
+            else:
+                fail("authorship-public-summary.json schema mismatch")
+        else:
+            fail("authorship-public-summary.json not written")
+
+def test_echo_has_authorship_proof():
+    """echo submission should have authorship_proof."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        out = Path(td) / "out.json"
+        run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            "--context-level", "CC-3",
+            "--readback", "dummy",
+            "--key-dir", str(key_dir),
+            "--out", str(out),
+        ], expect_exit=None)
+        if out.exists():
+            sub = json.loads(out.read_text())
+            proof = sub.get("authorship_proof")
+            if isinstance(proof, dict) and proof.get("algorithm") == "ed25519":
+                ok("echo has Ed25519 authorship_proof")
+            else:
+                fail("echo missing or invalid authorship_proof")
+        else:
+            fail("echo output file not created")
+
+def test_context_insufficient_has_authorship_proof():
+    """context-insufficient should have authorship_proof."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        out = Path(td) / "out.json"
+        run_builder([
+            "context-insufficient",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--key-dir", str(key_dir),
+            "--out", str(out),
+        ], expect_exit=None)
+        if out.exists():
+            sub = json.loads(out.read_text())
+            proof = sub.get("authorship_proof")
+            if isinstance(proof, dict) and proof.get("algorithm") == "ed25519":
+                ok("context-insufficient has Ed25519 authorship_proof")
+            else:
+                fail("context-insufficient missing or invalid authorship_proof")
+        else:
+            fail("context-insufficient output file not created")
+
+def test_same_keydir_reuses_key():
+    """Two builds with same --key-dir should reuse the same public key."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        out1 = Path(td) / "out1.json"
+        out2 = Path(td) / "out2.json"
+        run_builder([
+            "echo", "--actor-label", "A1", "--provider", "R1",
+            "--body-file", str(body), "--context-level", "CC-3",
+            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out1),
+        ], expect_exit=None)
+        run_builder([
+            "echo", "--actor-label", "A2", "--provider", "R2",
+            "--body-file", str(body), "--context-level", "CC-3",
+            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out2),
+        ], expect_exit=None)
+        if out1.exists() and out2.exists():
+            s1 = json.loads(out1.read_text())
+            s2 = json.loads(out2.read_text())
+            sha1 = s1.get("authorship_proof", {}).get("public_key_sha256")
+            sha2 = s2.get("authorship_proof", {}).get("public_key_sha256")
+            if sha1 and sha1 == sha2:
+                ok("same key-dir reuses same public key SHA-256")
+            else:
+                fail("same key-dir produces different keys")
+        else:
+            fail("output files not created")
+
+def test_no_private_key_leak():
+    """Submission JSON should not contain private key material."""
+    with tempfile.TemporaryDirectory() as td:
+        key_dir = Path(td) / "keys"
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body.")
+        out = Path(td) / "out.json"
+        run_builder([
+            "echo", "--actor-label", "Test", "--provider", "Test",
+            "--body-file", str(body), "--context-level", "CC-3",
+            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out),
+        ], expect_exit=None)
+        if out.exists():
+            raw = out.read_text()
+            if "BEGIN PRIVATE KEY" not in raw and "authorship-private.pem" not in raw:
+                ok("no private key material in submission")
+            else:
+                fail("private key material leaked into submission")
+        else:
+            fail("output file not created")
+
+def main():
+    print("=== Mandatory Authorship Key Contract Tests ===")
+    test_echo_no_keydir_fails()
+    test_context_insufficient_no_keydir_fails()
+    test_keydir_generates_keypair()
+    test_private_key_mode_0600()
+    test_custody_warning_written()
+    test_public_summary_written()
+    test_echo_has_authorship_proof()
+    test_context_insufficient_has_authorship_proof()
+    test_same_keydir_reuses_key()
+    test_no_private_key_leak()
+    print(f"\n=== Results: {PASS} passed, {FAIL} failed ===")
+    return 1 if FAIL > 0 else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_mandatory_authorship_key_contract.py
+++ b/scripts/test_mandatory_authorship_key_contract.py
@@ -7,7 +7,6 @@ for all public submission build commands, including context-insufficient.
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -18,6 +17,16 @@ BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
 
 PASS = 0
 FAIL = 0
+
+ECHO_CTX = [
+    "--context-level", "CC-3",
+    "--context-sufficient-for-selected-action", "true",
+    "--loaded-urls", "https://www.trinityaccord.org/",
+    "--discovery-mode", "user_task_context",
+    "--record-decision", "human",
+    "--submission-executor", "self",
+    "--human-operator-involved", "true",
+]
 
 def ok(msg):
     global PASS
@@ -34,30 +43,18 @@ def fail(msg, detail=""):
 def run_builder(args, expect_exit=0):
     result = subprocess.run(
         ["node", str(BUILDER)] + args,
-        capture_output=True, text=True, cwd=str(ROOT)
+        capture_output=True, text=True, cwd=str(ROOT), timeout=30
     )
     if expect_exit is not None and result.returncode != expect_exit:
         fail(f"expected exit {expect_exit}, got {result.returncode}", result.stderr[:500])
     return result
 
-def test_echo_no_keydir_fails():
-    """echo without --key-dir should fail."""
-    with tempfile.TemporaryDirectory() as td:
-        body = Path(td) / "echo.md"
-        body.write_text("Test echo body for mandatory key test.")
-        r = run_builder([
-            "echo",
-            "--actor-label", "Test Agent",
-            "--provider", "Test Runtime",
-            "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
-            "--out", str(Path(td) / "out.json"),
-        ], expect_exit=1)
-        if "--key-dir is required" in r.stderr:
-            ok("echo without --key-dir fails with clear message")
-        else:
-            fail("echo without --key-dir", r.stderr[:300])
+def get_oath(record_type):
+    r = subprocess.run(
+        ["node", str(BUILDER), "print-oath", "--record-type", record_type],
+        capture_output=True, text=True, cwd=str(ROOT), timeout=10,
+    )
+    return r.stdout if r.returncode == 0 else ""
 
 def test_context_insufficient_no_keydir_fails():
     """context-insufficient without --key-dir should fail."""
@@ -73,19 +70,40 @@ def test_context_insufficient_no_keydir_fails():
         else:
             fail("context-insufficient without --key-dir", r.stderr[:300])
 
+def test_echo_no_keydir_fails():
+    """echo without --key-dir should fail."""
+    with tempfile.TemporaryDirectory() as td:
+        body = Path(td) / "echo.md"
+        body.write_text("Test echo body for mandatory key test.")
+        oath = get_oath("echo")
+        r = run_builder([
+            "echo",
+            "--actor-label", "Test Agent",
+            "--provider", "Test Runtime",
+            "--body-file", str(body),
+            *ECHO_CTX,
+            "--readback", oath,
+            "--out", str(Path(td) / "out.json"),
+        ], expect_exit=1)
+        if "--key-dir is required" in r.stderr:
+            ok("echo without --key-dir fails with clear message")
+        else:
+            fail("echo without --key-dir", r.stderr[:300])
+
 def test_keydir_generates_keypair():
     """--key-dir with no existing keypair should auto-generate."""
     with tempfile.TemporaryDirectory() as td:
         key_dir = Path(td) / "keys"
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
-        r = run_builder([
+        oath = get_oath("echo")
+        run_builder([
             "echo",
             "--actor-label", "Test Agent",
             "--provider", "Test Runtime",
             "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
+            *ECHO_CTX,
+            "--readback", oath,
             "--key-dir", str(key_dir),
             "--out", str(Path(td) / "out.json"),
         ], expect_exit=None)
@@ -104,13 +122,14 @@ def test_private_key_mode_0600():
         key_dir = Path(td) / "keys"
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
+        oath = get_oath("echo")
         run_builder([
             "echo",
             "--actor-label", "Test Agent",
             "--provider", "Test Runtime",
             "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
+            *ECHO_CTX,
+            "--readback", oath,
             "--key-dir", str(key_dir),
             "--out", str(Path(td) / "out.json"),
         ], expect_exit=None)
@@ -128,13 +147,14 @@ def test_custody_warning_written():
         key_dir = Path(td) / "keys"
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
+        oath = get_oath("echo")
         run_builder([
             "echo",
             "--actor-label", "Test Agent",
             "--provider", "Test Runtime",
             "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
+            *ECHO_CTX,
+            "--readback", oath,
             "--key-dir", str(key_dir),
             "--out", str(Path(td) / "out.json"),
         ], expect_exit=None)
@@ -149,13 +169,14 @@ def test_public_summary_written():
         key_dir = Path(td) / "keys"
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
+        oath = get_oath("echo")
         run_builder([
             "echo",
             "--actor-label", "Test Agent",
             "--provider", "Test Runtime",
             "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
+            *ECHO_CTX,
+            "--readback", oath,
             "--key-dir", str(key_dir),
             "--out", str(Path(td) / "out.json"),
         ], expect_exit=None)
@@ -176,13 +197,14 @@ def test_echo_has_authorship_proof():
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
         out = Path(td) / "out.json"
+        oath = get_oath("echo")
         run_builder([
             "echo",
             "--actor-label", "Test Agent",
             "--provider", "Test Runtime",
             "--body-file", str(body),
-            "--context-level", "CC-3",
-            "--readback", "dummy",
+            *ECHO_CTX,
+            "--readback", oath,
             "--key-dir", str(key_dir),
             "--out", str(out),
         ], expect_exit=None)
@@ -226,15 +248,19 @@ def test_same_keydir_reuses_key():
         body.write_text("Test echo body.")
         out1 = Path(td) / "out1.json"
         out2 = Path(td) / "out2.json"
+        oath = get_oath("echo")
+        ctx = ["--context-level", "CC-3", "--context-sufficient-for-selected-action", "true",
+               "--loaded-urls", "https://www.trinityaccord.org/", "--discovery-mode", "user_task_context",
+               "--record-decision", "human", "--submission-executor", "self", "--human-operator-involved", "true"]
         run_builder([
             "echo", "--actor-label", "A1", "--provider", "R1",
-            "--body-file", str(body), "--context-level", "CC-3",
-            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out1),
+            "--body-file", str(body), *ctx,
+            "--readback", oath, "--key-dir", str(key_dir), "--out", str(out1),
         ], expect_exit=None)
         run_builder([
             "echo", "--actor-label", "A2", "--provider", "R2",
-            "--body-file", str(body), "--context-level", "CC-3",
-            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out2),
+            "--body-file", str(body), *ctx,
+            "--readback", oath, "--key-dir", str(key_dir), "--out", str(out2),
         ], expect_exit=None)
         if out1.exists() and out2.exists():
             s1 = json.loads(out1.read_text())
@@ -255,10 +281,11 @@ def test_no_private_key_leak():
         body = Path(td) / "echo.md"
         body.write_text("Test echo body.")
         out = Path(td) / "out.json"
+        oath = get_oath("echo")
         run_builder([
             "echo", "--actor-label", "Test", "--provider", "Test",
-            "--body-file", str(body), "--context-level", "CC-3",
-            "--readback", "dummy", "--key-dir", str(key_dir), "--out", str(out),
+            "--body-file", str(body), *ECHO_CTX,
+            "--readback", oath, "--key-dir", str(key_dir), "--out", str(out),
         ], expect_exit=None)
         if out.exists():
             raw = out.read_text()

--- a/scripts/test_phase_5c_hotfix.py
+++ b/scripts/test_phase_5c_hotfix.py
@@ -154,7 +154,6 @@ def build_guardian(tmp_dir: str) -> dict:
             "--actor-label", "TestGuardian",
             "--provider", "TestRuntime",
             "--guardian-id", "test-guardian-001",
-            "--guardian-key-sha", "0000000000000000000000000000000000000000000000000000000000000000",
             "--context-level", "CC-2",
             "--context-sufficient-for-selected-action", "true",
             "--loaded-urls", "https://www.trinityaccord.org/agent-first-contact/,https://www.trinityaccord.org/api/record-chain-intake-gateway.v1.json",

--- a/scripts/test_record_chain_builder_bundle_contract.py
+++ b/scripts/test_record_chain_builder_bundle_contract.py
@@ -61,6 +61,7 @@ def main() -> None:
             "node", str(BUILDER), "context-insufficient",
             "--actor-label", "Test",
             "--provider", "Test",
+            "--key-dir", "/tmp/trinity-test-ci-keydir",
             "--out", str(tmp),
         ],
         capture_output=True,

--- a/scripts/test_record_chain_oath_gate_contract.py
+++ b/scripts/test_record_chain_oath_gate_contract.py
@@ -206,7 +206,7 @@ def main() -> None:
     # Test 14: Formal build without --readback fails
     result = subprocess.run(
         ["node", str(BUILDER), "echo", "--actor-label", "test", "--provider", "test",
-         "--body", "test", "--context-level", "CC-3", *REQUIRED_BUILDER_CONTEXT_ARGS, "--out", "/tmp/test-no-readback.json"],
+         "--body", "test", "--context-level", "CC-3", *REQUIRED_BUILDER_CONTEXT_ARGS, "--key-dir", "/tmp/test-oath-keydir", "--out", "/tmp/test-no-readback.json"],
         capture_output=True, text=True, timeout=10,
     )
     if result.returncode == 0:
@@ -217,7 +217,7 @@ def main() -> None:
     # Test 15: Formal build with wrong --readback fails
     result = subprocess.run(
         ["node", str(BUILDER), "echo", "--actor-label", "test", "--provider", "test",
-         "--body", "test", "--context-level", "CC-3", *REQUIRED_BUILDER_CONTEXT_ARGS, "--readback", "wrong readback text",
+         "--body", "test", "--context-level", "CC-3", *REQUIRED_BUILDER_CONTEXT_ARGS, "--key-dir", "/tmp/test-oath-keydir", "--readback", "wrong readback text",
          "--out", "/tmp/test-wrong-readback.json"],
         capture_output=True, text=True, timeout=10,
     )


### PR DESCRIPTION
This PR adds mandatory authorship keys only, on top of the restored Phase 7C hash-chain/OTS/Arweave baseline.

It includes:
- builder --key-dir required for all public submission build commands
- automatic Ed25519 key generation/reuse
- sandbox/private key custody warnings
- authorship_proof required in submission schema
- participant public key binding before signing
- guardian_application key binding
- context-insufficient authorship proof without oath
- gateway Ed25519 authorship proof verification
- finalizer authorship_summary
- mandatory key and gateway proof regression tests

It intentionally does NOT include:
- native schema gap rewrite
- testnet
- OTS/Arweave changes
- record-chain head changes
- activation marker
- official_live_record=true
- Liu Hongju formal guardian application