### PR TITLE
feat: add --require-new-records no-op guard to auto-finalizer and orchestrator

### DIFF
--- a/.github/workflows/pre-scale-e2e-orchestrator-v2.yml
+++ b/.github/workflows/pre-scale-e2e-orchestrator-v2.yml
@@ -23,6 +23,11 @@ on:
         default: ""
         description: "Confirmation text for live mode"
         type: string
+      require_new_records:
+        required: false
+        default: "false"
+        description: "Fail if no new records are finalized (prevents no-op false success)"
+        type: string
 
 permissions:
   contents: write
@@ -63,10 +68,15 @@ jobs:
 
       - name: Auto finalize accepted submissions
         run: |
+          REQUIRE_FLAG=""
+          if [ "${{ inputs.require_new_records }}" = "true" ]; then
+            REQUIRE_FLAG="--require-new-records"
+          fi
           python3 scripts/auto_finalize_accepted_submissions.py \
             --max-records "${{ inputs.max_records }}" \
             --source-run-id "pre-scale-e2e-${{ github.run_id }}" \
             --mode "${{ inputs.mode }}" \
+            $REQUIRE_FLAG \
             | tee /tmp/auto-finalize-summary.json
 
       - name: Verify chain after finalization
@@ -85,6 +95,10 @@ jobs:
           BEFORE="${{ inputs.from_height_exclusive }}"
           if [ -z "$BEFORE" ]; then BEFORE="${{ steps.before.outputs.height }}"; fi
           AFTER=$(python3 -c 'import json; print(json.load(open("api/record-chain-head.json"))["height"])')
+          if [ "$BEFORE" = "$AFTER" ] && [ "${{ inputs.require_new_records }}" = "true" ]; then
+            echo "::error::No new records: height unchanged ($BEFORE → $AFTER) with require_new_records=true"
+            exit 1
+          fi
           if [ "$BEFORE" = "$AFTER" ]; then
             python3 scripts/build_record_chain_data_arweave_bundle.py \
               --mode snapshot \

--- a/scripts/auto_finalize_accepted_submissions.py
+++ b/scripts/auto_finalize_accepted_submissions.py
@@ -25,28 +25,6 @@ def run(cmd: list[str]) -> None:
     if result.returncode != 0:
         raise SystemExit(f"command failed: {' '.join(cmd)}")
 
-def receipt_id_from_receipt(receipt: dict[str, Any]) -> str:
-    """Return canonical receipt id across legacy and server receipt schemas."""
-    rid = receipt.get("receipt_id") or receipt.get("server_receipt_id")
-    return str(rid or "")
-
-
-def receipt_is_accepted(receipt: dict[str, Any]) -> bool:
-    """Accept both legacy accepted receipts and immutable server receipts."""
-    return receipt.get("accepted") is True or bool(receipt.get("server_receipt_id"))
-
-
-def iter_submission_paths(submissions_dir: Path) -> list[Path]:
-    """Find dated and legacy intake submission files deterministically."""
-    return sorted(submissions_dir.glob("**/*.submission.json"))
-
-
-def find_receipt_for_submission(submission_path: Path, submissions_dir: Path, receipts_dir: Path) -> Path:
-    """Map submissions/YYYY/MM/<id>.submission.json to receipts/YYYY/MM/<id>.receipt.json."""
-    rel = submission_path.relative_to(submissions_dir)
-    return receipts_dir / str(rel).replace(".submission.json", ".receipt.json")
-
-
 def existing_receipt_ids() -> set[str]:
     out: set[str] = set()
     for entry in read_jsonl(LEDGER):
@@ -65,25 +43,28 @@ def current_confirm_string() -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--submissions-dir", default="record-chain/intake/submissions")
-    ap.add_argument("--receipts-dir", default="record-chain/intake/receipts")
+    ap.add_argument("--submissions-dir", default="record-chain/intake/accepted/submissions")
+    ap.add_argument("--receipts-dir", default="record-chain/intake/accepted/receipts")
     ap.add_argument("--max-records", type=int, default=10)
     ap.add_argument("--source-run-id", default="auto-finalize")
     ap.add_argument("--mode", choices=["dry-run", "live"], default="dry-run")
+    ap.add_argument("--require-new-records", action="store_true", default=False,
+                    help="Exit non-zero if no new records were finalized (prevents no-op false success).")
     args = ap.parse_args()
 
     submissions_dir = ROOT / args.submissions_dir
     receipts_dir = ROOT / args.receipts_dir
 
     if not submissions_dir.exists() or not receipts_dir.exists():
+        exit_code = 1 if args.require_new_records else 0
         print(json.dumps({
-            "result": "pass",
+            "result": "fail" if args.require_new_records else "pass",
             "mode": args.mode,
             "finalized_count": 0,
             "skipped_count": 0,
             "reason": "intake directories missing; no-op"
         }, indent=2, sort_keys=True))
-        return 0
+        return exit_code
 
     existing = existing_receipt_ids()
     finalized = []
@@ -91,21 +72,22 @@ def main() -> int:
 
     confirm = current_confirm_string()
 
-    for sub in iter_submission_paths(submissions_dir):
+    for sub in sorted(submissions_dir.glob("*.submission.json")):
         if len(finalized) >= args.max_records:
             break
 
-        receipt = find_receipt_for_submission(sub, submissions_dir, receipts_dir)
+        base = sub.name.replace(".submission.json", "")
+        receipt = receipts_dir / f"{base}.receipt.json"
         if not receipt.exists():
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "missing receipt"})
             continue
 
         rec = read_json(receipt)
-        if not receipt_is_accepted(rec):
+        if rec.get("accepted") is not True:
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "receipt not accepted"})
             continue
 
-        receipt_id = receipt_id_from_receipt(rec)
+        receipt_id = rec.get("receipt_id")
         if receipt_id in existing:
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "already finalized", "receipt_id": receipt_id})
             continue
@@ -133,15 +115,21 @@ def main() -> int:
 
         finalized.append({"submission": str(sub.relative_to(ROOT)), "receipt_id": receipt_id})
 
+    result = "pass"
+    exit_code = 0
+    if args.require_new_records and len(finalized) == 0:
+        result = "fail"
+        exit_code = 1
+
     print(json.dumps({
-        "result": "pass",
+        "result": result,
         "mode": args.mode,
         "finalized_count": len(finalized),
         "skipped_count": len(skipped),
         "finalized": finalized,
         "skipped": skipped,
     }, indent=2, sort_keys=True))
-    return 0
+    return exit_code
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/auto_finalize_accepted_submissions.py
+++ b/scripts/auto_finalize_accepted_submissions.py
@@ -25,6 +25,28 @@ def run(cmd: list[str]) -> None:
     if result.returncode != 0:
         raise SystemExit(f"command failed: {' '.join(cmd)}")
 
+def receipt_id_from_receipt(receipt: dict[str, Any]) -> str:
+    """Return canonical receipt id across legacy and server receipt schemas."""
+    rid = receipt.get("receipt_id") or receipt.get("server_receipt_id")
+    return str(rid or "")
+
+
+def receipt_is_accepted(receipt: dict[str, Any]) -> bool:
+    """Accept both legacy accepted receipts and immutable server receipts."""
+    return receipt.get("accepted") is True or bool(receipt.get("server_receipt_id"))
+
+
+def iter_submission_paths(submissions_dir: Path) -> list[Path]:
+    """Find dated and legacy intake submission files deterministically."""
+    return sorted(submissions_dir.glob("**/*.submission.json"))
+
+
+def find_receipt_for_submission(submission_path: Path, submissions_dir: Path, receipts_dir: Path) -> Path:
+    """Map submissions/YYYY/MM/<id>.submission.json to receipts/YYYY/MM/<id>.receipt.json."""
+    rel = submission_path.relative_to(submissions_dir)
+    return receipts_dir / str(rel).replace(".submission.json", ".receipt.json")
+
+
 def existing_receipt_ids() -> set[str]:
     out: set[str] = set()
     for entry in read_jsonl(LEDGER):
@@ -43,8 +65,8 @@ def current_confirm_string() -> str:
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--submissions-dir", default="record-chain/intake/accepted/submissions")
-    ap.add_argument("--receipts-dir", default="record-chain/intake/accepted/receipts")
+    ap.add_argument("--submissions-dir", default="record-chain/intake/submissions")
+    ap.add_argument("--receipts-dir", default="record-chain/intake/receipts")
     ap.add_argument("--max-records", type=int, default=10)
     ap.add_argument("--source-run-id", default="auto-finalize")
     ap.add_argument("--mode", choices=["dry-run", "live"], default="dry-run")
@@ -72,22 +94,21 @@ def main() -> int:
 
     confirm = current_confirm_string()
 
-    for sub in sorted(submissions_dir.glob("*.submission.json")):
+    for sub in iter_submission_paths(submissions_dir):
         if len(finalized) >= args.max_records:
             break
 
-        base = sub.name.replace(".submission.json", "")
-        receipt = receipts_dir / f"{base}.receipt.json"
+        receipt = find_receipt_for_submission(sub, submissions_dir, receipts_dir)
         if not receipt.exists():
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "missing receipt"})
             continue
 
         rec = read_json(receipt)
-        if rec.get("accepted") is not True:
+        if not receipt_is_accepted(rec):
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "receipt not accepted"})
             continue
 
-        receipt_id = rec.get("receipt_id")
+        receipt_id = receipt_id_from_receipt(rec)
         if receipt_id in existing:
             skipped.append({"submission": str(sub.relative_to(ROOT)), "reason": "already finalized", "receipt_id": receipt_id})
             continue

--- a/scripts/test_require_new_records_guard.py
+++ b/scripts/test_require_new_records_guard.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Test --require-new-records guard with date-partitioned intake layout."""
+from __future__ import annotations
+import json, shutil, subprocess, sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_date_partitioned_with_server_receipt_id():
+    test_dir = ROOT / ".test-require-new-records"
+    sub_dir = test_dir / "intake" / "submissions" / "2026" / "06"
+    rec_dir = test_dir / "intake" / "receipts" / "2026" / "06"
+    try:
+        shutil.rmtree(test_dir, ignore_errors=True)
+        sub_dir.mkdir(parents=True)
+        rec_dir.mkdir(parents=True)
+
+        (sub_dir / "test-001.submission.json").write_text(json.dumps({
+            "record_type": "echo", "record_id": "test-001",
+            "echo_content": {"echo_text": "test", "echo_intent": "verification"},
+        }), encoding="utf-8")
+        (rec_dir / "test-001.receipt.json").write_text(json.dumps({
+            "server_receipt_id": "rcg-20260607-test-001", "accepted": True,
+        }), encoding="utf-8")
+
+        r = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "auto_finalize_accepted_submissions.py"),
+             "--submissions-dir", str(test_dir / "intake" / "submissions"),
+             "--receipts-dir", str(test_dir / "intake" / "receipts"),
+             "--mode", "dry-run", "--require-new-records"],
+            cwd=ROOT, text=True, capture_output=True,
+        )
+        out = json.loads(r.stdout)
+        assert r.returncode == 0, f"exit {r.returncode}: {r.stderr}"
+        assert out["result"] == "pass"
+        assert out["finalized_count"] > 0
+        assert out["finalized"][0]["receipt_id"] == "rcg-20260607-test-001"
+        print("PASS: date-partitioned + server_receipt_id + --require-new-records")
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+def test_noop_fails_with_flag():
+    test_dir = ROOT / ".test-empty-guard"
+    try:
+        shutil.rmtree(test_dir, ignore_errors=True)
+        (test_dir / "intake" / "submissions").mkdir(parents=True)
+        (test_dir / "intake" / "receipts").mkdir(parents=True)
+
+        r = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "auto_finalize_accepted_submissions.py"),
+             "--submissions-dir", str(test_dir / "intake" / "submissions"),
+             "--receipts-dir", str(test_dir / "intake" / "receipts"),
+             "--mode", "dry-run", "--require-new-records"],
+            cwd=ROOT, text=True, capture_output=True,
+        )
+        out = json.loads(r.stdout)
+        assert r.returncode == 1, f"Expected exit 1, got {r.returncode}"
+        assert out["result"] == "fail"
+        assert out["finalized_count"] == 0
+        print("PASS: empty dirs + --require-new-records → exit 1")
+    finally:
+        shutil.rmtree(test_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_date_partitioned_with_server_receipt_id()
+    test_noop_fails_with_flag()
+    print("\nAll tests passed.")


### PR DESCRIPTION
## Summary

Adds `--require-new-records` guard to prevent no-op false success in the auto-finalizer and orchestrator pipeline.

### Changes

**`scripts/auto_finalize_accepted_submissions.py`**:
- New `--require-new-records` CLI flag
- When set: exits non-zero if `finalized_count == 0`
- Also fails when intake directories are missing (no silent pass)
- Without flag: behavior unchanged (backward compatible)

**`.github/workflows/pre-scale-e2e-orchestrator-v2.yml`**:
- New `require_new_records` workflow input (default: `false`)
- Passes `--require-new-records` to auto-finalizer step when enabled
- Fails `Build data bundle` step when height unchanged and flag is set

### Context

Covers the missing guard from PR #448. The recursive discovery part of PR 448 is already on main; this adds only the no-op protection.

### Testing

```bash
# Without flag: still passes
python3 scripts/auto_finalize_accepted_submissions.py --mode dry-run
# With flag: fails when no records
python3 scripts/auto_finalize_accepted_submissions.py --mode dry-run --require-new-records  # exit 1
```

Closes #448 (partial — recursive discovery already merged).