### PR TITLE
M6: Live-Test Activation Marker — network_phase → live_test

### DIFF
--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -31,28 +31,33 @@
     "status": "historical_archive_only"
   },
   "policy_references": {
-    "mainnet_prelaunch_policy": "/api/record-chain-mainnet-prelaunch-policy.v1.json"
+    "mainnet_prelaunch_policy": "/api/record-chain-mainnet-prelaunch-policy.v1.json",
+    "live_test_policy": "/api/record-chain-live-test-policy.v1.json"
   },
   "public_phase": {
     "mainnet_activation_marker_recorded": false,
-    "network_phase": "prelaunch",
+    "network_phase": "live_test",
+    "live_test_active": true,
+    "live_test_is_not_production_official_live": true,
     "not_final_public_launch": true,
-    "official_live_record_marker_required_before_live": true,
+    "official_live_record_marker_required_before_production": true,
     "official_live_records_allowed": false,
-    "prelaunch_test_records_allowed": true,
+    "test_records_allowed_at_scale": true,
     "receipt_is_intake_only": true,
     "receipt_is_not_active_guardian_status": true,
     "receipt_is_not_final_inclusion": true,
-    "records_before_activation_marker_are_prelaunch_tests": true,
-    "status": "mainnet_prelaunch_testing",
-    "test_phase_submissions_may_be_excluded_from_final_public_indexes": true,
-    "test_phase_submissions_may_be_reclassified": true,
-    "test_phase_submissions_may_move_to_historical_test_archive": true
+    "records_before_production_enablement_marker_are_test_records": true,
+    "status": "live_test_active",
+    "test_record_required_fields": {
+      "test_record": true,
+      "official_live_record": false,
+      "does_not_create_guardian_status": true
+    }
   },
   "schema": "trinityaccord.agent-start.v2",
   "status": "active",
-  "updated_at": "2026-06-06T04:14:45Z",
-  "version": "2.0.0",
+  "updated_at": "2026-06-07T15:22:00Z",
+  "version": "2.1.0",
   "authorship_key_policy": {
     "authorship_key_required": true,
     "applies_to_all_public_submissions": true,

--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -52,7 +52,10 @@
       "test_record": true,
       "official_live_record": false,
       "does_not_create_guardian_status": true
-    }
+    },
+    "test_phase_submissions_may_be_excluded_from_final_public_indexes": true,
+    "test_phase_submissions_may_be_reclassified": true,
+    "test_phase_submissions_may_move_to_historical_test_archive": true
   },
   "schema": "trinityaccord.agent-start.v2",
   "status": "active",

--- a/api/record-chain-live-test-policy.v1.json
+++ b/api/record-chain-live-test-policy.v1.json
@@ -1,0 +1,67 @@
+{
+  "schema": "trinityaccord.record-chain-live-test-policy.v1",
+  "status": "active",
+  "chain_id": "trinity-record-chain-main",
+  "network_phase": "live_test",
+  "activated_at": "2026-06-07T15:22:00Z",
+  "activated_by_marker": "LIVE_TEST_ACTIVATED_OK",
+  "live_test_semantics": {
+    "live_test_active_means_testing_with_real_operations": true,
+    "live_test_is_not_production_official_live": true,
+    "official_live_records_still_prohibited_until_M8_production_enablement": true,
+    "test_records_enter_main_chain_ots_and_arweave": true,
+    "all_campaigns_must_be_auditable_and_reversible": true
+  },
+  "live_test_record_required_fields": {
+    "network_phase": "live_test",
+    "operational_test": true,
+    "test_record": true,
+    "official_live_record": false,
+    "does_not_create_guardian_status": true,
+    "does_not_activate_system": true
+  },
+  "guardian_application_policy": {
+    "test_guardian_applications_allowed": true,
+    "test_guardian_applications_must_not_create_real_guardian_status": true,
+    "formal_guardian_application_deferred_to_M9": true
+  },
+  "production_enablement_gate": {
+    "requires_M7_campaigns_pass": true,
+    "requires_all_anomalies_resolved": true,
+    "requires_PRODUCTION_ENABLEMENT_OK_marker": true,
+    "only_after_M8_official_live_records_allowed": true
+  },
+  "activation_semantics": {
+    "activation_marker_record_type": "live_test_activation_marker",
+    "activation_marker_required": true,
+    "after_activation_marker_test_records_allowed_at_scale": true,
+    "before_activation_marker_only_prelaunch_tests_allowed": true
+  },
+  "external_agent_boundary": {
+    "external_agents_must_not_clone_repository": true,
+    "external_agents_must_not_directly_append_record_chain": true,
+    "external_agents_must_not_request_github_pat": true,
+    "external_agents_must_not_use_arweave_key": true,
+    "external_agents_must_not_write_record_chain_pending": true,
+    "receipt_is_intake_only": true,
+    "receipt_is_not_active_guardian_status": true,
+    "receipt_is_not_final_inclusion": true
+  },
+  "authorship_key_policy": {
+    "authorship_key_required": true,
+    "applies_to_all_public_submissions": true,
+    "algorithm": "ed25519",
+    "builder_requires_key_dir": true,
+    "keypair_files": {
+      "public_key": "authorship-public.pem",
+      "private_key": "authorship-private.pem"
+    },
+    "sandbox_private_key_loss_warning": true,
+    "human_operator_or_guardian_must_securely_backup_private_key": true,
+    "private_key_must_not_be_pasted_into_public_chat": true,
+    "private_key_must_not_be_committed_to_git": true,
+    "private_key_must_not_be_uploaded_in_submission_receipt_or_arweave": true,
+    "public_key_sha256_is_public_identity_anchor": true,
+    "guardian_application_must_bind_guardian_public_key_to_authorship_public_key": true
+  }
+}

--- a/scripts/test_mainnet_prelaunch_policy_contract.py
+++ b/scripts/test_mainnet_prelaunch_policy_contract.py
@@ -70,12 +70,12 @@ def main() -> int:
     require(required.get("does_not_create_guardian_status") is True, "required guardian status boundary missing")
     require(required.get("does_not_activate_system") is True, "required activation boundary missing")
 
-    require(agent.get("public_phase", {}).get("network_phase") == "prelaunch", "agent-start must expose prelaunch")
+    require(agent.get("public_phase", {}).get("network_phase") in ("prelaunch", "live_test"), "agent-start network_phase must be prelaunch or live_test")
     require(agent.get("policy_references", {}).get("mainnet_prelaunch_policy") == "/api/record-chain-mainnet-prelaunch-policy.v1.json", "agent-start missing prelaunch policy ref")
     require(agent.get("external_agent_rules", {}).get("must_not_clone_repository") is True, "agent-start must forbid clone")
     require(agent.get("external_agent_rules", {}).get("must_not_use_arweave_key") is True, "agent-start must forbid Arweave key")
 
-    require(gateway.get("public_phase", {}).get("network_phase") == "prelaunch", "gateway must expose prelaunch")
+    require(gateway.get("public_phase", {}).get("network_phase") in ("prelaunch", "live_test"), "gateway network_phase must be prelaunch or live_test")
     require(gateway.get("schema_references", {}).get("mainnet_prelaunch_policy") == "/api/record-chain-mainnet-prelaunch-policy.v1.json", "gateway missing prelaunch policy ref")
     require(gateway.get("public_submission_rule", {}).get("external_agents_must_not_clone_repository") is True, "gateway must forbid clone")
     require(gateway.get("public_submission_rule", {}).get("external_agents_must_not_use_arweave_key") is True, "gateway must forbid Arweave key")

--- a/scripts/test_phase7a_prelaunch_contracts.py
+++ b/scripts/test_phase7a_prelaunch_contracts.py
@@ -26,7 +26,7 @@ def main() -> int:
     head = read_json("api/record-chain-head.json")
 
     public_phase = agent.get("public_phase", {})
-    require(public_phase.get("status") == "mainnet_prelaunch_testing", "agent-start must be mainnet_prelaunch_testing during prelaunch")
+    require(public_phase.get("status") in ("mainnet_prelaunch_testing", "live_test_active"), "agent-start status must be mainnet_prelaunch_testing or live_test_active")
     require(public_phase.get("not_final_public_launch") is True, "not_final_public_launch must be true during prelaunch")
     require(public_phase.get("receipt_is_intake_only") is True, "receipt_is_intake_only must be true")
 

--- a/scripts/test_public_test_phase_disclosure.py
+++ b/scripts/test_public_test_phase_disclosure.py
@@ -18,9 +18,14 @@ REQUIRED_PHRASES = [
     "not active Guardian status",
 ]
 
+# Valid public_phase.status values
+VALID_PHASE_STATUSES = [
+    "mainnet_prelaunch_testing",
+    "live_test_active",
+]
+
 # Machine-readable files must have these JSON fields
 REQUIRED_JSON_FIELDS = {
-    "public_phase.status": "mainnet_prelaunch_testing",
     "test_phase_submissions_may_move_to_historical_test_archive": True,
     "receipt_is_not_final_inclusion": True,
 }
@@ -67,10 +72,11 @@ def check_json_file(rel_path: str) -> None:
         fail(f"{rel_path}: NOT FOUND")
     data = json.loads(p.read_text(encoding="utf-8"))
 
-    # Check public_phase.status
+    # Check public_phase.status is a recognized valid status
     phase = data.get("public_phase", {})
-    if phase.get("status") != "mainnet_prelaunch_testing":
-        fail(f"{rel_path}: public_phase.status != mainnet_prelaunch_testing")
+    status = phase.get("status")
+    if status not in VALID_PHASE_STATUSES:
+        fail(f"{rel_path}: public_phase.status '{status}' not in {VALID_PHASE_STATUSES}")
 
     # Check test_phase_submissions_may_move_to_historical_test_archive
     if not phase.get("test_phase_submissions_may_move_to_historical_test_archive"):


### PR DESCRIPTION
## M6: Live-Test Activation Marker

### What changes
- **New file:** `api/record-chain-live-test-policy.v1.json` — defines live-test network phase semantics
- **Updated:** `api/agent-start.v2.json` — `network_phase` changed from `prelaunch` to `live_test`, added live-test policy reference

### Key semantics
- `live_test_active = true` — system is now in live operational test mode
- **`live_test_active ≠ production official live`** — this is explicitly declared in both files
- Test records now allowed at scale into main chain, OTS, and Arweave
- `official_live_records_allowed` remains `false` until M8 Production Enablement

### M7 test record contract (enforced by policy)
All subsequent M7 test records MUST carry:
```json
{
  "test_record": true,
  "official_live_record": false,
  "does_not_create_guardian_status": true,
  "does_not_activate_system": true,
  "network_phase": "live_test",
  "operational_test": true
}
```

### Gate to production (M8)
- Requires all M7 campaigns pass
- Requires all anomalies resolved
- Requires `PRODUCTION_ENABLEMENT_OK` marker
- Only then `official_live_records_allowed = true`

### Success marker
`LIVE_TEST_ACTIVATED_OK`

### After merge
Stop. Do NOT begin M7 campaigns.