### PR TITLE
Fix builder compatibility with PR455 gateway rules

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -5,8 +5,8 @@
     "language": "node",
     "runtime": "node>=18",
     "url": "/downloads/record-chain-builder.mjs",
-    "sha256": "7e1bfad10ca8cc4346a1dc17fa673401c646a33a292cd2abfa6fbcfb13e70add",
-    "size_bytes": 100742,
+    "sha256": "3e2879b7d5041fd2dd1ca3d708cf2cf86993b1170c41a84ecf07631dd6a57e72",
+    "size_bytes": 101136,
     "supports": [
       "echo",
       "verification",

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -183,7 +183,7 @@ const OATH_POLICY = {
   },
   "linked_guardian_module": "guardian_stewardship_v1"
 };
-const OATH_POLICY_SHA256 = "7ecc6908c9ac147d8d6d493f750c94d6117929e7dff2d18bcbc4c70527886ea4";
+const OATH_POLICY_SHA256 = "9356e8c0955d7f17814dff1a93300cb271acfa21cfe39da63a7b5201364cb820";
 
 function getCanonicalOath(recordType, linkedGuardian = false) {
   const modules = getOathModules(recordType, linkedGuardian);
@@ -663,9 +663,6 @@ function buildV2CommonFields(opts) {
       receipt_is_not_final_inclusion: true,
       test_phase_submission_may_be_reclassified: true,
     },
-    optional_linked_guardian_application_request: {
-      does_participant_request_guardian_application_with_this_record: false,
-    },
   };
 }
 
@@ -729,6 +726,9 @@ function buildGuardianApplicationDraft(opts) {
       guardian_understands_retirement_does_not_delete_history: true,
     },
     ...buildV2CommonFields(opts),
+    optional_linked_guardian_application_request: {
+      does_participant_request_guardian_application_with_this_record: false,
+    },
     context_readiness: buildContextReadiness(opts),
     created_at: isoNow(),
   };
@@ -741,6 +741,9 @@ function buildGuardianRetirementDraft(opts) {
     guardian_id: opts.guardianId || "",
     guardian_public_key_sha256: opts.guardianKeySha || "",
     reason: opts.body || "Voluntary retirement",
+    optional_linked_guardian_application_request: {
+      does_participant_request_guardian_application_with_this_record: false,
+    },
     retirement_does_not_remove_historical_record: true,
     ...buildV2CommonFields(opts),
     context_readiness: buildContextReadiness({ ...opts, contextLevel: opts.contextLevel || "CC-1" }),
@@ -1002,13 +1005,13 @@ const FIELD_EXPLANATIONS = {
 };
 
 const RECORD_TYPE_FIELDS = {
-  echo: ["schema", "record_type", "echo_content", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
-  verification: ["schema", "record_type", "verification_content", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
+  echo: ["schema", "record_type", "echo_content", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "context_readiness", "created_at"],
+  verification: ["schema", "record_type", "verification_content", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "context_readiness", "created_at"],
   "guardian-application": ["schema", "record_type", "guardian_application_content", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
   "guardian-retirement": ["schema", "record_type", "guardian_id", "guardian_public_key_sha256", "reason", "retirement_does_not_remove_historical_record", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
-  propagation: ["schema", "record_type", "title", "body", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
-  correction: ["schema", "record_type", "title", "body", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
-  "context-insufficient": ["schema", "record_type", "reason", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "optional_linked_guardian_application_request", "context_readiness", "created_at"],
+  propagation: ["schema", "record_type", "title", "body", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "context_readiness", "created_at"],
+  correction: ["schema", "record_type", "title", "body", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "context_readiness", "created_at"],
+  "context-insufficient": ["schema", "record_type", "reason", "submitting_participant_identity", "discovery_and_introduction_context", "decision_autonomy_context", "submission_execution_context", "authorization_context", "non_authority_boundary_acknowledgement", "context_readiness", "created_at"],
 };
 
 // ── Error code help map ──────────────────────────────────────────────
@@ -1186,8 +1189,13 @@ function runDoctor(submission) {
     { key: "submission_execution_context", code: "MISSING_SUBMISSION_EXECUTION_CONTEXT" },
     { key: "authorization_context", code: "MISSING_AUTHORIZATION_CONTEXT" },
     { key: "non_authority_boundary_acknowledgement", code: "MISSING_NON_AUTHORITY_BOUNDARY" },
-    { key: "optional_linked_guardian_application_request", code: "MISSING_GUARDIAN_APPLICATION_REQUEST" },
   ];
+
+  // Guardian field is only required for guardian_application and guardian_retirement
+  const guardianRecordTypes = new Set(["guardian_application", "guardian_retirement"]);
+  if (guardianRecordTypes.has(draft.record_type)) {
+    v2Fields.push({ key: "optional_linked_guardian_application_request", code: "MISSING_GUARDIAN_APPLICATION_REQUEST" });
+  }
 
   for (const { key, code } of v2Fields) {
     if (!draft[key]) {
@@ -1248,8 +1256,9 @@ function repairSubmission(submission, opts = {}) {
     changes.push("Removed deprecated 'context_level' field (context_readiness already present).");
   }
 
-  // 3. Add optional_linked_guardian_application_request if missing
-  if (!draft.optional_linked_guardian_application_request) {
+  // 3. Add optional_linked_guardian_application_request if missing (only for guardian record types)
+  const guardianTypes = new Set(["guardian_application", "guardian_retirement"]);
+  if (guardianTypes.has(draft.record_type) && !draft.optional_linked_guardian_application_request) {
     draft.optional_linked_guardian_application_request = {
       does_participant_request_guardian_application_with_this_record: false,
     };
@@ -1504,9 +1513,11 @@ function generateTemplate(recordType) {
     test_phase_submission_may_be_reclassified: true,
   };
 
-  draft.optional_linked_guardian_application_request = {
-    does_participant_request_guardian_application_with_this_record: false,
-  };
+  if (recordType === "guardian_application" || recordType === "guardian_retirement") {
+    draft.optional_linked_guardian_application_request = {
+      does_participant_request_guardian_application_with_this_record: false,
+    };
+  }
 
   draft.context_readiness = {
     declared_context_level: "__helper_note: Context level, e.g. CC-0, CC-1, CC-2, CC-3, CC-4",

--- a/scripts/inject_oath_into_builder.py
+++ b/scripts/inject_oath_into_builder.py
@@ -31,8 +31,7 @@ def main() -> None:
         "oath_policy_sha256_semantics",
         "canonical_oath_text_hash_is_record_type_specific",
     }
-    policy_core = {k: v for k, v in policy.items() if k not in _metadata_keys}
-    canonical_policy = json.dumps(policy_core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    canonical_policy = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     policy_sha256 = hashlib.sha256(canonical_policy.encode("utf-8")).hexdigest()
 
     # Check if already injected

--- a/scripts/test_record_chain_builder_bundle_contract.py
+++ b/scripts/test_record_chain_builder_bundle_contract.py
@@ -138,14 +138,8 @@ def main() -> None:
             if m:
                 embedded_sha = m.group(1)
                 policy = json.loads(oath_policy_path.read_text(encoding="utf-8"))
-                # Exclude API metadata fields not in builder's embedded OATH_POLICY
-                _metadata_keys = {
-                    "oath_policy_sha256",
-                    "oath_policy_sha256_semantics",
-                    "canonical_oath_text_hash_is_record_type_specific",
-                }
-                policy_core = {k: v for k, v in policy.items() if k not in _metadata_keys}
-                canonical = json.dumps(policy_core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+                # Hash the full policy JSON (same as gateway validation.py)
+                canonical = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
                 actual_sha = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
                 if embedded_sha != actual_sha:
                     errors.append(

--- a/scripts/test_record_chain_intake_gateway_contract.py
+++ b/scripts/test_record_chain_intake_gateway_contract.py
@@ -164,14 +164,8 @@ def main() -> None:
     import hashlib
     wrong_readback = "This is not the canonical oath text"
     policy = json.loads((ROOT / "api" / "record-chain-oath-policy.v1.json").read_text())
-    # Exclude API metadata fields not in builder's embedded OATH_POLICY
-    _metadata_keys = {
-        "oath_policy_sha256",
-        "oath_policy_sha256_semantics",
-        "canonical_oath_text_hash_is_record_type_specific",
-    }
-    policy_core = {k: v for k, v in policy.items() if k not in _metadata_keys}
-    policy_json = json.dumps(policy_core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    # Hash full policy JSON (same as gateway validation.py)
+    policy_json = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
     policy_sha = hashlib.sha256(policy_json.encode("utf-8")).hexdigest()
 
     # Build canonical oath for echo

--- a/scripts/test_record_chain_oath_gate_contract.py
+++ b/scripts/test_record_chain_oath_gate_contract.py
@@ -121,14 +121,8 @@ def main() -> None:
         m = re.search(r'OATH_POLICY_SHA256\s*=\s*"([a-f0-9]{64})"', builder_text)
         if m:
             embedded_sha = m.group(1)
-            # Exclude API metadata fields not in builder's embedded OATH_POLICY
-            _metadata_keys = {
-                "oath_policy_sha256",
-                "oath_policy_sha256_semantics",
-                "canonical_oath_text_hash_is_record_type_specific",
-            }
-            policy_core = {k: v for k, v in policy.items() if k not in _metadata_keys}
-            canonical = json.dumps(policy_core, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            # Hash full policy JSON (same as gateway validation.py)
+            canonical = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
             actual_sha = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
             if embedded_sha != actual_sha:
                 errors.append(f"builder OATH_POLICY_SHA256 mismatch: embedded={embedded_sha[:16]}... actual={actual_sha[:16]}...")


### PR DESCRIPTION
## Summary

Fix builder compatibility with PR #455 Record-Chain Intake gateway rules.

- Update builder oath policy hash to current gateway policy (`9356e8c0...`)
- Stop emitting `optional_linked_guardian_application_request` for echo/verification/propagation/correction records
- Update doctor/repair to only require guardian field for guardian record types
- Verified: unmodified builder echo → preflight accepted with no diagnostics

## Context

M8.1 PR455 delta smoke showed the live gateway path works after manual repair/re-signing, but the official builder is incompatible with PR455 gateway validation:
- `OATH_POLICY_SHA256` was stale (`7ecc6908...` vs current `9356e8c0...`)
- `optional_linked_guardian_application_request` was emitted for all record types; PR455 gateway rejects it for echo with `RECORD_TYPE_SEPARATION_VIOLATION`

## M8 impact

- M7 remains pass; no full M7 rerun required
- M8.1 remains on hold until this PR is merged and smoke is rerun with unmodified builder