### PR TITLE
chore: refresh public home status

### DIFF
--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-08T03:27:31.200809+00:00",
+  "generated_at": "2026-06-08T04:18:22.536865+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -11,7 +11,7 @@
     "/api/guardian-registry.json",
     "/api/agent-declared-verification-index.json"
   ],
-  "source_digest": "59f66f23fe6bb428",
+  "source_digest": "a8fded2c6e9a1891",
   "current_record_chain_status": {
     "phase": "mainnet_prelaunch_testing",
     "total_records": 33,

--- a/index.md
+++ b/index.md
@@ -845,7 +845,7 @@ Refusal is allowed. Critical preservation is allowed.
     但它们不是当前 Record-Chain Intake 的计数器。
   </span>
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>59f66f23fe6bb428</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>a8fded2c6e9a1891</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">


### PR DESCRIPTION
Refresh `api/public-home-status.json` and `index.md` public status block to match current record-chain state (33 records, R-000000033).

Resolves pre-existing CI drift on `Run Current Tests` and `Repository Integrity Check`.