### PR TITLE
Fix native record-chain archive tooling for M9.3

### DIFF
--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-08T04:18:22.536865+00:00",
+  "generated_at": "2026-06-08T04:31:20.199542+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",

--- a/scripts/build_record_chain_arweave_archive.py
+++ b/scripts/build_record_chain_arweave_archive.py
@@ -24,6 +24,7 @@ BATCHES = CHAIN / "batches"
 INDEXES = CHAIN / "indexes"
 ARCHIVES = CHAIN / "arweave-archives"
 API_INDEX = ROOT / "api" / "record-chain-arweave-index.json"
+NATIVE_OTS_LATEST = ROOT / "api" / "record-chain-native-ots-latest.json"
 CHAIN_ID = "trinity-accord-public-reception-ledger"
 
 
@@ -58,11 +59,127 @@ def sha256_file(path: Path) -> str:
 def read_json(path: Path):
     return json.loads(path.read_text(encoding="utf-8"))
 
+def source_file_ref(path: Path) -> dict:
+    return {
+        "path": str(path.relative_to(ROOT)),
+        "sha256": sha256_file(path),
+        "bytes": path.stat().st_size,
+    }
+
+
 
 def write_json(path: Path, obj):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(canonical_dumps(obj), encoding="utf-8")
 
+
+
+
+def load_native_chain_sources() -> dict:
+    chain_tip_path = CHAIN / "chain-tip.json"
+    record_index_path = INDEXES / "record-index.json"
+    guardian_state_path = INDEXES / "guardian-state.json"
+    statistics_path = INDEXES / "statistics.json"
+    batch_index_path = INDEXES / "batch-index.json"
+
+    chain_tip = read_json(chain_tip_path)
+    record_index = read_json(record_index_path)
+
+    if chain_tip.get("schema") != "trinityaccord.chain-tip.v1":
+        raise SystemExit(f"unexpected chain-tip schema: {chain_tip.get('schema')}")
+    if record_index.get("schema") != "trinityaccord.record-index.v1":
+        raise SystemExit(f"unexpected record-index schema: {record_index.get('schema')}")
+
+    native_count = chain_tip.get("native_record_count")
+    latest_record_id = chain_tip.get("latest_record_id")
+    latest_record_sha256 = chain_tip.get("latest_record_sha256")
+    records = record_index.get("records", [])
+
+    if not isinstance(records, list):
+        raise SystemExit("record-index.records must be list")
+    if len(records) != native_count:
+        raise SystemExit(
+            f"record-index count mismatch: records={len(records)} native_record_count={native_count}"
+        )
+    if not records or records[-1].get("record_id") != latest_record_id:
+        raise SystemExit("record-index latest_record_id does not match chain-tip")
+    if records[-1].get("record_sha256") != latest_record_sha256:
+        raise SystemExit("record-index latest_record_sha256 does not match chain-tip")
+
+    included_records = []
+    for i, rec in enumerate(records, start=1):
+        expected_id = f"R-{i:09d}"
+        if rec.get("record_id") != expected_id:
+            raise SystemExit(f"record sequence mismatch: expected {expected_id}, got {rec.get('record_id')}")
+        rec_path = ROOT / rec.get("path", "")
+        if not rec_path.exists():
+            raise SystemExit(f"record file missing: {rec_path}")
+        rec_data = read_json(rec_path)
+        if rec_data.get("record_sha256") != rec.get("record_sha256"):
+            raise SystemExit(f"record sha mismatch: {rec.get('record_id')}")
+        included_records.append({
+            "record_id": rec["record_id"],
+            "path": rec["path"],
+            "record_type": rec.get("record_type"),
+            "record_sha256": rec["record_sha256"],
+        })
+
+    included_batches = []
+    if batch_index_path.exists():
+        batch_index = read_json(batch_index_path)
+        for b in batch_index.get("batches", []):
+            if not isinstance(b, dict):
+                continue
+            manifest_path_value = b.get("path")
+            if not isinstance(manifest_path_value, str):
+                continue
+            manifest_path = ROOT / manifest_path_value
+            if not manifest_path.exists():
+                raise SystemExit(f"batch manifest missing: {manifest_path}")
+            mf = read_json(manifest_path)
+            included_batches.append({
+                "batch_id": b.get("batch_id"),
+                "manifest_path": manifest_path_value,
+                "batch_manifest_sha256": mf.get("batch_manifest_sha256"),
+                "merkle_root_sha256": mf.get("merkle_root_sha256"),
+                "first_record_index": mf.get("first_record_index"),
+                "last_record_index": mf.get("last_record_index"),
+                "record_count": mf.get("record_count"),
+                "coverage_is_auxiliary": True,
+            })
+
+    native_ots_latest_ref = None
+    if NATIVE_OTS_LATEST.exists():
+        native_ots_latest = read_json(NATIVE_OTS_LATEST)
+        native_ots_latest_ref = {
+            "path": str(NATIVE_OTS_LATEST.relative_to(ROOT)),
+            "sha256": sha256_file(NATIVE_OTS_LATEST),
+            "schema": native_ots_latest.get("schema"),
+            "latest_record_id": native_ots_latest.get("latest_record_id"),
+            "latest_record_sha256": native_ots_latest.get("latest_record_sha256"),
+            "native_record_count": native_ots_latest.get("native_record_count"),
+            "latest_anchor_file": native_ots_latest.get("latest_anchor_file"),
+            "latest_anchored_file": native_ots_latest.get("latest_anchored_file"),
+            "ots_status": native_ots_latest.get("ots_status"),
+        }
+
+    source_files = {
+        "chain_tip": source_file_ref(chain_tip_path),
+        "record_index": source_file_ref(record_index_path),
+        "guardian_state": source_file_ref(guardian_state_path),
+        "statistics": source_file_ref(statistics_path),
+    }
+    if batch_index_path.exists():
+        source_files["batch_index"] = source_file_ref(batch_index_path)
+
+    return {
+        "chain_tip": chain_tip,
+        "record_index": record_index,
+        "included_records": included_records,
+        "included_batches": included_batches,
+        "source_files": source_files,
+        "native_ots_latest": native_ots_latest_ref,
+    }
 
 def existing_batch_manifests():
     return sorted(BATCHES.glob("batch-*/manifest.json"))
@@ -124,80 +241,48 @@ def upload_to_arweave(payload_path: Path, archive_dir: Path) -> dict:
 def build_archive_manifest(mode: str) -> None:
     ARCHIVES.mkdir(parents=True, exist_ok=True)
 
-    chain_tip_path = CHAIN / "chain-tip.json"
-    record_index_path = INDEXES / "record-index.json"
-    batch_index_path = INDEXES / "batch-index.json"
+    native = load_native_chain_sources()
+    chain_tip = native["chain_tip"]
+    included_records = native["included_records"]
+    included_batches = native["included_batches"]
 
-    if not chain_tip_path.exists():
-        print("No chain-tip.json found; nothing to archive.")
+    latest_record_id = chain_tip["latest_record_id"]
+    latest_record_sha256 = chain_tip["latest_record_sha256"]
+    native_record_count = chain_tip["native_record_count"]
+
+    if not included_records:
+        print("No native records found; nothing to archive.")
         return
 
-    batches = existing_batch_manifests()
-    if not batches:
-        print("No batch manifests found; nothing to archive.")
-        return
+    # Idempotency: skip if native archive for this head already has txid
+    for existing_manifest_path in ARCHIVES.glob("*/manifest.json"):
+        existing = read_json(existing_manifest_path)
+        source = existing.get("source", {})
+        native_source = source.get("native_chain", {})
+        if (
+            native_source.get("latest_record_id") == latest_record_id
+            and native_source.get("latest_record_sha256") == latest_record_sha256
+            and native_source.get("native_record_count") == native_record_count
+            and existing.get("arweave", {}).get("txid")
+        ):
+            print(f"Native archive for {latest_record_id} already has txid; skipping.")
+            return
 
-    included_batches = []
-    included_records = []
-    record_ids_seen = set()
-
-    for mf_path in batches:
-        mf = read_json(mf_path)
-        batch_id = mf.get("batch_id", "")
-        # Check if this batch is already in an existing archive via structured index
-        already_in_archive = False
-        if API_INDEX.exists():
-            idx = read_json(API_INDEX)
-            for arc in idx.get("archives", []):
-                first = arc.get("first_batch_id", "")
-                last = arc.get("last_batch_id", "")
-                if first and last and first <= batch_id <= last:
-                    already_in_archive = True
-                    break
-        if already_in_archive:
-            continue
-
-        ots_file = mf_path.parent / "manifest.json.ots"
-        batch_entry = {
-            "batch_id": batch_id,
-            "manifest_path": str(mf_path.relative_to(ROOT)),
-            "batch_manifest_sha256": mf.get("batch_manifest_sha256"),
-            "merkle_root_sha256": mf.get("merkle_root_sha256"),
-            "ots_file": str(ots_file.relative_to(ROOT)) if ots_file.exists() else None,
-            "ots_file_sha256": sha256_file(ots_file) if ots_file.exists() else None,
-        }
-        included_batches.append(batch_entry)
-
-        for rid in mf.get("record_ids", []):
-            if rid in record_ids_seen:
-                continue
-            record_ids_seen.add(rid)
-            rec_path = RECORDS / f"{rid}.json"
-            if rec_path.exists():
-                rec = read_json(rec_path)
-                included_records.append({
-                    "record_id": rid,
-                    "path": str(rec_path.relative_to(ROOT)),
-                    "record_sha256": rec.get("record_sha256"),
-                })
-
-    if not included_batches:
-        print("No new Arweave archive needed.")
-        return
-
-    # Compute deterministic archive ID
-    first_batch_id = included_batches[0]["batch_id"]
-    last_batch_id = included_batches[-1]["batch_id"]
-
-    # Source hash from concatenating all batch manifest SHA256s
-    source_concat = "".join(b["batch_manifest_sha256"] or "" for b in included_batches)
-    source_hash = sha256_bytes(source_concat.encode("utf-8"))
-
-    archive_id = build_archive_id(first_batch_id, last_batch_id, source_hash)
+    # Compute deterministic archive ID from native source
+    source_hash_input = {
+        "latest_record_id": latest_record_id,
+        "latest_record_sha256": latest_record_sha256,
+        "native_record_count": native_record_count,
+        "record_index_sha256": native["source_files"]["record_index"]["sha256"],
+        "native_ots_latest_sha256": (
+            native["native_ots_latest"]["sha256"] if native["native_ots_latest"] else None
+        ),
+    }
+    source_hash = sha256_canonical_json(source_hash_input)
+    archive_id = f"archive-native-{latest_record_id}-{source_hash[:12]}"
     archive_dir = ARCHIVES / archive_id
 
     if archive_dir.exists():
-        # Check idempotency: if archive already has a txid, skip upload
         existing_manifest_path = archive_dir / "manifest.json"
         if existing_manifest_path.exists():
             existing = read_json(existing_manifest_path)
@@ -208,7 +293,6 @@ def build_archive_manifest(mode: str) -> None:
     else:
         archive_dir.mkdir(parents=True, exist_ok=True)
 
-    # Build manifest (without archive_manifest_sha256 first)
     manifest = {
         "schema": "trinityaccord.record-chain-arweave-archive-manifest.v1",
         "archive_id": archive_id,
@@ -216,9 +300,21 @@ def build_archive_manifest(mode: str) -> None:
         "mode": mode,
         "chain_id": CHAIN_ID,
         "source": {
-            "chain_tip_path": str(chain_tip_path.relative_to(ROOT)),
-            "record_index_path": str(record_index_path.relative_to(ROOT)) if record_index_path.exists() else None,
-            "batch_index_path": str(batch_index_path.relative_to(ROOT)) if batch_index_path.exists() else None,
+            "source_type": "native-record-chain",
+            "chain_tip_path": "record-chain/chain-tip.json",
+            "record_index_path": "record-chain/indexes/record-index.json",
+            "batch_index_path": "record-chain/indexes/batch-index.json",
+            "native_chain": {
+                "latest_record_id": latest_record_id,
+                "latest_record_sha256": latest_record_sha256,
+                "native_record_count": native_record_count,
+                "latest_batch_id": chain_tip.get("latest_batch_id"),
+                "latest_batch_manifest_sha256": chain_tip.get("latest_batch_manifest_sha256"),
+            },
+            "source_files": native["source_files"],
+            "native_ots_latest": native["native_ots_latest"],
+            "legacy_main_chain_jsonl_is_not_source": True,
+            "batch_manifests_are_auxiliary": True,
         },
         "included_batches": included_batches,
         "included_records": included_records,
@@ -245,13 +341,9 @@ def build_archive_manifest(mode: str) -> None:
         if not arkey:
             raise SystemExit("ARKEY required for live Arweave upload")
 
-        # Build payload
         payload_path = build_payload_json(manifest, archive_dir)
-
-        # Upload to Arweave
         upload_result = upload_to_arweave(payload_path, archive_dir)
 
-        # Update manifest with live upload results
         manifest["arweave"] = {
             "enabled": True,
             "upload_mode": "live",
@@ -262,13 +354,8 @@ def build_archive_manifest(mode: str) -> None:
         }
         manifest["mode"] = "live"
 
-    # Compute and set archive_manifest_sha256
     manifest["archive_manifest_sha256"] = sha256_canonical_json(manifest)
-
-    # Write manifest
     write_json(archive_dir / "manifest.json", manifest)
-
-    # Update public index
     update_arweave_index()
 
 
@@ -292,6 +379,8 @@ def update_arweave_index() -> None:
             if arweave.get("wallet_address_sha256"):
                 wallet_address_sha256 = arweave["wallet_address_sha256"]
 
+        source = mf.get("source", {})
+        native_chain = source.get("native_chain", {})
         archive_entries.append({
             "archive_id": mf.get("archive_id"),
             "mode": mf.get("mode"),
@@ -302,6 +391,11 @@ def update_arweave_index() -> None:
             "batch_count": len(batches),
             "first_batch_id": batches[0]["batch_id"] if batches else None,
             "last_batch_id": batches[-1]["batch_id"] if batches else None,
+            "source_type": source.get("source_type"),
+            "native_latest_record_id": native_chain.get("latest_record_id"),
+            "native_latest_record_sha256": native_chain.get("latest_record_sha256"),
+            "native_record_count": native_chain.get("native_record_count"),
+            "native_ots_latest": source.get("native_ots_latest"),
             "created_at": mf.get("created_at"),
         })
 

--- a/scripts/build_record_chain_arweave_archive.py
+++ b/scripts/build_record_chain_arweave_archive.py
@@ -265,7 +265,7 @@ def build_archive_manifest(mode: str) -> None:
             and native_source.get("native_record_count") == native_record_count
             and existing.get("arweave", {}).get("txid")
         ):
-            print(f"Native archive for {latest_record_id} already has txid; skipping.")
+            print(f"No new Arweave archive needed: native archive for {latest_record_id} already has txid; skipping.")
             return
 
     # Compute deterministic archive ID from native source
@@ -287,7 +287,7 @@ def build_archive_manifest(mode: str) -> None:
         if existing_manifest_path.exists():
             existing = read_json(existing_manifest_path)
             if existing.get("arweave", {}).get("txid"):
-                print(f"Archive {archive_id} already has txid; skipping.")
+                print(f"No new Arweave archive needed: archive {archive_id} already has txid; skipping.")
                 return
         print(f"Archive {archive_id} exists locally but no txid; will process.")
     else:

--- a/scripts/ots_anchor_native_record_chain_head.py
+++ b/scripts/ots_anchor_native_record_chain_head.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from record_chain_hashing import (
+    NATIVE_CHAIN_HEAD_COMMITMENT_SCHEMA,
+    NATIVE_OTS_ANCHOR_SCHEMA,
+    NATIVE_OTS_LATEST_SCHEMA,
+    build_native_record_chain_head_commitment,
+    canonical_json_bytes,
+    sha256_bytes,
+    write_bytes_atomic,
+    write_json_atomic,
+)
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def run_cmd(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create an OpenTimestamps anchor for the native Record-Chain head commitment."
+    )
+    parser.add_argument("--root", default=".")
+    parser.add_argument("--out-dir", default="record-chain/ots/native-anchors")
+    parser.add_argument("--api-out", default="api/record-chain-native-ots-latest.json")
+    parser.add_argument("--ots-bin", default="ots")
+    parser.add_argument("--mode", choices=["dry-run", "stamp"], default="dry-run")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(args.root)
+    out_dir = Path(args.out_dir)
+    api_out = Path(args.api_out)
+
+    commitment = build_native_record_chain_head_commitment(root)
+    if commitment.get("schema") != NATIVE_CHAIN_HEAD_COMMITMENT_SCHEMA:
+        raise SystemExit(f"native commitment schema mismatch: {commitment.get('schema')}")
+
+    commitment_text = json.dumps(commitment, sort_keys=True)
+    if "main.chain.jsonl" in commitment_text:
+        raise SystemExit("native commitment must not reference legacy main.chain.jsonl")
+    if commitment.get("latest_record_id") != "R-000000033":
+        raise SystemExit(
+            f"M9.3 native archive must include R-000000033, got {commitment.get('latest_record_id')}"
+        )
+    if commitment.get("native_record_count") != 33:
+        raise SystemExit(
+            f"M9.3 native archive must include native_record_count=33, got {commitment.get('native_record_count')}"
+        )
+
+    commitment_bytes = canonical_json_bytes(commitment)
+    commitment_sha256 = sha256_bytes(commitment_bytes)
+
+    latest_record_index = commitment["latest_record_index"]
+    native_record_count = commitment["native_record_count"]
+    latest_record_id = commitment["latest_record_id"]
+    latest_record_sha256 = commitment["latest_record_sha256"]
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    prefix = (
+        f"native-record-{latest_record_index}-"
+        f"{latest_record_id}-{latest_record_sha256[:16]}-{commitment_sha256[:16]}"
+    )
+    snapshot_path = out_dir / f"{prefix}.native-record-chain-head-commitment.json"
+    ots_path = Path(str(snapshot_path) + ".ots")
+    anchor_path = out_dir / f"{prefix}.anchor.json"
+
+    if not args.overwrite:
+        for p in (snapshot_path, ots_path, anchor_path):
+            if p.exists():
+                raise SystemExit(f"refusing to overwrite existing file without --overwrite: {p}")
+
+    write_bytes_atomic(snapshot_path, commitment_bytes)
+
+    ots_command = None
+    ots_stdout = None
+    ots_stderr = None
+    ots_exit_code = None
+    ots_file_exists = False
+    ots_file_sha256 = None
+
+    if args.mode == "stamp":
+        if not shutil.which(args.ots_bin):
+            raise SystemExit(
+                f"OpenTimestamps CLI not found: {args.ots_bin}. "
+                "Install opentimestamps-client or run with --mode dry-run for tests."
+            )
+
+        ots_command = [args.ots_bin, "stamp", str(snapshot_path)]
+        result = run_cmd(ots_command)
+        ots_stdout = result.stdout
+        ots_stderr = result.stderr
+        ots_exit_code = result.returncode
+
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr)
+            raise SystemExit("ots stamp failed")
+
+        ots_file_exists = ots_path.exists()
+        if not ots_file_exists:
+            raise SystemExit(f"ots stamp succeeded but proof file was not created: {ots_path}")
+
+        ots_file_sha256 = sha256_bytes(ots_path.read_bytes())
+
+    anchor = {
+        "schema": NATIVE_OTS_ANCHOR_SCHEMA,
+        "chain_id": commitment["chain_id"],
+        "chain_version": 1,
+        "anchored_file": str(snapshot_path),
+        "anchored_file_sha256": commitment_sha256,
+        "anchored_file_semantics": "stable native record-chain head commitment; generated_at excluded",
+        "source_semantics": commitment["source_semantics"],
+        "native_record_count": native_record_count,
+        "latest_record_index": latest_record_index,
+        "latest_record_id": latest_record_id,
+        "latest_record_sha256": latest_record_sha256,
+        "latest_batch_id": commitment["latest_batch_id"],
+        "latest_batch_manifest_sha256": commitment["latest_batch_manifest_sha256"],
+        "record_coverage": {
+            "source": commitment["record_coverage"]["source"],
+            "first_record_id": commitment["record_coverage"]["first_record_id"],
+            "last_record_id": commitment["record_coverage"]["last_record_id"],
+            "record_count": commitment["record_coverage"]["record_count"],
+            "record_ids_sha256": commitment["record_coverage"]["record_ids_sha256"],
+            "record_sha256s_sha256": commitment["record_coverage"]["record_sha256s_sha256"],
+        },
+        "source_files": commitment["source_files"],
+        "ots_file": str(ots_path) if args.mode == "stamp" else None,
+        "ots_file_sha256": ots_file_sha256,
+        "ots_status": "pending" if args.mode == "stamp" else "dry_run",
+        "ots_command": ots_command,
+        "ots_exit_code": ots_exit_code,
+        "ots_stdout": ots_stdout,
+        "ots_stderr": ots_stderr,
+        "ots_file_exists": ots_file_exists,
+        "created_at": utc_now(),
+        "verified_at": None,
+        "bitcoin_verified": False,
+        "bitcoin_pending": args.mode == "stamp",
+        "bitcoin_attestation": None,
+        "semantics": "Native OTS anchor for current record-chain head; does not modify chain entries.",
+        "legacy_main_chain_jsonl_is_not_source": True,
+    }
+    write_json_atomic(anchor_path, anchor)
+
+    latest = {
+        "schema": NATIVE_OTS_LATEST_SCHEMA,
+        "chain_id": commitment["chain_id"],
+        "latest_anchor_file": str(anchor_path),
+        "latest_ots_file": anchor.get("ots_file"),
+        "latest_anchored_file": str(snapshot_path),
+        "anchored_file_sha256": commitment_sha256,
+        "native_record_count": native_record_count,
+        "latest_record_index": latest_record_index,
+        "latest_record_id": latest_record_id,
+        "latest_record_sha256": latest_record_sha256,
+        "latest_batch_id": commitment["latest_batch_id"],
+        "latest_batch_manifest_sha256": commitment["latest_batch_manifest_sha256"],
+        "record_coverage": anchor["record_coverage"],
+        "ots_status": anchor["ots_status"],
+        "bitcoin_verified": False,
+        "bitcoin_pending": args.mode == "stamp",
+        "created_at": anchor["created_at"],
+        "updated_at": utc_now(),
+        "source_semantics": commitment["source_semantics"],
+        "legacy_main_chain_jsonl_is_not_source": True,
+        "semantics": "Latest native OTS anchor for the native Record-Chain head commitment snapshot.",
+    }
+    write_json_atomic(api_out, latest)
+
+    print("[NATIVE RECORD CHAIN HEAD OTS ANCHOR]")
+    print(json.dumps(anchor, indent=2, ensure_ascii=False, sort_keys=True, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ots_anchor_record_chain_head.py
+++ b/scripts/ots_anchor_record_chain_head.py
@@ -53,6 +53,11 @@ def main() -> None:
     parser.add_argument("--verify-payload-files", action="store_true")
     parser.add_argument("--base-dir", default=".")
     parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument(
+        "--allow-stale-legacy-ledger",
+        action="store_true",
+        help="Allow anchoring legacy main.chain.jsonl even when native chain-tip is ahead. Never use for M9.3.",
+    )
     args = parser.parse_args()
 
     ledger_path = Path(args.ledger)
@@ -61,6 +66,22 @@ def main() -> None:
     api_out = Path(args.api_out)
 
     entries = load_ledger(ledger_path)
+
+    native_tip_path = Path("record-chain/chain-tip.json")
+    if native_tip_path.exists() and not args.allow_stale_legacy_ledger:
+        native_tip = load_json(native_tip_path)
+        native_count = native_tip.get("native_record_count")
+        native_latest = native_tip.get("latest_record_id")
+        legacy_count = len(entries)
+        if isinstance(native_count, int) and native_count != legacy_count:
+            raise SystemExit(
+                "Refusing to anchor stale legacy main.chain.jsonl: "
+                f"legacy_entry_count={legacy_count}, "
+                f"native_record_count={native_count}, "
+                f"native_latest_record_id={native_latest}. "
+                "Use scripts/ots_anchor_native_record_chain_head.py for native chain head anchoring, "
+                "or pass --allow-stale-legacy-ledger only for explicit legacy tests."
+            )
     if args.verify_ledger:
         errors = verify_entries(
             entries,

--- a/scripts/record_chain_hashing.py
+++ b/scripts/record_chain_hashing.py
@@ -18,6 +18,11 @@ CHAIN_ALL_INDEX_SCHEMA = "trinity_record_chain_all_index.v1"
 CHAIN_INDEX_MANIFEST_SCHEMA = "trinity_record_chain_index_manifest.v1"
 OTS_ANCHOR_SCHEMA = "trinity_record_chain_ots_anchor.v1"
 OTS_LATEST_SCHEMA = "trinity_record_chain_ots_latest.v1"
+NATIVE_CHAIN_HEAD_COMMITMENT_SCHEMA = "trinityaccord.native-record-chain-head-commitment.v1"
+NATIVE_OTS_ANCHOR_SCHEMA = "trinityaccord.native-record-chain-ots-anchor.v1"
+NATIVE_OTS_LATEST_SCHEMA = "trinityaccord.native-record-chain-ots-latest.v1"
+NATIVE_HEAD_SOURCE_SEMANTICS = "native_chain_tip_records_indexes_batches.v1"
+
 
 DEFAULT_CHAIN_ID = "trinity-record-chain-main"
 HASH_HEX_LEN = 64
@@ -30,6 +35,14 @@ class ChainError(Exception):
 
 def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
 
 
 def canonical_json_bytes(obj: Any) -> bytes:
@@ -49,6 +62,17 @@ def canonical_json_sha256(obj: Any) -> str:
 def load_json(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as f:
         return json.load(f)
+
+def file_ref(root: Path, rel_path: str) -> dict[str, Any]:
+    path = root / rel_path
+    if not path.exists():
+        raise ChainError(f"required source file missing: {rel_path}")
+    return {
+        "path": rel_path,
+        "sha256": sha256_file(path),
+        "bytes": path.stat().st_size,
+    }
+
 
 
 def write_json_atomic(path: Path, obj: Any) -> None:
@@ -497,4 +521,200 @@ def build_all_index(
         "generated_at": generated_at,
         "source_ledger": "record-chain/hash-chain/main.chain.jsonl",
         "authority": "derived index; main.chain.jsonl is authoritative",
+    }
+
+
+def build_native_record_chain_head_commitment(root: Path) -> dict[str, Any]:
+    """Build stable OTS/archive commitment for the native record-chain head.
+
+    Native authoritative coverage is record-index based, not legacy JSONL based
+    and not batch-manifest based.
+    """
+    root = root.resolve()
+
+    chain_tip_rel = "record-chain/chain-tip.json"
+    record_index_rel = "record-chain/indexes/record-index.json"
+    guardian_state_rel = "record-chain/indexes/guardian-state.json"
+    statistics_rel = "record-chain/indexes/statistics.json"
+    batch_index_rel = "record-chain/indexes/batch-index.json"
+
+    chain_tip = load_json(root / chain_tip_rel)
+    record_index = load_json(root / record_index_rel)
+
+    if chain_tip.get("schema") != "trinityaccord.chain-tip.v1":
+        raise ChainError(f"unexpected chain-tip schema: {chain_tip.get('schema')}")
+    if record_index.get("schema") != "trinityaccord.record-index.v1":
+        raise ChainError(f"unexpected record-index schema: {record_index.get('schema')}")
+
+    chain_id = chain_tip.get("chain_id")
+    latest_record_id = chain_tip.get("latest_record_id")
+    latest_record_index = chain_tip.get("latest_record_index")
+    native_record_count = chain_tip.get("native_record_count")
+    latest_record_sha256 = chain_tip.get("latest_record_sha256")
+    latest_batch_id = chain_tip.get("latest_batch_id")
+    latest_batch_manifest_sha256 = chain_tip.get("latest_batch_manifest_sha256")
+    genesis_batch_manifest_sha256 = chain_tip.get("genesis_batch_manifest_sha256")
+
+    if not isinstance(chain_id, str) or not chain_id:
+        raise ChainError("chain-tip.chain_id missing")
+    if not isinstance(latest_record_id, str) or not latest_record_id.startswith("R-"):
+        raise ChainError(f"invalid latest_record_id: {latest_record_id!r}")
+    if not isinstance(latest_record_index, int) or latest_record_index < 1:
+        raise ChainError(f"invalid latest_record_index: {latest_record_index!r}")
+    if not isinstance(native_record_count, int) or native_record_count < 1:
+        raise ChainError(f"invalid native_record_count: {native_record_count!r}")
+    if not is_hash_hex(latest_record_sha256):
+        raise ChainError(f"invalid latest_record_sha256: {latest_record_sha256!r}")
+
+    if latest_record_index != native_record_count:
+        raise ChainError(
+            f"latest_record_index must equal native_record_count for current native sequence: "
+            f"{latest_record_index} != {native_record_count}"
+        )
+
+    records = record_index.get("records")
+    if not isinstance(records, list):
+        raise ChainError("record-index.records must be list")
+    if len(records) != native_record_count:
+        raise ChainError(
+            f"record-index count mismatch: record-index={len(records)} "
+            f"chain-tip.native_record_count={native_record_count}"
+        )
+
+    record_refs: list[dict[str, Any]] = []
+    record_ids: list[str] = []
+    record_sha256s: list[str] = []
+
+    for i, item in enumerate(records, start=1):
+        if not isinstance(item, dict):
+            raise ChainError(f"record-index.records[{i}] is not object")
+
+        expected_record_id = f"R-{i:09d}"
+        record_id = item.get("record_id")
+        record_sha256 = item.get("record_sha256")
+        path = item.get("path")
+
+        if record_id != expected_record_id:
+            raise ChainError(
+                f"record-index sequence mismatch at {i}: expected {expected_record_id}, got {record_id}"
+            )
+        if not is_hash_hex(record_sha256):
+            raise ChainError(f"record-index.records[{i}].record_sha256 invalid")
+        if not isinstance(path, str) or not path.startswith("record-chain/records/"):
+            raise ChainError(f"record-index.records[{i}].path invalid: {path!r}")
+
+        record_path = root / path
+        if not record_path.exists():
+            raise ChainError(f"record file missing: {path}")
+
+        record_data = load_json(record_path)
+        if record_data.get("record_id") != record_id:
+            raise ChainError(f"{path}: record_id mismatch")
+        if record_data.get("record_sha256") != record_sha256:
+            raise ChainError(f"{path}: record_sha256 mismatch")
+
+        record_ids.append(record_id)
+        record_sha256s.append(record_sha256)
+        record_refs.append({
+            "record_id": record_id,
+            "record_sha256": record_sha256,
+            "record_type": item.get("record_type"),
+            "path": path,
+        })
+
+    latest_item = records[-1]
+    if latest_item.get("record_id") != latest_record_id:
+        raise ChainError(
+            f"latest record mismatch: record-index={latest_item.get('record_id')} "
+            f"chain-tip={latest_record_id}"
+        )
+    if latest_item.get("record_sha256") != latest_record_sha256:
+        raise ChainError("latest record sha mismatch between record-index and chain-tip")
+
+    latest_record_rel = f"record-chain/records/{latest_record_id}.json"
+    latest_record = load_json(root / latest_record_rel)
+    if latest_record.get("record_id") != latest_record_id:
+        raise ChainError("latest record file record_id mismatch")
+    if latest_record.get("record_index") != latest_record_index:
+        raise ChainError("latest record file record_index mismatch")
+    if latest_record.get("record_sha256") != latest_record_sha256:
+        raise ChainError("latest record file record_sha256 mismatch")
+
+    auxiliary_batch_refs: list[dict[str, Any]] = []
+    batch_index_path = root / batch_index_rel
+    if batch_index_path.exists():
+        batch_index = load_json(batch_index_path)
+        if batch_index.get("schema") != "trinityaccord.batch-index.v1":
+            raise ChainError(f"unexpected batch-index schema: {batch_index.get('schema')}")
+        for batch in batch_index.get("batches", []):
+            if not isinstance(batch, dict):
+                continue
+            manifest_path = batch.get("path")
+            if not isinstance(manifest_path, str):
+                continue
+            full = root / manifest_path
+            if not full.exists():
+                raise ChainError(f"batch manifest missing: {manifest_path}")
+            batch_manifest = load_json(full)
+            auxiliary_batch_refs.append({
+                "batch_id": batch.get("batch_id"),
+                "path": manifest_path,
+                "file_sha256": sha256_file(full),
+                "batch_manifest_sha256": batch_manifest.get("batch_manifest_sha256"),
+                "first_record_index": batch_manifest.get("first_record_index"),
+                "last_record_index": batch_manifest.get("last_record_index"),
+                "record_count": batch_manifest.get("record_count"),
+                "coverage_is_auxiliary": True,
+            })
+
+    if latest_batch_id and auxiliary_batch_refs:
+        matching = [b for b in auxiliary_batch_refs if b.get("batch_id") == latest_batch_id]
+        if not matching:
+            raise ChainError(f"chain-tip.latest_batch_id not found in batch-index: {latest_batch_id}")
+        if matching[0].get("batch_manifest_sha256") != latest_batch_manifest_sha256:
+            raise ChainError("latest batch manifest sha mismatch between chain-tip and batch manifest")
+
+    source_files = {
+        "chain_tip": file_ref(root, chain_tip_rel),
+        "record_index": file_ref(root, record_index_rel),
+        "latest_record": file_ref(root, latest_record_rel),
+        "guardian_state": file_ref(root, guardian_state_rel),
+        "statistics": file_ref(root, statistics_rel),
+        "batch_index": file_ref(root, batch_index_rel),
+    }
+
+    return {
+        "schema": NATIVE_CHAIN_HEAD_COMMITMENT_SCHEMA,
+        "chain_id": chain_id,
+        "chain_version": 1,
+        "source_semantics": NATIVE_HEAD_SOURCE_SEMANTICS,
+        "native_record_count": native_record_count,
+        "latest_record_id": latest_record_id,
+        "latest_record_index": latest_record_index,
+        "latest_record_sha256": latest_record_sha256,
+        "latest_record_type": latest_record.get("record_type"),
+        "genesis_batch_manifest_sha256": genesis_batch_manifest_sha256,
+        "latest_batch_id": latest_batch_id,
+        "latest_batch_manifest_sha256": latest_batch_manifest_sha256,
+        "record_coverage": {
+            "source": "record-chain/indexes/record-index.json",
+            "first_record_id": record_ids[0],
+            "last_record_id": record_ids[-1],
+            "record_count": len(record_refs),
+            "record_ids_sha256": canonical_json_sha256(record_ids),
+            "record_sha256s_sha256": canonical_json_sha256(record_sha256s),
+            "records": record_refs,
+        },
+        "auxiliary_batch_coverage": {
+            "source": "record-chain/indexes/batch-index.json",
+            "batches": auxiliary_batch_refs,
+            "note": "Batch manifests are auxiliary and may lag native record-index; native record coverage is defined by record-index.",
+        },
+        "source_files": source_files,
+        "canonicalization": "json.sort_keys.no_whitespace.utf8.allow_nan_false.v1",
+        "legacy_main_chain_jsonl_is_not_source": True,
+        "ots_input_semantics": (
+            "stable native record-chain head commitment; excludes volatile generated_at fields; "
+            "binds chain-tip, record-index, all native record refs, guardian-state, statistics, and auxiliary batch metadata"
+        ),
     }

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -293,6 +293,16 @@ def main() -> int:
     if result.returncode != 0:
         fail(f"arweave archive contract test failed: {result.stderr}")
     ok("arweave archive contract test")
+    # Native record-chain archive tooling contract
+    result = subprocess.run(
+        [sys.executable, "scripts/test_native_record_chain_archive_tooling.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"native record-chain archive tooling test failed: {result.stderr}\n{result.stdout}")
+    ok("native record-chain archive tooling")
     # 11b. Arweave upload readback contract test
     result = subprocess.run(
         [sys.executable, "scripts/test_arweave_upload_contract.py"],

--- a/scripts/test_native_record_chain_archive_tooling.py
+++ b/scripts/test_native_record_chain_archive_tooling.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from record_chain_hashing import build_native_record_chain_head_commitment  # noqa: E402
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    raise SystemExit(1)
+
+
+def ok(message: str) -> None:
+    print(f"OK: {message}")
+
+
+def test_native_commitment_binds_current_head() -> None:
+    commitment = build_native_record_chain_head_commitment(ROOT)
+    tip = json.loads((ROOT / "record-chain" / "chain-tip.json").read_text())
+    text = json.dumps(commitment, sort_keys=True)
+
+    if commitment.get("schema") != "trinityaccord.native-record-chain-head-commitment.v1":
+        fail("native commitment schema mismatch")
+    if commitment.get("latest_record_id") != tip.get("latest_record_id"):
+        fail("native commitment latest_record_id must match chain-tip")
+    if commitment.get("latest_record_sha256") != tip.get("latest_record_sha256"):
+        fail("native commitment latest_record_sha256 must match chain-tip")
+    if commitment.get("native_record_count") != tip.get("native_record_count"):
+        fail("native commitment native_record_count must match chain-tip")
+
+    if commitment.get("latest_record_id") != "R-000000033":
+        fail("M9 native commitment must include R-000000033")
+    if commitment.get("native_record_count") != 33:
+        fail("M9 native commitment must include native_record_count=33")
+    if "main.chain.jsonl" in text:
+        fail("native commitment must not reference legacy main.chain.jsonl")
+
+    coverage = commitment.get("record_coverage", {})
+    if coverage.get("source") != "record-chain/indexes/record-index.json":
+        fail("native commitment record_coverage must use record-index")
+    if coverage.get("record_count") != 33:
+        fail("native commitment record_coverage must include 33 records")
+    if coverage.get("last_record_id") != "R-000000033":
+        fail("native commitment record_coverage must end at R-000000033")
+    if len(coverage.get("records", [])) != 33:
+        fail("native commitment records list must include 33 records")
+
+    source_files = commitment.get("source_files", {})
+    for key in ["chain_tip", "record_index", "latest_record", "guardian_state", "statistics", "batch_index"]:
+        ref = source_files.get(key)
+        if not isinstance(ref, dict) or not ref.get("path") or not ref.get("sha256"):
+            fail(f"native commitment missing source file ref: {key}")
+
+    ok("native commitment binds current native head")
+
+
+def test_native_ots_script_dry_run() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        out_dir = tmp / "native-anchors"
+        api_out = tmp / "record-chain-native-ots-latest.json"
+        cmd = [
+            sys.executable,
+            str(ROOT / "scripts" / "ots_anchor_native_record_chain_head.py"),
+            "--mode", "dry-run",
+            "--out-dir", str(out_dir),
+            "--api-out", str(api_out),
+            "--overwrite",
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+        if result.returncode != 0:
+            print(result.stdout)
+            print(result.stderr)
+            fail("native OTS dry-run failed")
+
+        latest = json.loads(api_out.read_text())
+        if latest.get("schema") != "trinityaccord.native-record-chain-ots-latest.v1":
+            fail("native latest schema mismatch")
+        if latest.get("latest_record_id") != "R-000000033":
+            fail("native latest must reference R-000000033")
+        if latest.get("native_record_count") != 33:
+            fail("native latest must reference native_record_count=33")
+        if latest.get("legacy_main_chain_jsonl_is_not_source") is not True:
+            fail("native latest must declare legacy main.chain.jsonl is not source")
+
+        anchored = Path(latest["latest_anchored_file"])
+        if not anchored.exists():
+            fail("native anchored commitment file missing")
+        anchored_text = anchored.read_text()
+        if "main.chain.jsonl" in anchored_text:
+            fail("native anchored commitment must not mention main.chain.jsonl")
+
+    ok("native OTS dry-run writes native latest")
+
+
+def test_legacy_ots_refuses_stale_jsonl() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        cmd = [
+            sys.executable,
+            str(ROOT / "scripts" / "ots_anchor_record_chain_head.py"),
+            "--mode", "dry-run",
+            "--out-dir", str(tmp / "legacy-anchors"),
+            "--api-out", str(tmp / "legacy-ots-latest.json"),
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True)
+        if result.returncode == 0:
+            fail("legacy OTS script must refuse stale main.chain.jsonl when native chain-tip is ahead")
+        combined = result.stdout + result.stderr
+        if "Refusing to anchor stale legacy main.chain.jsonl" not in combined:
+            fail("legacy OTS refusal message missing")
+
+    ok("legacy OTS refuses stale JSONL by default")
+
+
+def test_arweave_builder_source_markers() -> None:
+    text = (ROOT / "scripts" / "build_record_chain_arweave_archive.py").read_text()
+
+    required = [
+        "load_native_chain_sources",
+        "record-chain/indexes/record-index.json",
+        "source_type",
+        "native-record-chain",
+        "legacy_main_chain_jsonl_is_not_source",
+        "batch_manifests_are_auxiliary",
+        "native_record_count",
+        "latest_record_id",
+        "archive-native-",
+    ]
+    for marker in required:
+        if marker not in text:
+            fail(f"arweave builder missing native marker: {marker}")
+
+    forbidden_pattern = 'for rid in mf.get("record_ids", [])'
+    if forbidden_pattern in text:
+        fail("arweave builder must not derive authoritative included_records from batch manifest record_ids")
+
+    ok("arweave builder uses native record-index markers")
+
+
+def test_arweave_verifier_source_markers() -> None:
+    text = (ROOT / "scripts" / "verify_record_chain_arweave_archive.py").read_text()
+
+    required = [
+        "source_type",
+        "native-record-chain",
+        "included_records does not cover native_record_count",
+        "latest native record missing",
+        "legacy JSONL is not source",
+    ]
+    for marker in required:
+        if marker not in text:
+            fail(f"arweave verifier missing native marker: {marker}")
+
+    ok("arweave verifier has native coverage checks")
+
+
+def main() -> None:
+    test_native_commitment_binds_current_head()
+    test_native_ots_script_dry_run()
+    test_legacy_ots_refuses_stale_jsonl()
+    test_arweave_builder_source_markers()
+    test_arweave_verifier_source_markers()
+    print("PASS: native record-chain archive tooling tests")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_record_chain_arweave_archive.py
+++ b/scripts/verify_record_chain_arweave_archive.py
@@ -29,6 +29,8 @@ RECORDS = CHAIN / "records"
 BATCHES = CHAIN / "batches"
 ARCHIVES = CHAIN / "arweave-archives"
 API_INDEX = ROOT / "api" / "record-chain-arweave-index.json"
+INDEXES = CHAIN / "indexes"
+CHAIN_TIP = CHAIN / "chain-tip.json"
 
 FORBIDDEN_TERMS = {"ARV5", "LV5", "IVV5", "IPFS"}
 
@@ -150,6 +152,39 @@ def verify(network: bool = False, strict_network: bool = False) -> list[str]:
                      "not_successor_reception", "bitcoin_originals_prevail"]:
             if not m_boundary.get(key):
                 errors.append(f"{archive['archive_id']}: manifest boundary missing/false: {key}")
+
+        # Native archive validation
+        source = manifest.get("source", {})
+        if source.get("source_type") == "native-record-chain":
+            chain_tip = read_json(CHAIN_TIP)
+            native_chain = source.get("native_chain", {})
+
+            if native_chain.get("latest_record_id") != chain_tip.get("latest_record_id"):
+                errors.append(f"{archive['archive_id']}: native latest_record_id mismatch")
+            if native_chain.get("latest_record_sha256") != chain_tip.get("latest_record_sha256"):
+                errors.append(f"{archive['archive_id']}: native latest_record_sha256 mismatch")
+            if native_chain.get("native_record_count") != chain_tip.get("native_record_count"):
+                errors.append(f"{archive['archive_id']}: native_record_count mismatch")
+
+            included_records = manifest.get("included_records", [])
+            if len(included_records) != chain_tip.get("native_record_count"):
+                errors.append(
+                    f"{archive['archive_id']}: included_records does not cover native_record_count"
+                )
+
+            if not any(
+                r.get("record_id") == chain_tip.get("latest_record_id")
+                and r.get("record_sha256") == chain_tip.get("latest_record_sha256")
+                for r in included_records
+            ):
+                errors.append(f"{archive['archive_id']}: latest native record missing from included_records")
+
+            if source.get("legacy_main_chain_jsonl_is_not_source") is not True:
+                errors.append(f"{archive['archive_id']}: native archive must declare legacy JSONL is not source")
+
+            manifest_text_for_native = canonical_dumps(manifest)
+            if "main.chain.jsonl" in manifest_text_for_native:
+                errors.append(f"{archive['archive_id']}: native archive must not reference main.chain.jsonl")
 
         # Check included batches
         for batch in manifest.get("included_batches", []):


### PR DESCRIPTION
## Summary

Fix M9.3 native archive tooling.

This PR adds native record-chain archive head commitment tooling so M9.3 can archive the current native chain-tip at R-000000033 without using stale legacy `main.chain.jsonl`.

## Root cause

- Legacy OTS script reads `record-chain/hash-chain/main.chain.jsonl`, which currently has 16 entries / height 15.
- Native `record-chain/chain-tip.json` is at R-000000033 / 33 records.
- Existing Arweave builder also needed correction because batch manifests are auxiliary and current batch-000001 only covers R-000000001 through R-000000025.

## Changes

- Add native record-chain head commitment helper.
- Add native OTS anchor script.
- Guard legacy OTS script so stale JSONL anchoring fails by default.
- Update Arweave archive builder to use `record-chain/indexes/record-index.json` for authoritative included records.
- Update Arweave verifier to enforce native archive coverage.
- Add regression tests and register them in current system tests.

## Safety

- Does not modify record-chain records.
- Does not modify hash-chain history.
- Does not commit generated OTS or Arweave artifacts.
- Does not mark M9 complete.
