### PR TITLE
fix: add --enable-paid-upload and OTS registry duplicate-skip guard

### DIFF
--- a/.github/workflows/pre-scale-e2e-orchestrator.yml
+++ b/.github/workflows/pre-scale-e2e-orchestrator.yml
@@ -156,15 +156,53 @@ else:
     ])
 PY
 
-      - name: Upload OTS bundle live via Phase 5 script
+      - name: Check OTS registry for duplicate upload
+        id: ots_dup_check
         if: inputs.mode == 'live'
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+import json
+from pathlib import Path
+
+head = json.load(open("api/record-chain-head.json"))
+current_head = head["head_entry_hash"]
+registry_path = Path("record-chain/ots/arweave-registry.json")
+
+if not registry_path.exists():
+    print("skip_ots_upload=false")
+    print("reason=registry_file_missing")
+else:
+    registry = json.load(open(registry_path))
+    latest = registry.get("latest_by_head", {}).get(current_head, {})
+    if any(latest.get(k) for k in [
+        "latest_pending_tx_id",
+        "latest_verified_tx_id",
+        "latest_upgraded_tx_id",
+        "latest_any_tx_id",
+    ]):
+        print("skip_ots_upload=true")
+        print("reason=already_uploaded_for_head")
+    else:
+        print("skip_ots_upload=false")
+        print("reason=no_existing_upload_for_head")
+PY
+
+      - name: Upload OTS bundle live via Phase 5 script
+        if: inputs.mode == 'live' && steps.ots_dup_check.outputs.skip_ots_upload != 'true'
         run: |
           mkdir -p /tmp/arweave-ots
           printf '%s' "$ARKEY" > /tmp/arweave-ots/wallet.jwk.json
           chmod 600 /tmp/arweave-ots/wallet.jwk.json
           python3 scripts/run_phase5_ots_arweave_paid_upload.py \
             --jwk-path /tmp/arweave-ots/wallet.jwk.json \
+            --enable-paid-upload \
             --confirm-paid-upload I_UNDERSTAND_THIS_UPLOADS_THE_OTS_PROOF_BUNDLE_TO_ARWEAVE
+
+      - name: Skip OTS upload (already exists)
+        if: inputs.mode == 'live' && steps.ots_dup_check.outputs.skip_ots_upload == 'true'
+        run: |
+          echo "Skipping Phase 5 OTS paid upload: ${{ steps.ots_dup_check.outputs.reason }}"
+          echo "Current head already has an Arweave tx in the OTS registry."
 
       - name: Verify OTS registry if live
         if: inputs.mode == 'live'

--- a/scripts/test_pre_scale_e2e_automation_contract.py
+++ b/scripts/test_pre_scale_e2e_automation_contract.py
@@ -37,6 +37,12 @@ def main():
     require("verify_ots_arweave_registry.py" in orchestrator, "orchestrator must verify OTS registry")
     require("run_current_system_tests.py" in orchestrator, "orchestrator must run current tests")
 
+    # Paid upload guard: --enable-paid-upload must be passed to Phase 5
+    require("--enable-paid-upload" in orchestrator, "orchestrator must pass --enable-paid-upload to Phase 5 script")
+
+    # Duplicate upload prevention: latest_by_head registry check
+    require("latest_by_head" in orchestrator, "orchestrator must check latest_by_head in OTS registry to skip duplicate uploads")
+
     print("PASS: pre-scale e2e automation contract")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes

### `.github/workflows/pre-scale-e2e-orchestrator.yml`
1. **Added `--enable-paid-upload`** to Phase 5 OTS upload call
2. **Added OTS registry duplicate-skip check** — before Phase 5 upload, reads `record-chain/ots/arweave-registry.json` → `latest_by_head[current_head]`
   - If any of `latest_pending_tx_id` / `latest_verified_tx_id` / `latest_upgraded_tx_id` / `latest_any_tx_id` exists → **skip** Phase 5 upload
   - Avoids redundant paid Arweave uploads for the same head
3. **Preserved**: `I_UNDERSTAND_THIS_RUNS_PRE_SCALE_E2E_AUTOMATION` confirm guard
4. **Preserved**: `ARKEY` from `secrets.ARKEY`

### `scripts/test_pre_scale_e2e_automation_contract.py`
- Added contract check: workflow must contain `--enable-paid-upload`
- Added contract check: workflow must contain `latest_by_head` duplicate-skip logic

## Safety
- No changes to live confirm guard or ARKEY sourcing
- Duplicate-skip prevents accidental double-charging on re-runs
- `--enable-paid-upload` is an existing flag on the Phase 5 script (already accepted by argparse)

Closes: none
Merge when CI is green.