### PR TITLE
fix: make Arweave data bundle filenames immutable

### DIFF
--- a/scripts/build_record_chain_data_arweave_bundle.py
+++ b/scripts/build_record_chain_data_arweave_bundle.py
@@ -222,19 +222,28 @@ def main() -> int:
             raise SystemExit("--from-height-exclusive required for delta")
         to_h = args.to_height_inclusive if args.to_height_inclusive is not None else int(head["height"])
         bundle = build_delta(args.from_height_exclusive, to_h)
-        name = f"data-delta-height-{args.from_height_exclusive + 1}-to-{to_h}-{bundle['head_after']['head_entry_hash'][:12]}.json"
+        # Content hash for immutable filename — excludes bundle_canonical_sha256
+        content_hash = sha256_obj({k: v for k, v in bundle.items() if k != "bundle_canonical_sha256"})
+        name = f"data-delta-height-{args.from_height_exclusive + 1}-to-{to_h}-{bundle['head_after']['head_entry_hash'][:12]}-{content_hash[:12]}.json"
     else:
         h = args.height if args.height is not None else int(head["height"])
         bundle = build_snapshot(h)
-        name = f"data-snapshot-height-{h}-{bundle['head_entry_hash'][:12]}.json"
+        content_hash = sha256_obj({k: v for k, v in bundle.items() if k != "bundle_canonical_sha256"})
+        name = f"data-snapshot-height-{h}-{bundle['head_entry_hash'][:12]}-{content_hash[:12]}.json"
 
     path = out_dir / name
+    # Anti-overwrite: if file exists with different content, fail
+    if path.exists():
+        existing = read_json(path)
+        existing_hash = sha256_obj({k: v for k, v in existing.items() if k != "bundle_canonical_sha256"})
+        if existing_hash != content_hash:
+            raise SystemExit(f"refusing to overwrite {name}: existing hash {existing_hash[:12]} != new hash {content_hash[:12]}")
     write_json(path, bundle)
     print(json.dumps({
         "result": "pass",
         "bundle_file": str(path.relative_to(ROOT)),
         "bundle_type": bundle["bundle_type"],
-        "bundle_sha256": sha256_obj(bundle),
+        "bundle_sha256": content_hash,
     }, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/test_record_chain_data_arweave_archive_contract.py
+++ b/scripts/test_record_chain_data_arweave_archive_contract.py
@@ -24,6 +24,12 @@ def main():
     require("record_payload" in build, "bundle must include full record payload")
     require("client_oath_readback" in build, "builder must scan client_oath_readback")
     require("readback_text" in build, "builder must scan readback_text")
+    # Immutable filename: bundle content hash must be in filename
+    require("content_hash[:12]" in build, "builder must include content hash in filename")
+    require("data-delta-height" in build, "builder must use delta filename pattern")
+    require("data-snapshot-height" in build, "builder must use snapshot filename pattern")
+    # Anti-overwrite: must refuse to overwrite different content with same name
+    require("refusing to overwrite" in build, "builder must refuse overwriting different content")
 
     verify = (ROOT / "scripts/verify_record_chain_data_arweave_registry.py").read_text(encoding="utf-8")
     require("arweave_hash_match" in verify, "registry verifier must check hash match")


### PR DESCRIPTION
## Root Cause

Bundle filenames used  only, which is deterministic for the same height. But bundle content includes  (utc_now), so each run produces different content in the same filename. This caused:

1. Run N generates  with sha=X
2. Registry entry records 
3. Run N+1 overwrites same file with sha=Y
4. Verify reads entry, checks file → sha=Y != sha=X → **"entry[0]: bundle sha mismatch"**

## Fix

****:
- Compute 
- Include in filename: 
- Anti-overwrite: if file exists with different content hash, fail hard
- Output  now uses same hash as registry/verifier (consistent)

****:
- Verify builder includes  in filename
- Verify anti-overwrite check exists

## Result

Each unique bundle content gets a unique filename. Registry entries always point to immutable artifacts. Overwriting different content with the same name is prevented.

## After Merge

Re-run M5 live rehearsal (pre-scale-e2e-orchestrator-v2, mode=live, max_records=3).
