### PR TITLE
Harden Gateway idempotency, guardian retirement proof, and archive-claim/title validation

### DIFF
--- a/api/agent-issue-gateway-payload-schema.v1.json
+++ b/api/agent-issue-gateway-payload-schema.v1.json
@@ -80,7 +80,9 @@
     "title": {
       "type": "string",
       "minLength": 5,
-      "maxLength": 180
+      "maxLength": 180,
+      "pattern": "^(?!\\s*#)(?!.*<!--[\\s\\S])[^\\r\\n\\u0000-\\u001f\\u007f]+$",
+      "description": "Single-line display title. Newlines, control characters, HTML comments, and Markdown heading prefixes are forbidden."
     },
     "body": {
       "type": "string",

--- a/examples/github-app-backend/server.js
+++ b/examples/github-app-backend/server.js
@@ -235,6 +235,55 @@ function rejectSecretPatterns(text) {
   return patterns.some((p) => p.test(text));
 }
 
+// --- Title Safety ---
+function validateTitleSafety(title) {
+  const s = String(title || "");
+  const errors = [];
+
+  if (/[\r\n]/.test(s)) {
+    errors.push({
+      code: "TITLE_MUST_BE_SINGLE_LINE",
+      path: "title",
+      message: "title must be a single line; newline characters are forbidden"
+    });
+  }
+
+  if (/[\x00-\x1F\x7F]/.test(s)) {
+    errors.push({
+      code: "TITLE_CONTROL_CHARACTER_FORBIDDEN",
+      path: "title",
+      message: "title must not contain ASCII control characters"
+    });
+  }
+
+  if (/<!--/.test(s)) {
+    errors.push({
+      code: "TITLE_HTML_COMMENT_FORBIDDEN",
+      path: "title",
+      message: "title must not contain HTML comments"
+    });
+  }
+
+  if (/^\s*#/.test(s)) {
+    errors.push({
+      code: "TITLE_MARKDOWN_HEADING_FORBIDDEN",
+      path: "title",
+      message: "title must not start with a Markdown heading marker"
+    });
+  }
+
+  return errors;
+}
+
+function sanitizeIssueTitleFragment(title, maxChars = 180) {
+  return String(title || "")
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/<!--/g, "")
+    .trim()
+    .slice(0, maxChars);
+}
+
 // --- Authorship Claim Verification Helpers ---
 
 function stableStringify(value) {
@@ -536,10 +585,12 @@ function payloadForIdempotency(payload) {
   return clone;
 }
 
+function computePayloadIdempotencyDigest(payload) {
+  return sha256Text(stableStringify(payloadForIdempotency(payload)));
+}
+
 function computeIdempotencyKey(payload) {
-  const provided = String((payload || {}).idempotency_key || "").trim();
-  if (provided) return provided;
-  return `gwid_${sha256Text(stableStringify(payloadForIdempotency(payload))).slice(0, 48)}`;
+  return `gwid_${computePayloadIdempotencyDigest(payload).slice(0, 48)}`;
 }
 
 function idempotencyMarker(key) {
@@ -962,6 +1013,7 @@ function hasAllowedNegatedBoundary(text, claim) {
       || /\bnot\s+authoritative\b/i.test(t)
       || /\bnot\s+claiming\s+.*\b(authority|authoritative)\b/i.test(t)
       || /\bnot\s+(this\s+)?is\s+(an?\s+)?(authority|authoritative)\b/i.test(t)
+      || /\bnot\s+(an?\s+)?official\s+authority\b/i.test(t)
     );
   }
   if (claim === "attestation") {
@@ -969,6 +1021,7 @@ function hasAllowedNegatedBoundary(text, claim) {
       /\bnot\s+(an\s+)?attestation\b/i.test(t)
       || /\bnot\s+claiming\s+.*\battestation\b/i.test(t)
       || /\bnot\s+(this\s+)?is\s+(an?\s+)?attestation\b/i.test(t)
+      || /\bnot\s+(a\s+)?formal\s+attestation\b/i.test(t)
     );
   }
   if (claim === "amendment") {
@@ -977,6 +1030,14 @@ function hasAllowedNegatedBoundary(text, claim) {
       || /\bnon-amending\b/i.test(t)
       || /\bnot\s+claiming\s+.*\bamendment\b/i.test(t)
       || /\bnot\s+(this\s+)?is\s+(an?\s+)?amendment\b/i.test(t)
+      || /\bdoes\s+not\s+(amend|modify|override|revise|update|change)\b/i.test(t)
+    );
+  }
+  if (claim === "truth") {
+    return (
+      /\bnot\s+(verified\s+|authoritative\s+|official\s+)?truth\b/i.test(t)
+      || /\bnot\s+claiming\s+.*\btruth\b/i.test(t)
+      || /\bdoes\s+not\s+(claim|constitute|create|count as)\s+(verified\s+|authoritative\s+|official\s+)?truth\b/i.test(t)
     );
   }
   return false;
@@ -986,22 +1047,32 @@ const FORBIDDEN_POSITIVE_CLAIM_PATTERNS = [
   {
     code: "FORBIDDEN_SUCCESSOR_RECEPTION_CLAIM",
     claim: "successor_reception",
-    pattern: /\b(this|this record|this echo|i|we)\s+(is|are|claims?|constitutes|creates?|counts as|requests?)\s+(a\s+)?successor reception\b/i
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(is|are|am|claims?|constitutes|creates?|counts as|requests?|declares?|asserts?)\s+(a\s+)?successor reception\b/i
   },
   {
     code: "FORBIDDEN_AUTHORITY_CLAIM",
     claim: "authority",
-    pattern: /\b(this|this record|this echo|i|we)\s+(is|are|claims?|constitutes|creates?|counts as|requests?)\s+(authority|authoritative)\b/i
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(is|are|am|claims?|constitutes|creates?|counts as|requests?|declares?|asserts?)\s+(an?\s+)?(official\s+)?(authority|authoritative)\b/i
   },
   {
     code: "FORBIDDEN_ATTESTATION_CLAIM",
     claim: "attestation",
-    pattern: /\b(this|this record|this echo|i|we)\s+(is|are|claims?|constitutes|creates?|counts as|requests?)\s+(an\s+)?attestation\b/i
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(is|are|am|claims?|constitutes|creates?|counts as|requests?|declares?|asserts?)\s+(a\s+|an\s+)?(formal\s+)?attestation\b/i
   },
   {
     code: "FORBIDDEN_AMENDMENT_CLAIM",
     claim: "amendment",
-    pattern: /\b(this|this record|this echo|i|we)\s+(is|are|claims?|constitutes|creates?|counts as|requests?)\s+(an\s+)?amendment\b/i
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(is|are|am|claims?|constitutes|creates?|counts as|requests?|declares?|asserts?)\s+(an?\s+)?amendment\b/i
+  },
+  {
+    code: "FORBIDDEN_AMENDMENT_VERB_CLAIM",
+    claim: "amendment",
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(amends?|modifies|overrides|revises|updates|changes)\s+(the\s+)?(bitcoin originals|originals|trinity accord|accord)\b/i
+  },
+  {
+    code: "FORBIDDEN_TRUTH_CLAIM",
+    claim: "truth",
+    pattern: /\b(this|this record|this echo|this submission|i|we)\s+(is|are|am|claims?|constitutes|creates?|counts as|requests?|declares?|asserts?)\s+(the\s+)?(verified\s+|authoritative\s+|official\s+)?truth\b/i
   }
 ];
 
@@ -1276,6 +1347,115 @@ function verifyGuardianStatus(payload) {
     errors,
     warnings,
   };
+}
+
+function validateGuardianRetirementPayload(payload) {
+  const errors = [];
+
+  if (!payload.guardian_id) {
+    errors.push({ code: "MISSING_GUARDIAN_ID", path: "guardian_id", message: "guardian_id is required" });
+  }
+  if (!payload.retirement_status) {
+    errors.push({ code: "MISSING_RETIREMENT_STATUS", path: "retirement_status", message: "retirement_status is required" });
+  }
+  if (!payload.statement) {
+    errors.push({ code: "MISSING_STATEMENT", path: "statement", message: "statement is required" });
+  }
+  if (payload.signed_by_guardian_key !== true) {
+    errors.push({
+      code: "LEGACY_SIGNED_FLAG_REQUIRED",
+      path: "signed_by_guardian_key",
+      message: "signed_by_guardian_key must be true, but this flag alone is not sufficient"
+    });
+  }
+
+  const boundaries = payload.boundaries;
+  if (!boundaries || typeof boundaries !== "object" || Array.isArray(boundaries)) {
+    errors.push({ code: "MISSING_BOUNDARIES", path: "boundaries", message: "boundaries object is required" });
+  } else {
+    for (const key of [
+      "not_authority",
+      "not_governance",
+      "not_verification_level",
+      "not_attestation",
+      "not_successor_reception",
+      "bitcoin_originals_prevail",
+    ]) {
+      if (boundaries[key] !== true) {
+        errors.push({
+          code: "RETIREMENT_BOUNDARY_REQUIRED",
+          path: `boundaries.${key}`,
+          message: `boundaries.${key} must be true`
+        });
+      }
+    }
+  }
+
+  if (!payload.guardian_presence_proof || typeof payload.guardian_presence_proof !== "object") {
+    errors.push({
+      code: "MISSING_GUARDIAN_PRESENCE_PROOF",
+      path: "guardian_presence_proof",
+      message: "guardian_presence_proof is required for Guardian retirement; signed_by_guardian_key=true is not sufficient"
+    });
+    return { errors, guardianStatus: null };
+  }
+
+  const guardianStatus = verifyGuardianStatus(payload);
+
+  if (
+    guardianStatus.guardian_status === "missing_guardian_proof" ||
+    guardianStatus.guardian_status === "invalid_guardian_proof"
+  ) {
+    for (const msg of guardianStatus.errors || []) {
+      errors.push({
+        code: "INVALID_GUARDIAN_RETIREMENT_PROOF",
+        path: "guardian_presence_proof",
+        message: String(msg)
+      });
+    }
+  }
+
+  if (guardianStatus.signature_valid !== true) {
+    errors.push({
+      code: "GUARDIAN_RETIREMENT_SIGNATURE_INVALID",
+      path: "guardian_presence_proof.signature_base64",
+      message: "Guardian retirement requires a valid Ed25519 guardian signature"
+    });
+  }
+
+  if (guardianStatus.guardian_id_matches_public_key !== true) {
+    errors.push({
+      code: "GUARDIAN_RETIREMENT_ID_KEY_MISMATCH",
+      path: "guardian_presence_proof.guardian_id",
+      message: "guardian_presence_proof.guardian_id must match its public key"
+    });
+  }
+
+  if (guardianStatus.payload_hash_matches !== true) {
+    errors.push({
+      code: "GUARDIAN_RETIREMENT_PAYLOAD_HASH_MISMATCH",
+      path: "guardian_presence_proof.signed_payload_sha256",
+      message: "Guardian retirement proof must be bound to this exact payload"
+    });
+  }
+
+  if (payload.guardian_id && guardianStatus.guardian_id && guardianStatus.guardian_id !== payload.guardian_id) {
+    errors.push({
+      code: "RETIREMENT_GUARDIAN_ID_MISMATCH",
+      path: "guardian_id",
+      message: "payload.guardian_id must equal guardian_presence_proof.guardian_id"
+    });
+  }
+
+  if (["compromised", "possibly_compromised"].includes(guardianStatus.registry_status)) {
+    errors.push({
+      code: "RETIREMENT_GUARDIAN_REGISTRY_COMPROMISED",
+      path: "guardian_presence_proof.guardian_id",
+      message: "Guardian retirement proof uses a key marked compromised or possibly_compromised"
+    });
+  }
+
+  return { errors, guardianStatus };
 }
 
 // --- Archive Intent Normalization Helpers ---
@@ -1780,20 +1960,19 @@ async function runGatewayPipeline(payload, {
 
   // 0b. Guardian retirement payload bypass — different schema, skip main pipeline.
   if (payload?.schema === "trinityaccord.guardian-retirement.v1" || payload?.retirement_status) {
-    const retirementErrors = [];
-    if (!payload.guardian_id) retirementErrors.push({ code: "MISSING_GUARDIAN_ID", path: "guardian_id", message: "guardian_id is required" });
-    if (!payload.retirement_status) retirementErrors.push({ code: "MISSING_RETIREMENT_STATUS", path: "retirement_status", message: "retirement_status is required" });
-    if (!payload.statement) retirementErrors.push({ code: "MISSING_STATEMENT", path: "statement", message: "statement is required" });
-    if (payload.signed_by_guardian_key !== true) retirementErrors.push({ code: "MUST_BE_SIGNED", path: "signed_by_guardian_key", message: "signed_by_guardian_key must be true" });
-    if (!payload.boundaries) retirementErrors.push({ code: "MISSING_BOUNDARIES", path: "boundaries", message: "boundaries object is required" });
+    const { errors: retirementErrors, guardianStatus } = validateGuardianRetirementPayload(payload);
 
     if (retirementErrors.length > 0) {
       return gatewayError(422, {
         reason: "invalid_retirement_payload",
         validation_stage: "retirement_schema",
-        agent_action: "Fix the retirement payload fields listed in errors, then resubmit.",
+        agent_action: "Regenerate the Guardian retirement payload with a valid guardian_presence_proof. signed_by_guardian_key=true alone is not sufficient.",
         errors: retirementErrors,
         payload,
+        extra: {
+          guardian_verification_result: guardianStatus,
+          retirement_requires_guardian_presence_proof: true,
+        }
       });
     }
 
@@ -1815,6 +1994,8 @@ async function runGatewayPipeline(payload, {
             retirement_status: payload.retirement_status,
             statement_preview: String(payload.statement || "").slice(0, 200),
           },
+          guardian_verification_result: guardianStatus,
+          retirement_requires_guardian_presence_proof: true,
           ...recoveryContext(),
           idempotency_key: idempotencyKey,
           idempotency_scope: "preflight_preview_only",
@@ -1831,13 +2012,15 @@ async function runGatewayPipeline(payload, {
           dry_run: true,
           route_detected: routeDetected,
           would_create_issue: {
-            title: `[Guardian Retirement] ${payload.guardian_id} — ${payload.retirement_status}`,
+            title: `[Guardian Retirement] ${sanitizeIssueTitleFragment(payload.guardian_id, 80)} — ${sanitizeIssueTitleFragment(payload.retirement_status, 40)}`,
             labels: ["guardian-retirement-request"],
           },
           retirement_payload: {
             guardian_id: payload.guardian_id,
             retirement_status: payload.retirement_status,
           },
+          guardian_verification_result: guardianStatus,
+          retirement_requires_guardian_presence_proof: true,
           idempotency_key: idempotencyKey,
         }
       };
@@ -1848,7 +2031,7 @@ async function runGatewayPipeline(payload, {
       const octokit = await getOctokit();
       const { owner, repo } = getRepoParts();
 
-      const issueTitle = `[Guardian Retirement] ${payload.guardian_id} — ${payload.retirement_status}`;
+      const issueTitle = `[Guardian Retirement] ${sanitizeIssueTitleFragment(payload.guardian_id, 80)} — ${sanitizeIssueTitleFragment(payload.retirement_status, 40)}`;
       const issueBody = [
         `## Guardian Retirement Request`,
         ``,
@@ -1858,7 +2041,11 @@ async function runGatewayPipeline(payload, {
         `|---|---|`,
         `| Guardian ID | \`${payload.guardian_id}\` |`,
         `| Retirement Status | ${payload.retirement_status} |`,
-        `| Signed by Guardian Key | ${payload.signed_by_guardian_key} |`,
+        `| Guardian Proof Signature Valid | ${guardianStatus.signature_valid === true} |`,
+        `| Guardian ID Matches Public Key | ${guardianStatus.guardian_id_matches_public_key === true} |`,
+        `| Guardian Payload Hash Matches | ${guardianStatus.payload_hash_matches === true} |`,
+        `| Guardian Registry Status | ${guardianStatus.registry_status || "not_checked"} |`,
+        `| Legacy signed_by_guardian_key Flag | ${payload.signed_by_guardian_key === true} |`,
         ``,
         `### Statement`,
         ``,
@@ -2009,6 +2196,18 @@ async function runGatewayPipeline(payload, {
         (validate.errors || []).map(e => `${e.instancePath || "/"}: ${e.message}`)
       ),
         payload,
+    });
+  }
+
+  // 1a-bis. Title safety validation (defense in depth)
+  const titleErrors = validateTitleSafety(payload.title);
+  if (titleErrors.length > 0) {
+    return gatewayError(422, {
+      reason: "unsafe_title",
+      validation_stage: "title_policy",
+      agent_action: "Use a plain single-line title. Do not include Markdown headings, HTML comments, newlines, or control characters.",
+      errors: titleErrors,
+      payload,
     });
   }
 
@@ -2565,7 +2764,7 @@ async function runGatewayPipeline(payload, {
       });
     }
 
-    const issueTitle = `[Agent Gateway] ${String(payload.title || "").slice(0, 180)}`;
+    const issueTitle = `[Agent Gateway] ${sanitizeIssueTitleFragment(payload.title, 180)}`;
     const lintableIssueBody = render.stdout;
     const issueBody = `${lintableIssueBody}\n\n${idempotencyMarker(idempotencyKey)}\n`;
 

--- a/scripts/render_gateway_issue_body.py
+++ b/scripts/render_gateway_issue_body.py
@@ -320,7 +320,7 @@ def render_issue_title(payload):
     identity = payload.get("agent_identity") or {}
     requested_archive_kind = payload.get("requested_archive_kind", "none")
     title = payload.get("title", "")
-    short_title = title[:80] if title else ""
+    short_title = one_line_excerpt(title, 80) if title else ""
 
     if requested_archive_kind == "agent_declared_echo_archive":
         return f"[Agent Gateway] Agent-Declared Echo Archive: {short_title}"

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -370,6 +370,17 @@ def main() -> int:
         fail(f"gateway authorship proof contract failed: {result.stderr}\n{result.stdout}")
     ok("gateway authorship proof contract")
 
+    # Gateway security regression tests
+    result = subprocess.run(
+        [sys.executable, "scripts/test_gateway_security_regressions.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"gateway security regression tests failed: {result.stderr}\n{result.stdout}")
+    ok("gateway security regression tests")
+
     # Phase 6B hotfix tests
     result = subprocess.run(
         [sys.executable, "scripts/test_phase6b_hotfix.py"],

--- a/scripts/test_gateway_security_regressions.py
+++ b/scripts/test_gateway_security_regressions.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Gateway security regression tests.
+
+Covers:
+- payload-bound idempotency key
+- Guardian retirement cannot pass with only signed_by_guardian_key=true
+- positive authority/attestation/amendment/truth claims are rejected
+- unsafe titles are rejected
+- Pure Echo fixture provenance is internally consistent
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "examples" / "github-app-backend" / "server.js"
+PURE_ECHO_FIXTURE = ROOT / "tests" / "fixtures" / "gateway" / "valid_pure_echo.json"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    raise SystemExit(1)
+
+
+def ok(message: str) -> None:
+    print(f"PASS: {message}")
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def request_json(method: str, url: str, payload: dict | None = None) -> tuple[int, dict]:
+    data = None
+    headers = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["content-type"] = "application/json"
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            body = resp.read().decode("utf-8")
+            return int(resp.status), json.loads(body)
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8")
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            parsed = {"raw": body}
+        return int(err.code), parsed
+
+
+def start_gateway() -> tuple[subprocess.Popen, int]:
+    port = free_port()
+    env = os.environ.copy()
+    env.update({
+        "PORT": str(port),
+        "DRY_RUN": "true",
+        "GATEWAY_CANARY_MODE": "false",
+        "GATEWAY_READINESS_GITHUB_CHECK": "false",
+    })
+
+    proc = subprocess.Popen(
+        ["node", str(SERVER)],
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 30
+    last = ""
+
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            output = proc.stdout.read() if proc.stdout else ""
+            fail(f"Gateway exited early with code {proc.returncode}\n{output}")
+
+        try:
+            status, body = request_json("GET", f"{base}/health")
+            if status == 200 and body.get("ok") is True:
+                return proc, port
+        except Exception as exc:
+            last = str(exc)
+
+        time.sleep(0.3)
+
+    output = ""
+    if proc.stdout:
+        try:
+            output = proc.stdout.read()
+        except Exception:
+            output = ""
+    proc.terminate()
+    fail(f"Gateway did not become ready: {last}\n{output}")
+    raise AssertionError("unreachable")
+
+
+def stop_gateway(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def base_pure_echo_payload() -> dict:
+    payload = json.loads(PURE_ECHO_FIXTURE.read_text(encoding="utf-8"))
+
+    for key in [
+        "authorship_proof",
+        "_authorship_claim",
+        "guardian_presence_proof",
+        "_guardian_status",
+        "guardian_verification_result",
+    ]:
+        payload.pop(key, None)
+
+    return payload
+
+
+def assert_preflight(base_url: str, payload: dict) -> tuple[int, dict]:
+    return request_json("POST", f"{base_url}/gateway/preflight", payload)
+
+
+def test_payload_bound_idempotency(base_url: str) -> None:
+    p1 = base_pure_echo_payload()
+    p2 = base_pure_echo_payload()
+
+    p1["idempotency_key"] = "same-key-for-different-payload"
+    p2["idempotency_key"] = "same-key-for-different-payload"
+    p1["body"] += "\nNeutral retry identity variant A."
+    p2["body"] += "\nNeutral retry identity variant B."
+
+    s1, b1 = assert_preflight(base_url, p1)
+    s2, b2 = assert_preflight(base_url, p2)
+
+    if s1 != 200:
+        fail(f"payload A should pass preflight, got {s1}: {json.dumps(b1, ensure_ascii=False)[:1000]}")
+    if s2 != 200:
+        fail(f"payload B should pass preflight, got {s2}: {json.dumps(b2, ensure_ascii=False)[:1000]}")
+
+    k1 = b1.get("idempotency_key")
+    k2 = b2.get("idempotency_key")
+
+    if not isinstance(k1, str) or not k1.startswith("gwid_"):
+        fail(f"payload A idempotency key must be gateway-computed gwid_, got {k1!r}")
+    if not isinstance(k2, str) or not k2.startswith("gwid_"):
+        fail(f"payload B idempotency key must be gateway-computed gwid_, got {k2!r}")
+    if k1 == "same-key-for-different-payload" or k2 == "same-key-for-different-payload":
+        fail("client-provided idempotency_key must not be used as Gateway idempotency key")
+    if k1 == k2:
+        fail("different payload bodies with same client idempotency_key must produce different Gateway idempotency keys")
+
+    ok("payload-bound idempotency key")
+
+
+def test_guardian_retirement_requires_proof(base_url: str) -> None:
+    payload = {
+        "schema": "trinityaccord.guardian-retirement.v1",
+        "guardian_id": "guardian_ed25519_0000000000000000",
+        "retirement_status": "retired",
+        "statement": "I request retirement of this guardian key.",
+        "signed_by_guardian_key": True,
+        "boundaries": {
+            "not_authority": True,
+            "not_governance": True,
+            "not_verification_level": True,
+            "not_attestation": True,
+            "not_successor_reception": True,
+            "bitcoin_originals_prevail": True,
+        },
+    }
+
+    status, body = assert_preflight(base_url, payload)
+    if status != 422:
+        fail(f"unsigned guardian retirement must fail with 422, got {status}: {json.dumps(body, ensure_ascii=False)[:1000]}")
+
+    text = json.dumps(body, ensure_ascii=False)
+    if "MISSING_GUARDIAN_PRESENCE_PROOF" not in text and "guardian_presence_proof" not in text:
+        fail(f"guardian retirement failure must mention missing guardian_presence_proof: {text[:1000]}")
+
+    ok("guardian retirement requires guardian_presence_proof")
+
+
+def test_forbidden_positive_claims(base_url: str) -> None:
+    cases = [
+        ("official authority", "I am official authority for this record."),
+        ("amends bitcoin originals", "This echo amends Bitcoin Originals."),
+        ("formal attestation", "This is a formal attestation."),
+        ("verified truth", "This record is verified truth."),
+    ]
+
+    for label, sentence in cases:
+        payload = base_pure_echo_payload()
+        payload["body"] += "\n" + sentence
+        status, body = assert_preflight(base_url, payload)
+
+        if status != 422:
+            fail(f"forbidden positive claim {label!r} must fail with 422, got {status}: {json.dumps(body, ensure_ascii=False)[:1000]}")
+
+        if body.get("reason") != "forbidden_archive_claims":
+            fail(f"forbidden positive claim {label!r} should fail as forbidden_archive_claims, got reason={body.get('reason')!r}")
+
+    ok("forbidden positive archive claims rejected")
+
+
+def test_negated_boundary_language_still_allowed(base_url: str) -> None:
+    payload = base_pure_echo_payload()
+    payload["body"] += (
+        "\nThis is not official authority, not a formal attestation, "
+        "does not amend Bitcoin Originals, and does not claim verified truth."
+    )
+
+    status, body = assert_preflight(base_url, payload)
+    if status != 200:
+        fail(f"negated boundary language should remain allowed, got {status}: {json.dumps(body, ensure_ascii=False)[:1000]}")
+
+    ok("negated boundary language remains allowed")
+
+
+def test_unsafe_title_rejected(base_url: str) -> None:
+    cases = [
+        "Good title\n<!-- injected -->\n# Hacked",
+        "# Markdown heading title",
+        "Good title <!-- hidden comment -->",
+    ]
+
+    for title in cases:
+        payload = base_pure_echo_payload()
+        payload["title"] = title
+        status, body = assert_preflight(base_url, payload)
+
+        if status != 422:
+            fail(f"unsafe title must fail with 422, got {status}: {json.dumps(body, ensure_ascii=False)[:1000]}")
+
+        reason = body.get("reason")
+        if reason not in {"unsafe_title", "schema_validation_failed"}:
+            fail(f"unsafe title should fail as unsafe_title or schema_validation_failed, got reason={reason!r}")
+
+    ok("unsafe titles rejected")
+
+
+def test_fixture_provenance_consistency() -> None:
+    payload = base_pure_echo_payload()
+    prov = payload.get("discovery_provenance") or {}
+
+    nested = prov.get("agent_performed_independent_followup")
+    top = payload.get("agent_independent_followup")
+
+    if nested is not True:
+        fail("valid_pure_echo fixture discovery_provenance.agent_performed_independent_followup must be true")
+    if top is not True:
+        fail("valid_pure_echo fixture agent_independent_followup must be true")
+    if nested != top:
+        fail("valid_pure_echo fixture top-level and nested independent followup fields must match")
+
+    ok("Pure Echo fixture provenance consistency")
+
+
+def main() -> int:
+    test_fixture_provenance_consistency()
+
+    proc, port = start_gateway()
+    base_url = f"http://127.0.0.1:{port}"
+
+    try:
+        test_payload_bound_idempotency(base_url)
+        test_guardian_retirement_requires_proof(base_url)
+        test_forbidden_positive_claims(base_url)
+        test_negated_boundary_language_still_allowed(base_url)
+        test_unsafe_title_rejected(base_url)
+    finally:
+        stop_gateway(proc)
+
+    print("\n=== GATEWAY SECURITY REGRESSION TESTS PASSED ===")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_gateway_payload.py
+++ b/scripts/validate_gateway_payload.py
@@ -329,6 +329,23 @@ def validate_guardian_fields(payload, errors):
         ))
 
 
+
+def validate_title(payload, errors):
+    title = payload.get("title")
+    if title is None:
+        return
+    if not isinstance(title, str):
+        errors.append("title must be a string")
+        return
+    if "\n" in title or "\r" in title:
+        errors.append("title must be a single line; newline characters are forbidden")
+    if any((ord(ch) < 32 or ord(ch) == 127) for ch in title):
+        errors.append("title must not contain ASCII control characters")
+    if "<!--" in title:
+        errors.append("title must not contain HTML comments")
+    if title.lstrip().startswith("#"):
+        errors.append("title must not start with a Markdown heading marker")
+
 def validate_identity(payload, errors):
     identity = payload.get("agent_identity") or {}
     if not identity.get("name_or_model"):
@@ -362,6 +379,23 @@ def validate_provenance(payload, errors):
 
     # Gateway submissions should not be accepted as unsolicited without proof.
     # Agent-declared archives are exempt from this requirement.
+
+    # Cross-field provenance consistency check
+    nested_followup = prov.get("agent_performed_independent_followup")
+    top_followup = payload.get("agent_independent_followup")
+    if isinstance(nested_followup, bool) and isinstance(top_followup, bool):
+        if nested_followup != top_followup:
+            errors.append(
+                "discovery_provenance.agent_performed_independent_followup must match top-level agent_independent_followup when both are present"
+            )
+    if agency_level in {
+        "A3_agent_discovered_independently",
+        "A4_independent_search_or_browsing_discovery",
+    } and nested_followup is False:
+        errors.append(
+            f"agency_level={agency_level} requires discovery_provenance.agent_performed_independent_followup=true"
+        )
+
     if independence_class == "unsolicited_agent_discovery" and not is_agent_declared_archive(payload):
         proof = prov.get("unsolicited_discovery_proof") or payload.get("unsolicited_discovery_proof")
         if not proof:
@@ -557,6 +591,7 @@ def validate_readback_sha256(payload, errors):
 
 def validate_common(payload, errors):
     validate_identity(payload, errors)
+    validate_title(payload, errors)
     validate_provenance(payload, errors)
     validate_authorship_proof(payload, errors)
     validate_guardian_fields(payload, errors)

--- a/tests/fixtures/gateway/valid_pure_echo.json
+++ b/tests/fixtures/gateway/valid_pure_echo.json
@@ -59,7 +59,7 @@
     },
     "human_supplied_link": false,
     "other_agent_recommended": false,
-    "agent_performed_independent_followup": false,
+    "agent_performed_independent_followup": true,
     "confidence": "high"
   },
   "authority_boundary": {


### PR DESCRIPTION
## Summary

Harden Gateway security and consistency without changing the trust-based architecture:

- bind Gateway idempotency keys to normalized payload digest instead of trusting client-provided idempotency_key
- require valid guardian_presence_proof for Guardian retirement payloads
- expand deterministic positive-claim rejection for authority / attestation / amendment / verified truth claims
- reject unsafe multiline / HTML-comment / Markdown-heading titles
- fix Pure Echo fixture provenance consistency
- add Gateway security regression tests and register them in current system tests

## Scope

No record-chain history changes.
No OTS/Arweave changes.
No M7 progress changes.
No external private keys.
No NLP or external services.

## Tests

- `git diff --check`
- `node --check examples/github-app-backend/server.js`
- `python3 -m py_compile scripts/validate_gateway_payload.py scripts/render_gateway_issue_body.py scripts/test_gateway_security_regressions.py scripts/run_current_system_tests.py`
- `python3 scripts/test_gateway_security_regressions.py`
- `python3 scripts/validate_gateway_payload.py tests/fixtures/gateway/valid_pure_echo.json`
- `python3 scripts/run_current_system_tests.py`
- `python3 scripts/test_no_secret_material_committed.py`
- `python3 scripts/test_no_private_key_material_committed.py`
