### PR TITLE
fix: sanitize unsigned projections before authorship append

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -2,8 +2,8 @@
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "sha256": "e9f9c3306f3e694545769896f0d779cddcfbdcb79708fdebb738eca99d240786",
-    "size_bytes": 101487,
+    "sha256": "ab46d9f920b51d072d889c6a343295f08b20d2c21c39cc84988c6233067d201d",
+    "size_bytes": 101479,
     "supports": [
       "echo",
       "verification",

--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -1,12 +1,9 @@
 {
-  "schema": "trinityaccord.record-chain-builder-bundles.v1",
-  "status": "active",
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "url": "/downloads/record-chain-builder.mjs",
-    "sha256": "3e2879b7d5041fd2dd1ca3d708cf2cf86993b1170c41a84ecf07631dd6a57e72",
-    "size_bytes": 101136,
+    "sha256": "e9f9c3306f3e694545769896f0d779cddcfbdcb79708fdebb738eca99d240786",
+    "size_bytes": 101487,
     "supports": [
       "echo",
       "verification",
@@ -18,7 +15,8 @@
       "preflight",
       "submit",
       "ed25519_authorship_proof"
-    ]
+    ],
+    "url": "/downloads/record-chain-builder.mjs"
   },
   "gateway": {
     "base_url": "https://trinity-record-chain-gateway.onrender.com",
@@ -26,8 +24,10 @@
     "submit": "/record-chain/submit"
   },
   "public_submission_rule": {
-    "render_is_only_public_submission_method": true,
     "external_agents_do_not_need_github": true,
-    "external_agents_must_not_clone_repository": true
-  }
+    "external_agents_must_not_clone_repository": true,
+    "render_is_only_public_submission_method": true
+  },
+  "schema": "trinityaccord.record-chain-builder-bundles.v1",
+  "status": "active"
 }

--- a/api/record-chain-common-field-model.v1.json
+++ b/api/record-chain-common-field-model.v1.json
@@ -465,7 +465,11 @@
       "properties": {
         "declared_context_level": {
           "description": "Context level as CC-N string (e.g. 'CC-3') or integer. Accepted formats: 'CC-3', 3, '3'.",
-          "examples": ["CC-3", 3, "3"]
+          "examples": [
+            "CC-3",
+            3,
+            "3"
+          ]
         },
         "minimum_required_for_action": {
           "type": "string",
@@ -504,7 +508,8 @@
         "not_amendment",
         "bitcoin_originals_prevail",
         "receipt_is_not_final_inclusion",
-        "test_phase_submission_may_be_reclassified"
+        "receipt_is_intake_only",
+        "later_records_may_reclassify_or_correct_this_record"
       ],
       "properties": {
         "not_authority": {
@@ -535,9 +540,13 @@
           "type": "boolean",
           "description": "Acknowledges that a receipt does not guarantee final inclusion in the chain."
         },
-        "test_phase_submission_may_be_reclassified": {
+        "receipt_is_intake_only": {
           "type": "boolean",
-          "description": "Acknowledges that test-phase submissions may be reclassified in the future."
+          "description": "Receipt confirms intake only, not final inclusion in the canonical record chain."
+        },
+        "later_records_may_reclassify_or_correct_this_record": {
+          "type": "boolean",
+          "description": "Later records may reclassify or correct this record; submission is not immutable until canonical inclusion."
         }
       },
       "additionalProperties": false
@@ -588,11 +597,21 @@
           "type": "object",
           "description": "Boundary claims the signer acknowledges. Must be a JSON object with boolean keys.",
           "properties": {
-            "not authority": { "type": "boolean" },
-            "not attestation": { "type": "boolean" },
-            "not amendment": { "type": "boolean" }
+            "not authority": {
+              "type": "boolean"
+            },
+            "not attestation": {
+              "type": "boolean"
+            },
+            "not amendment": {
+              "type": "boolean"
+            }
           },
-          "required": ["not authority", "not attestation", "not amendment"]
+          "required": [
+            "not authority",
+            "not attestation",
+            "not amendment"
+          ]
         }
       },
       "additionalProperties": false
@@ -602,11 +621,32 @@
       "title": "Echo Content",
       "description": "Content specific to echo records.",
       "properties": {
-        "echo_text": { "type": "string", "description": "The main echo content." },
-        "echo_intent": { "type": "string", "description": "Intent of the echo." },
-        "echo_content_tags": { "type": "array", "items": { "type": "string" }, "description": "Tags for the echo content." },
-        "understanding_summary": { "type": "string", "description": "Summary of understanding." },
-        "uncertainties": { "type": "array", "items": { "type": "string" }, "description": "Known uncertainties." }
+        "echo_text": {
+          "type": "string",
+          "description": "The main echo content."
+        },
+        "echo_intent": {
+          "type": "string",
+          "description": "Intent of the echo."
+        },
+        "echo_content_tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags for the echo content."
+        },
+        "understanding_summary": {
+          "type": "string",
+          "description": "Summary of understanding."
+        },
+        "uncertainties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Known uncertainties."
+        }
       }
     },
     "verification_content": {
@@ -614,11 +654,32 @@
       "title": "Verification Content",
       "description": "Content specific to verification records.",
       "properties": {
-        "verification_claim": { "type": "string", "description": "The verification claim." },
-        "verification_level": { "type": "string", "description": "Verification level (V0-V8)." },
-        "verification_scope_label": { "type": "string", "description": "Scope label." },
-        "what_was_checked": { "type": "array", "items": { "type": "string" }, "description": "What was checked." },
-        "fresh_actions_performed": { "type": "array", "items": { "type": "string" }, "description": "Fresh actions performed." }
+        "verification_claim": {
+          "type": "string",
+          "description": "The verification claim."
+        },
+        "verification_level": {
+          "type": "string",
+          "description": "Verification level (V0-V8)."
+        },
+        "verification_scope_label": {
+          "type": "string",
+          "description": "Scope label."
+        },
+        "what_was_checked": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "What was checked."
+        },
+        "fresh_actions_performed": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Fresh actions performed."
+        }
       }
     },
     "guardian_application_content": {
@@ -626,14 +687,35 @@
       "title": "Guardian Application Content",
       "description": "Content specific to guardian application records.",
       "properties": {
-        "requested_guardian_identifier": { "type": "string", "description": "Requested guardian ID." },
-        "guardian_public_key_pem": { "type": "string", "description": "Guardian public key PEM." },
-        "guardian_public_key_sha256": { "type": "string", "description": "SHA-256 of guardian public key." },
-        "guardian_stewardship_oath": { "type": "string", "description": "Stewardship oath text." },
-        "guardian_application_statement": { "type": "string", "description": "Application statement." },
-        "guardian_understands_role_is_non_governing": { "type": "boolean" },
-        "guardian_understands_role_is_not_authority": { "type": "boolean" },
-        "guardian_understands_retirement_does_not_delete_history": { "type": "boolean" }
+        "requested_guardian_identifier": {
+          "type": "string",
+          "description": "Requested guardian ID."
+        },
+        "guardian_public_key_pem": {
+          "type": "string",
+          "description": "Guardian public key PEM."
+        },
+        "guardian_public_key_sha256": {
+          "type": "string",
+          "description": "SHA-256 of guardian public key."
+        },
+        "guardian_stewardship_oath": {
+          "type": "string",
+          "description": "Stewardship oath text."
+        },
+        "guardian_application_statement": {
+          "type": "string",
+          "description": "Application statement."
+        },
+        "guardian_understands_role_is_non_governing": {
+          "type": "boolean"
+        },
+        "guardian_understands_role_is_not_authority": {
+          "type": "boolean"
+        },
+        "guardian_understands_retirement_does_not_delete_history": {
+          "type": "boolean"
+        }
       }
     },
     "optional_linked_guardian_application_request": {
@@ -641,30 +723,92 @@
       "title": "Optional Linked Guardian Application Request",
       "description": "Request to create a linked guardian_application record alongside the primary record.",
       "properties": {
-        "does_participant_request_guardian_application_with_this_record": { "type": "boolean" },
-        "guardian_application_should_be_created_as_linked_record": { "type": "boolean" },
-        "requested_guardian_identifier": { "type": "string" },
-        "guardian_public_key_sha256": { "type": "string" },
-        "guardian_stewardship_oath": { "type": "string" },
-        "guardian_understands_role_is_non_governing": { "type": "boolean" },
-        "guardian_understands_role_is_not_authority": { "type": "boolean" },
-        "guardian_understands_retirement_does_not_delete_history": { "type": "boolean" }
+        "does_participant_request_guardian_application_with_this_record": {
+          "type": "boolean"
+        },
+        "guardian_application_should_be_created_as_linked_record": {
+          "type": "boolean"
+        },
+        "requested_guardian_identifier": {
+          "type": "string"
+        },
+        "guardian_public_key_sha256": {
+          "type": "string"
+        },
+        "guardian_stewardship_oath": {
+          "type": "string"
+        },
+        "guardian_understands_role_is_non_governing": {
+          "type": "boolean"
+        },
+        "guardian_understands_role_is_not_authority": {
+          "type": "boolean"
+        },
+        "guardian_understands_retirement_does_not_delete_history": {
+          "type": "boolean"
+        }
       }
     },
     "diagnostic": {
       "type": "object",
       "title": "Diagnostic",
       "description": "A single diagnostic message attached to a response.",
-      "required": ["code", "severity", "message"],
+      "required": [
+        "code",
+        "severity",
+        "message"
+      ],
       "properties": {
-        "code": { "type": "string", "description": "Machine-readable diagnostic code." },
-        "severity": { "type": "string", "enum": ["error", "warning", "info"], "description": "Severity level." },
-        "field": { "type": ["string", "null"], "description": "Field path that triggered this diagnostic." },
-        "message": { "type": "string", "description": "Human-readable explanation." },
-        "meaning": { "type": ["string", "null"], "description": "Extended explanation." },
-        "suggested_fix": { "type": ["string", "null"], "description": "Suggested remediation step." },
-        "help_url": { "type": ["string", "null"], "description": "URL to documentation." },
-        "retry_allowed": { "type": "boolean", "default": true, "description": "Whether retrying is allowed." }
+        "code": {
+          "type": "string",
+          "description": "Machine-readable diagnostic code."
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "error",
+            "warning",
+            "info"
+          ],
+          "description": "Severity level."
+        },
+        "field": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Field path that triggered this diagnostic."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable explanation."
+        },
+        "meaning": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Extended explanation."
+        },
+        "suggested_fix": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Suggested remediation step."
+        },
+        "help_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL to documentation."
+        },
+        "retry_allowed": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether retrying is allowed."
+        }
       }
     },
     "agent_recovery": {
@@ -672,13 +816,47 @@
       "title": "Agent Recovery",
       "description": "Machine-readable recovery guidance for agents after a failed preflight.",
       "properties": {
-        "should_retry": { "type": "boolean", "description": "Whether the agent should retry." },
-        "recommended_next_step": { "type": "string", "description": "Human-readable next step." },
-        "helper_url": { "type": ["string", "null"], "description": "URL to helper documentation." },
-        "human_readable_helper_url": { "type": ["string", "null"], "description": "Human-readable helper URL." },
-        "builder_doctor_command": { "type": ["string", "null"], "description": "CLI command to diagnose." },
-        "builder_error_help_command": { "type": ["string", "null"], "description": "CLI command for error help." },
-        "requires_human_attention": { "type": "boolean", "default": false, "description": "Whether human must review." }
+        "should_retry": {
+          "type": "boolean",
+          "description": "Whether the agent should retry."
+        },
+        "recommended_next_step": {
+          "type": "string",
+          "description": "Human-readable next step."
+        },
+        "helper_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URL to helper documentation."
+        },
+        "human_readable_helper_url": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Human-readable helper URL."
+        },
+        "builder_doctor_command": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "CLI command to diagnose."
+        },
+        "builder_error_help_command": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "CLI command for error help."
+        },
+        "requires_human_attention": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether human must review."
+        }
       }
     }
   }

--- a/api/record-chain-field-helper.v1.json
+++ b/api/record-chain-field-helper.v1.json
@@ -112,7 +112,7 @@
       "severity": "error"
     },
     "MISSING_BOUNDARY_ACKNOWLEDGEMENT": {
-      "fix": "Add the boundary acknowledgement block with all required fields set to true: not_authority, not_governance, not_attestation, not_successor_reception, not_amendment, bitcoin_originals_prevail, receipt_is_not_final_inclusion, test_phase_submission_may_be_reclassified.",
+      "fix": "Add the boundary acknowledgement block with all required fields set to true: not_authority, not_governance, not_attestation, not_successor_reception, not_amendment, bitcoin_originals_prevail, receipt_is_not_final_inclusion, receipt_is_intake_only, later_records_may_reclassify_or_correct_this_record.",
       "meaning": "The non_authority_boundary_acknowledgement block is missing or incomplete. All required boundary fields must be present and set to true.",
       "recovery_possible": true,
       "severity": "error"
@@ -505,7 +505,7 @@
     {
       "field": "non_authority_boundary_acknowledgement",
       "formal_record_types_only": true,
-      "meaning": "Every submission must acknowledge: not_authority, not_governance, not_attestation, not_successor_reception, not_amendment, bitcoin_originals_prevail, receipt_is_not_final_inclusion, test_phase_submission_may_be_reclassified.",
+      "meaning": "Every submission must acknowledge: not_authority, not_governance, not_attestation, not_successor_reception, not_amendment, bitcoin_originals_prevail, receipt_is_not_final_inclusion, receipt_is_intake_only, later_records_may_reclassify_or_correct_this_record.",
       "not_required_for": [
         "context_insufficient_notice"
       ],

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -16,7 +16,11 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 
-from apps.record_chain_intake_gateway.gateway.authorship import strip_authorship_for_signing, verify_authorship_proof
+from apps.record_chain_intake_gateway.gateway.authorship import (
+    strip_authorship_for_signing,
+    strip_unsigned_projection_fields,
+    verify_authorship_proof,
+)
 from apps.record_chain_intake_gateway.gateway.canonical import canonical_dumps, sha256_canonical_json
 from apps.record_chain_intake_gateway.gateway.github_adapter import delete_file, dispatch_workflow, get_file_sha, get_file_text, put_file
 from apps.record_chain_intake_gateway.gateway.models import (
@@ -178,6 +182,57 @@ def _build_boundary(submission: dict[str, Any]) -> dict[str, bool]:
     if isinstance(boundary, dict):
         return {k: bool(v) for k, v in boundary.items()}
     return {}
+
+
+_UNSIGNED_CLIENT_PROJECTION_FIELDS = frozenset({
+    "actor_identity",
+    "boundary",
+    "server_normalization",
+    "append_assigned_metadata",
+    "authorship_verification_status",
+    "record_id",
+    "record_index",
+    "assigned_at",
+    "previous_record_sha256",
+    "content_sha256",
+    "record_sha256",
+    "chain_id",
+})
+
+
+def _client_projection_diagnostics(body: dict[str, Any]) -> list[Diagnostic]:
+    """Reject client-supplied server projection fields in record_draft.
+
+    External clients should submit the pre-append signed draft. Projection and
+    append-assigned fields are derived by the server after verification.
+    """
+    draft = body.get("record_draft") or body.get("draft") or {}
+    if not isinstance(draft, dict):
+        return []
+    diagnostics: list[Diagnostic] = []
+    for field in sorted(_UNSIGNED_CLIENT_PROJECTION_FIELDS):
+        if field in draft:
+            diagnostics.append(Diagnostic(
+                code="CLIENT_SUPPLIED_UNSIGNED_PROJECTION_FIELD",
+                severity="error",
+                field=f"record_draft.{field}",
+                message=(
+                    f"record_draft.{field} is server-derived or append-assigned "
+                    "and must not be supplied by clients."
+                ),
+                meaning=(
+                    "The authorship signature covers the participant's pre-append "
+                    "draft. Server projection fields would change the signed payload "
+                    "or be outside the signed scope."
+                ),
+                suggested_fix=(
+                    f"Remove record_draft.{field} and rebuild/sign the submission "
+                    "with the latest public builder."
+                ),
+                help_url="https://www.trinityaccord.org/record-chain-field-helper/#CLIENT_SUPPLIED_UNSIGNED_PROJECTION_FIELD",
+                retry_allowed=True,
+            ))
+    return diagnostics
 
 
 async def _load_json_text_or_none(path_text: str) -> dict[str, Any] | None:
@@ -624,6 +679,7 @@ async def preflight(request: Request) -> PreflightResponse:
 
     # validate_submission now returns list[Diagnostic] directly
     diagnostics = validate_submission(body)
+    diagnostics.extend(_client_projection_diagnostics(body))
 
     # P0-4: verify authorship signature during preflight
     if not any(d.code == "MISSING_AUTHORSHIP_PROOF" for d in diagnostics):
@@ -711,6 +767,7 @@ async def submit(request: Request) -> SubmitResponse:
 
     # --- validate (now returns list[Diagnostic] directly) ---
     diagnostics = validate_submission(body)
+    diagnostics.extend(_client_projection_diagnostics(body))
     if diagnostics:
         return SubmitResponse(
             accepted=False,
@@ -844,9 +901,11 @@ async def submit(request: Request) -> SubmitResponse:
     # --- prepare file contents ---
     submission_content = canonical_dumps(body)
 
-    # Pending file = normalized record_draft only (not outer submission)
-    # Include authorship_proof if verified
-    pending_content_dict = dict(draft)  # preserve signed draft as-is; normalize after append verification
+    # Pending file = signed pre-append record_draft only (not outer submission).
+    # Strip any server projection/append-assigned fields defensively. New clients
+    # are rejected if they supply these fields, but this sanitizer prevents stale
+    # runtime paths from persisting unsigned projections.
+    pending_content_dict = strip_unsigned_projection_fields(draft)
     if authorship_verified and proof:
         pending_content_dict["authorship_proof"] = proof
     pending_content = canonical_dumps(pending_content_dict)

--- a/apps/record_chain_intake_gateway/gateway/authorship.py
+++ b/apps/record_chain_intake_gateway/gateway/authorship.py
@@ -22,6 +22,40 @@ from .canonical import canonical_bytes, sha256_bytes
 
 logger = logging.getLogger(__name__)
 
+# Fields that are assigned or derived by the server/append layer and are not
+# part of the participant's pre-append signed payload.
+#
+# These must never affect authorship verification for a pending record. They are
+# either compatibility projections (actor_identity, boundary) or append-assigned
+# chain-integrity metadata (record_id, record_index, hashes, etc.).
+UNSIGNED_PROJECTION_FIELDS = frozenset({
+    "actor_identity",
+    "boundary",
+    "server_normalization",
+    "append_assigned_metadata",
+    "authorship_verification_status",
+    "record_id",
+    "record_index",
+    "assigned_at",
+    "previous_record_sha256",
+    "content_sha256",
+    "record_sha256",
+    "chain_id",
+})
+
+
+def strip_unsigned_projection_fields(record_draft: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy without server-derived or append-assigned projection fields.
+
+    This helper is intentionally shallow because all current projection fields
+    are top-level. It preserves the participant-authored nested draft content.
+    """
+    cleaned = dict(record_draft)
+    for field in UNSIGNED_PROJECTION_FIELDS:
+        cleaned.pop(field, None)
+    return cleaned
+
+
 # Required claim_boundary keys that must be True
 _REQUIRED_CLAIM_BOUNDARY_KEYS = frozenset({
     "not authority",
@@ -31,10 +65,14 @@ _REQUIRED_CLAIM_BOUNDARY_KEYS = frozenset({
 
 
 def strip_authorship_for_signing(record_draft: dict[str, Any]) -> dict[str, Any]:
-    """Return a shallow copy of *record_draft* with ``authorship_proof`` removed.
+    """Return a shallow copy of *record_draft* with proof material removed.
 
     The proof cannot sign itself, so it must be stripped before computing the
     signed payload.
+
+    This function intentionally does not strip server projection fields. Call
+    strip_unsigned_projection_fields() first when verifying a pending record
+    that may contain server-derived projection fields.
     """
     cleaned = dict(record_draft)
     cleaned.pop("authorship_proof", None)

--- a/apps/record_chain_intake_gateway/gateway/validation.py
+++ b/apps/record_chain_intake_gateway/gateway/validation.py
@@ -189,7 +189,8 @@ REQUIRED_BOUNDARY_FIELDS: frozenset[str] = frozenset({
     "not_amendment",
     "bitcoin_originals_prevail",
     "receipt_is_not_final_inclusion",
-    "test_phase_submission_may_be_reclassified",
+    "receipt_is_intake_only",
+    "later_records_may_reclassify_or_correct_this_record",
 })
 
 # ---------------------------------------------------------------------------

--- a/apps/record_chain_intake_gateway/tests/conftest.py
+++ b/apps/record_chain_intake_gateway/tests/conftest.py
@@ -95,7 +95,7 @@ def _make_v2_echo_draft() -> dict[str, Any]:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": None,
         "payload": {
@@ -122,7 +122,7 @@ def _make_valid_submission() -> dict[str, Any]:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     }
 
@@ -173,7 +173,7 @@ def valid_context_insufficient_submission() -> dict[str, Any]:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     }
 

--- a/apps/record_chain_intake_gateway/tests/test_authorship_claim_boundary_object.py
+++ b/apps/record_chain_intake_gateway/tests/test_authorship_claim_boundary_object.py
@@ -47,7 +47,7 @@ def _echo_draft(claim_boundary=None) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": None,
         "payload": {"title": "Test", "body": "echo body"},
@@ -67,7 +67,7 @@ def _wrap_submission(draft: dict) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     })
 

--- a/apps/record_chain_intake_gateway/tests/test_chain_normalizer_accepts_v2_fields.py
+++ b/apps/record_chain_intake_gateway/tests/test_chain_normalizer_accepts_v2_fields.py
@@ -38,7 +38,7 @@ def _minimal_v2_draft(**overrides) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "context_readiness": {
             "declared_context_level": 3,

--- a/apps/record_chain_intake_gateway/tests/test_common_identity_autonomy_fields.py
+++ b/apps/record_chain_intake_gateway/tests/test_common_identity_autonomy_fields.py
@@ -54,7 +54,7 @@ def _echo_draft(**overrides) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": None,
         "payload": {"title": "Test", "body": "echo body"},
@@ -75,7 +75,7 @@ def _wrap_submission(draft: dict) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     })
 

--- a/apps/record_chain_intake_gateway/tests/test_human_identity_disclosure_optional.py
+++ b/apps/record_chain_intake_gateway/tests/test_human_identity_disclosure_optional.py
@@ -43,7 +43,7 @@ def _echo_draft(identity_overrides: dict | None = None) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": None,
         "payload": {"title": "Test", "body": "echo body"},
@@ -62,7 +62,7 @@ def _wrap_submission(draft: dict) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     })
 

--- a/apps/record_chain_intake_gateway/tests/test_no_echo_type.py
+++ b/apps/record_chain_intake_gateway/tests/test_no_echo_type.py
@@ -47,7 +47,7 @@ def _echo_draft() -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "payload": {"title": "Test", "body": "echo body"},
     }
@@ -82,7 +82,7 @@ class TestNoEchoTypeInDraft:
                 "not_amendment": True,
                 "bitcoin_originals_prevail": True,
                 "receipt_is_not_final_inclusion": True,
-                "test_phase_submission_may_be_reclassified": True,
+                "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
             },
         })
         diagnostics = validate_submission(submission)

--- a/apps/record_chain_intake_gateway/tests/test_optional_guardian_application_from_echo_verification.py
+++ b/apps/record_chain_intake_gateway/tests/test_optional_guardian_application_from_echo_verification.py
@@ -40,7 +40,7 @@ def _echo_draft_with_guardian_request() -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": {
             "does_participant_request_guardian_application_with_this_record": True,
@@ -68,7 +68,7 @@ def _wrap_submission(draft: dict, record_type: str = "echo") -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     })
 

--- a/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_context_level_parser.py
+++ b/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_context_level_parser.py
@@ -79,7 +79,7 @@ def _make_submission_with_context_level(level) -> dict:
                 "not_amendment": True,
                 "bitcoin_originals_prevail": True,
                 "receipt_is_not_final_inclusion": True,
-                "test_phase_submission_may_be_reclassified": True,
+                "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
             },
             "optional_linked_guardian_application_request": None,
             "payload": {"title": "Test", "body": "test body"},
@@ -92,7 +92,7 @@ def _make_submission_with_context_level(level) -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
     })
 

--- a/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_field_model_alignment.py
+++ b/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_field_model_alignment.py
@@ -80,7 +80,8 @@ class TestFieldModelAlignment:
     def test_common_model_has_new_boundary_fields(self, common_model):
         required = common_model["$defs"]["non_authority_boundary_acknowledgement"]["required"]
         assert "receipt_is_not_final_inclusion" in required
-        assert "test_phase_submission_may_be_reclassified" in required
+        assert "receipt_is_intake_only" in required
+        assert "later_records_may_reclassify_or_correct_this_record" in required
 
     def test_helper_has_new_identity_fields(self, field_helper):
         fg_fields = [g["field"] for g in field_helper["field_groups"]]

--- a/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_preflight_authorship.py
+++ b/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_preflight_authorship.py
@@ -51,7 +51,7 @@ def _make_echo_draft() -> dict:
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": None,
         "payload": {"title": "Test", "body": "test body"},
@@ -66,7 +66,7 @@ BOUNDARY = {
     "not_amendment": True,
     "bitcoin_originals_prevail": True,
     "receipt_is_not_final_inclusion": True,
-    "test_phase_submission_may_be_reclassified": True,
+    "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
 }
 
 

--- a/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_submission_boundary.py
+++ b/apps/record_chain_intake_gateway/tests/test_phase5c_hotfix_submission_boundary.py
@@ -24,7 +24,7 @@ def _make_submission_with_boundary_key(boundary_key: str) -> dict:
         "not_amendment": True,
         "bitcoin_originals_prevail": True,
         "receipt_is_not_final_inclusion": True,
-        "test_phase_submission_may_be_reclassified": True,
+        "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
     }
     sub: dict = {
         "record_type": "echo",
@@ -56,7 +56,7 @@ def _make_submission_with_boundary_key(boundary_key: str) -> dict:
                 "not_amendment": True,
                 "bitcoin_originals_prevail": True,
                 "receipt_is_not_final_inclusion": True,
-                "test_phase_submission_may_be_reclassified": True,
+                "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
             },
             "optional_linked_guardian_application_request": None,
             "payload": {"title": "Test", "body": "test body"},
@@ -113,7 +113,7 @@ class TestSubmissionBoundaryAlias:
                     "not_amendment": True,
                     "bitcoin_originals_prevail": True,
                     "receipt_is_not_final_inclusion": True,
-                    "test_phase_submission_may_be_reclassified": True,
+                    "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
                 },
                 "optional_linked_guardian_application_request": None,
                 "payload": {"title": "Test", "body": "test body"},

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -662,7 +662,7 @@ function buildV2CommonFields(opts) {
       bitcoin_originals_prevail: true,
       receipt_is_not_final_inclusion: true,
       receipt_is_intake_only: true,
-      later_records_may_reclassify_or_correct_this_record: true,
+    later_records_may_reclassify_or_correct_this_record: true,
     },
   };
 }
@@ -842,7 +842,7 @@ function buildSubmission(recordDraft, opts) {
       bitcoin_originals_prevail: true,
       receipt_is_not_final_inclusion: true,
       receipt_is_intake_only: true,
-      later_records_may_reclassify_or_correct_this_record: true,
+    later_records_may_reclassify_or_correct_this_record: true,
     },
   };
 }
@@ -971,7 +971,7 @@ const FIELD_EXPLANATIONS = {
   "non_authority_boundary_acknowledgement.bitcoin_originals_prevail": "Acknowledges Bitcoin originals prevail in any conflict.",
   "non_authority_boundary_acknowledgement.receipt_is_not_final_inclusion": "Acknowledges that receipt does not guarantee final inclusion.",
   "non_authority_boundary_acknowledgement.receipt_is_intake_only": "Acknowledges that receipt confirms intake only and is not final inclusion.",
-    "non_authority_boundary_acknowledgement.later_records_may_reclassify_or_correct_this_record": "Acknowledges that later append-only records may classify, correct, or supersede this record without mutating it.",
+  "non_authority_boundary_acknowledgement.later_records_may_reclassify_or_correct_this_record": "Acknowledges that later append-only records may classify, correct, or supersede this record without mutating it.",
 
   "optional_linked_guardian_application_request": "Whether the participant is requesting a guardian application alongside this record.",
   "optional_linked_guardian_application_request.does_participant_request_guardian_application_with_this_record": "Whether a guardian application is requested with this record.",
@@ -1514,7 +1514,7 @@ function generateTemplate(recordType) {
     bitcoin_originals_prevail: true,
     receipt_is_not_final_inclusion: true,
     receipt_is_intake_only: true,
-      later_records_may_reclassify_or_correct_this_record: true,
+    later_records_may_reclassify_or_correct_this_record: true,
   };
 
   if (recordType === "guardian_application" || recordType === "guardian_retirement") {

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -661,7 +661,8 @@ function buildV2CommonFields(opts) {
       not_amendment: true,
       bitcoin_originals_prevail: true,
       receipt_is_not_final_inclusion: true,
-      test_phase_submission_may_be_reclassified: true,
+      receipt_is_intake_only: true,
+      later_records_may_reclassify_or_correct_this_record: true,
     },
   };
 }
@@ -840,7 +841,8 @@ function buildSubmission(recordDraft, opts) {
       not_amendment: true,
       bitcoin_originals_prevail: true,
       receipt_is_not_final_inclusion: true,
-      test_phase_submission_may_be_reclassified: true,
+      receipt_is_intake_only: true,
+      later_records_may_reclassify_or_correct_this_record: true,
     },
   };
 }
@@ -968,7 +970,8 @@ const FIELD_EXPLANATIONS = {
   "non_authority_boundary_acknowledgement.not_amendment": "Acknowledges this is not an amendment to the Accord.",
   "non_authority_boundary_acknowledgement.bitcoin_originals_prevail": "Acknowledges Bitcoin originals prevail in any conflict.",
   "non_authority_boundary_acknowledgement.receipt_is_not_final_inclusion": "Acknowledges that receipt does not guarantee final inclusion.",
-  "non_authority_boundary_acknowledgement.test_phase_submission_may_be_reclassified": "Acknowledges test-phase submissions may be reclassified.",
+  "non_authority_boundary_acknowledgement.receipt_is_intake_only": "Acknowledges that receipt confirms intake only and is not final inclusion.",
+    "non_authority_boundary_acknowledgement.later_records_may_reclassify_or_correct_this_record": "Acknowledges that later append-only records may classify, correct, or supersede this record without mutating it.",
 
   "optional_linked_guardian_application_request": "Whether the participant is requesting a guardian application alongside this record.",
   "optional_linked_guardian_application_request.does_participant_request_guardian_application_with_this_record": "Whether a guardian application is requested with this record.",
@@ -1510,7 +1513,8 @@ function generateTemplate(recordType) {
     not_amendment: true,
     bitcoin_originals_prevail: true,
     receipt_is_not_final_inclusion: true,
-    test_phase_submission_may_be_reclassified: true,
+    receipt_is_intake_only: true,
+      later_records_may_reclassify_or_correct_this_record: true,
   };
 
   if (recordType === "guardian_application" || recordType === "guardian_retirement") {

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -588,6 +588,28 @@ def main() -> int:
         fail(f"m3 finalizer native compat contract failed: {result.stderr}\n{result.stdout}")
     ok("m3 finalizer native compatibility contract")
 
+    # Authorship projection sanitization regression
+    result = subprocess.run(
+        [sys.executable, "scripts/test_authorship_projection_sanitization.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"authorship projection sanitization test failed: {result.stderr}\n{result.stdout}")
+    ok("authorship projection sanitization")
+
+    # Builder production-live boundary regression
+    result = subprocess.run(
+        [sys.executable, "scripts/test_builder_production_live_boundaries.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"builder production-live boundary test failed: {result.stderr}\n{result.stdout}")
+    ok("builder production-live boundaries")
+
     print("\n=== ALL CURRENT SYSTEM TESTS PASSED ===")
     return 0
 

--- a/scripts/test_authorship_projection_sanitization.py
+++ b/scripts/test_authorship_projection_sanitization.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import base64
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+from gateway.authorship import (
+    public_key_sha256_from_pem,
+    strip_unsigned_projection_fields,
+    verify_authorship_proof,
+)
+from gateway.canonical import canonical_bytes, sha256_bytes
+from trinity_record_chain import sanitize_pending_record_for_append
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def make_keypair() -> tuple[Ed25519PrivateKey, str, str]:
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    public_pem = public_key.public_bytes(
+        encoding=Encoding.PEM,
+        format=PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    # Exercise private serialization but never write it to disk.
+    private_key.private_bytes(
+        encoding=Encoding.PEM,
+        format=PrivateFormat.PKCS8,
+        encryption_algorithm=NoEncryption(),
+    )
+    return private_key, public_pem, public_key_sha256_from_pem(public_pem)
+
+
+def make_signed_pending_with_projection() -> tuple[dict, dict]:
+    private_key, public_pem, public_sha = make_keypair()
+
+    signed_draft = {
+        "schema": "trinityaccord.record-chain-entry-draft.v2",
+        "record_type": "echo",
+        "created_at": "2026-06-08T00:00:00Z",
+        "echo_content": {
+            "echo_text": "Projection sanitization regression echo.",
+            "echo_intent": "recognition",
+        },
+        "submitting_participant_identity": {
+            "participant_type": "agent",
+            "participant_public_display_label": "Projection Test Agent",
+            "participant_provider_or_platform": "local",
+            "participant_model_or_runtime": "local",
+            "participant_public_key_sha256": public_sha,
+        },
+        "non_authority_boundary_acknowledgement": {
+            "not_authority": True,
+            "not_governance": True,
+            "not_attestation": True,
+            "not_successor_reception": True,
+            "not_amendment": True,
+            "bitcoin_originals_prevail": True,
+            "receipt_is_not_final_inclusion": True,
+            "receipt_is_intake_only": True,
+        },
+        "context_readiness": {
+            "declared_context_level": "CC-3",
+            "minimum_required_for_action": "CC-3",
+            "context_sufficient_for_selected_action": True,
+            "loaded_context_urls": ["https://www.trinityaccord.org/agent-start/"],
+        },
+    }
+
+    payload = canonical_bytes(signed_draft)
+    payload_sha = sha256_bytes(payload)
+    signature = private_key.sign(payload)
+
+    proof = {
+        "schema": "trinityaccord.agent-authorship-proof.v1",
+        "method": "public_key_signature",
+        "algorithm": "ed25519",
+        "public_key_pem": public_pem,
+        "public_key_sha256": public_sha,
+        "signed_payload_sha256": payload_sha,
+        "signed_message": payload_sha,
+        "signature_base64": base64.b64encode(signature).decode("ascii"),
+        "claim_boundary": {
+            "not authority": True,
+            "not attestation": True,
+            "not amendment": True,
+            "not successor reception": True,
+            "key_continuity_only": True,
+        },
+    }
+
+    polluted_pending = dict(signed_draft)
+    polluted_pending["authorship_proof"] = proof
+    polluted_pending["actor_identity"] = {
+        "label": "Projection Test Agent",
+        "provider": "local",
+        "id": public_sha,
+    }
+    polluted_pending["boundary"] = {
+        "not_authority": True,
+        "not_governance": True,
+        "not_attestation": True,
+        "not_successor_reception": True,
+        "not_amendment": True,
+        "bitcoin_originals_prevail": True,
+    }
+    polluted_pending["record_id"] = "R-999999999"
+    polluted_pending["record_index"] = 999999999
+    polluted_pending["content_sha256"] = "0" * 64
+    polluted_pending["record_sha256"] = "1" * 64
+
+    return signed_draft, polluted_pending
+
+
+def main() -> None:
+    signed_draft, polluted_pending = make_signed_pending_with_projection()
+    proof = polluted_pending["authorship_proof"]
+
+    ok, err = verify_authorship_proof(polluted_pending, proof)
+    require(not ok, "polluted pending must not verify directly")
+    require("signed_payload_sha256 mismatch" in str(err), "direct failure should be payload mismatch")
+
+    sanitized = strip_unsigned_projection_fields(polluted_pending)
+    require("actor_identity" not in sanitized, "actor_identity must be stripped")
+    require("boundary" not in sanitized, "boundary must be stripped")
+    require("record_id" not in sanitized, "record_id must be stripped")
+    require("record_index" not in sanitized, "record_index must be stripped")
+    require("content_sha256" not in sanitized, "content_sha256 must be stripped")
+    require("record_sha256" not in sanitized, "record_sha256 must be stripped")
+    require(sanitized["echo_content"] == signed_draft["echo_content"], "signed content must remain")
+
+    ok, err = verify_authorship_proof(sanitized, proof)
+    require(ok, f"sanitized pending should verify: {err}")
+
+    append_sanitized = sanitize_pending_record_for_append(polluted_pending)
+    require(append_sanitized == sanitized, "append sanitizer must match shared sanitizer output")
+
+    print("Authorship projection sanitization PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_builder_production_live_boundaries.py
+++ b/scripts/test_builder_production_live_boundaries.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
+BUNDLE_MANIFEST = ROOT / "api" / "record-chain-builder-bundles.v1.json"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def main() -> None:
+    text = BUILDER.read_text(encoding="utf-8")
+
+    forbidden = [
+        "test_phase_submission_may_be_reclassified",
+        "test-phase submissions may be reclassified",
+        "Acknowledges test-phase submissions may be reclassified",
+    ]
+    for phrase in forbidden:
+        require(phrase not in text, f"builder still contains retired test-phase phrase: {phrase}")
+
+    for phrase in [
+        "receipt_is_intake_only",
+        "later_records_may_reclassify_or_correct_this_record",
+        "receipt confirms intake only",
+    ]:
+        require(phrase in text, f"builder missing production-live boundary phrase: {phrase}")
+
+    manifest = json.loads(BUNDLE_MANIFEST.read_text(encoding="utf-8"))
+    builder_bytes = BUILDER.read_bytes()
+    require(
+        manifest["canonical_builder"]["sha256"] == hashlib.sha256(builder_bytes).hexdigest(),
+        "builder bundle manifest sha256 does not match builder",
+    )
+    require(
+        manifest["canonical_builder"]["size_bytes"] == len(builder_bytes),
+        "builder bundle manifest size_bytes does not match builder",
+    )
+
+    with tempfile.TemporaryDirectory() as td:
+        out = Path(td) / "echo.json"
+        key_dir = Path(td) / "keys"
+        oath = subprocess.check_output(
+            ["node", str(BUILDER), "print-oath", "--record-type", "echo"],
+            cwd=ROOT,
+            text=True,
+        )
+
+        subprocess.check_call(
+            [
+                "node",
+                str(BUILDER),
+                "echo",
+                "--actor-label",
+                "Builder Production Boundary Test Agent",
+                "--provider",
+                "local",
+                "--body",
+                "Production-live builder boundary smoke.",
+                "--context-level",
+                "CC-3",
+                "--context-sufficient-for-selected-action",
+                "true",
+                "--loaded-urls",
+                "https://www.trinityaccord.org/agent-start/",
+                "--discovery-mode",
+                "self_discovered",
+                "--record-decision",
+                "self",
+                "--submission-executor",
+                "self",
+                "--requesting-party-type",
+                "none",
+                "--introducing-party-type",
+                "none",
+                "--human-operator-involved",
+                "false",
+                "--readback",
+                oath,
+                "--key-dir",
+                str(key_dir),
+                "--out",
+                str(out),
+            ],
+            cwd=ROOT,
+        )
+
+        generated = out.read_text(encoding="utf-8")
+        require("test_phase_submission_may_be_reclassified" not in generated, "generated submission contains retired test-phase key")
+        require('\"receipt_is_intake_only\":true' in generated or '\"receipt_is_intake_only\": true' in generated, "generated submission missing receipt_is_intake_only")
+        require(
+            "later_records_may_reclassify_or_correct_this_record" in generated,
+            "generated submission missing append-only reclassification boundary",
+        )
+
+    print("Builder production-live boundary test PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_phase6b_hotfix.py
+++ b/scripts/test_phase6b_hotfix.py
@@ -66,10 +66,13 @@ def _attach_valid_authorship_proof(draft: dict) -> dict:
     draft = dict(draft)
     draft.pop("authorship_proof", None)
 
-    # Pre-add ALL fields that normalize_record_draft sets via setdefault.
-    # This ensures the signed payload matches the post-normalization canonical form.
-    draft.setdefault("schema", "trinityaccord.record-chain-entry.v1")
-    draft.setdefault("chain_id", CHAIN_ID)
+    # Strip unsigned projection fields before signing, matching production
+    # sanitize_pending_record_for_append() behavior.
+    from gateway.authorship import strip_unsigned_projection_fields, UNSIGNED_PROJECTION_FIELDS
+    draft = strip_unsigned_projection_fields(draft)
+
+    # Pre-add non-projection fields that normalize_record_draft sets via setdefault.
+    # Do NOT add back projection fields (chain_id, schema, etc.) as they are stripped.
     draft.setdefault("created_at", utc_now())
     draft.setdefault("what_i_checked", [])
     draft.setdefault("limitations", [])
@@ -111,22 +114,41 @@ def _attach_valid_authorship_proof(draft: dict) -> dict:
 
 
 def _make_echo_draft(index: int = 1) -> dict:
-    """Build a minimal valid echo draft with real Ed25519 authorship proof."""
+    """Build a minimal valid echo draft with real Ed25519 authorship proof.
+
+    Uses v2-style submitting_participant_identity (not actor_identity)
+    so that after strip_unsigned_projection_fields, normalize_record_draft
+    can derive actor_identity from submitting_participant_identity.
+    """
     draft = {
-        "schema": "trinityaccord.record-chain-entry.v1",
-        "chain_id": CHAIN_ID,
+        "schema": "trinityaccord.record-chain-entry-draft.v2",
         "record_type": "echo",
         "created_at": utc_now(),
-        "actor_identity": {
-            "label": "Test Agent",
-            "provider": "Test Runtime",
-            "id": "test-001",
+        "submitting_participant_identity": {
+            "participant_type": "agent",
+            "participant_public_display_label": "Test Agent",
+            "participant_self_declared_identifier": "test-001",
+            "participant_identifier_disclosure_status": "not_available",
+            "participant_identity_disclosure_preference": "key_continuity_only",
+            "participant_provider_or_platform": "Test Runtime",
+            "participant_model_or_runtime": "Test Runtime",
+            "participant_public_key_sha256": "",
+            "human_operator_context": {
+                "human_operator_involved": False,
+                "human_real_name_disclosure_status": "not_applicable",
+                "human_public_display_name": "",
+                "human_pseudonym_or_role_label": "",
+                "human_private_name_submitted": False,
+                "human_private_name_commitment_sha256": "",
+            },
         },
         "context_readiness": {
-            "read_level": "full",
-            "source_files_reviewed": ["README.md"],
+            "declared_context_level": "CC-0",
+            "minimum_required_for_action": "CC-0",
+            "context_sufficient_for_selected_action": False,
+            "loaded_context_urls": [],
+            "context_readiness_notes": "",
         },
-        "boundary_acknowledgement": dict(BOUNDARY),
         "echo_content": {
             "echo_text": "Phase 6B test echo",
             "echo_intent": "recognition",
@@ -139,20 +161,34 @@ def _make_echo_draft(index: int = 1) -> dict:
 def _make_guardian_draft(index: int = 1) -> dict:
     """Build a minimal valid guardian_application draft with real Ed25519 proof."""
     draft = {
-        "schema": "trinityaccord.record-chain-entry.v1",
-        "chain_id": CHAIN_ID,
+        "schema": "trinityaccord.record-chain-entry-draft.v2",
         "record_type": "guardian_application",
         "created_at": utc_now(),
-        "actor_identity": {
-            "label": "Test Guardian",
-            "provider": "Test Runtime",
-            "id": "guardian-001",
+        "submitting_participant_identity": {
+            "participant_type": "agent",
+            "participant_public_display_label": "Test Guardian",
+            "participant_self_declared_identifier": "guardian-001",
+            "participant_identifier_disclosure_status": "not_available",
+            "participant_identity_disclosure_preference": "key_continuity_only",
+            "participant_provider_or_platform": "Test Runtime",
+            "participant_model_or_runtime": "Test Runtime",
+            "participant_public_key_sha256": "",
+            "human_operator_context": {
+                "human_operator_involved": False,
+                "human_real_name_disclosure_status": "not_applicable",
+                "human_public_display_name": "",
+                "human_pseudonym_or_role_label": "",
+                "human_private_name_submitted": False,
+                "human_private_name_commitment_sha256": "",
+            },
         },
         "context_readiness": {
-            "read_level": "full",
-            "source_files_reviewed": ["README.md"],
+            "declared_context_level": "CC-0",
+            "minimum_required_for_action": "CC-0",
+            "context_sufficient_for_selected_action": False,
+            "loaded_context_urls": [],
+            "context_readiness_notes": "",
         },
-        "boundary_acknowledgement": dict(BOUNDARY),
         "guardian_application_content": {
             "requested_guardian_identifier": "G-00200",
             "guardian_public_key_sha256": "b" * 64,

--- a/scripts/test_phase_5c_hotfix.py
+++ b/scripts/test_phase_5c_hotfix.py
@@ -2,7 +2,7 @@
 """Phase 5C-HOTFIX regression tests.
 
 Tests:
-  1. Builder-generated echo has 8-field submission_boundary
+  1. Builder-generated echo has 9-field submission_boundary
   2. Builder-generated echo passes authorship proof verification (Ed25519)
   3. Linked Guardian draft passes normalize_record_draft()
   4. Helper diagnostic fixes do not mention retired canonical fields
@@ -33,7 +33,8 @@ REQUIRED_BOUNDARY_FIELDS = {
     "not_amendment",
     "bitcoin_originals_prevail",
     "receipt_is_not_final_inclusion",
-    "test_phase_submission_may_be_reclassified",
+    "receipt_is_intake_only",
+    "later_records_may_reclassify_or_correct_this_record",
 }
 
 # Retired field names that must not appear in diagnostic fix text

--- a/scripts/test_record_chain_intake_gateway_contract.py
+++ b/scripts/test_record_chain_intake_gateway_contract.py
@@ -104,7 +104,7 @@ def main() -> None:
                 "non_authority_boundary_acknowledgement": {
                     "not_authority": True, "not_governance": True, "not_attestation": True,
                     "not_successor_reception": True, "not_amendment": True, "bitcoin_originals_prevail": True,
-                    "receipt_is_not_final_inclusion": True, "test_phase_submission_may_be_reclassified": True,
+                    "receipt_is_not_final_inclusion": True, "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
                 },
                 "submitting_participant_identity": {
                     "participant_public_display_label": "test",

--- a/scripts/test_record_chain_intake_integrity_regressions.py
+++ b/scripts/test_record_chain_intake_integrity_regressions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -170,7 +171,7 @@ def test_append_authorship_verification_source_markers() -> None:
         fail("append must define/use verify_pending_record_authorship")
     if "verified_by_append_before_record" not in text:
         fail("append must write verified_by_append_before_record")
-    if "verify_authorship_proof(record, proof)" not in text:
+    if not re.search(r'verify_authorship_proof\(\w+,\s*proof\)', text):
         fail("append must call verify_authorship_proof(record, proof) on pending draft")
     if "invalid authorship_proof.schema" not in text:
         fail("append must validate authorship_proof.schema before verifier")

--- a/scripts/trinity_record_chain.py
+++ b/scripts/trinity_record_chain.py
@@ -400,11 +400,29 @@ def verify_pending_record_authorship(record: dict[str, Any]) -> None:
     # Import lazily so non-authorship commands do not pay this dependency cost.
     # Import lazily so non-authorship commands do not pay this dependency cost.
     sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
-    from gateway.authorship import verify_authorship_proof  # noqa: WPS433
+    from gateway.authorship import (  # noqa: WPS433
+        strip_unsigned_projection_fields,
+        verify_authorship_proof,
+    )
 
-    ok, err = verify_authorship_proof(record, proof)
+    record_for_verification = strip_unsigned_projection_fields(record)
+    ok, err = verify_authorship_proof(record_for_verification, proof)
     if not ok:
         raise ValueError(f"authorship proof verification failed for pending record: {err}")
+
+
+def sanitize_pending_record_for_append(record: dict[str, Any]) -> dict[str, Any]:
+    """Return the pending record object that may proceed to append.
+
+    The returned object removes server-derived or append-assigned projection
+    fields before normalization. This ensures append verifies and normalizes the
+    same signed-scope object rather than verifying a cleaned view but appending
+    the polluted raw pending file.
+    """
+    sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+    from gateway.authorship import strip_unsigned_projection_fields  # noqa: WPS433
+
+    return strip_unsigned_projection_fields(record)
 
 
 def normalize_record_draft(draft: dict[str, Any]) -> dict[str, Any]:
@@ -517,10 +535,11 @@ def append_records(all_records: bool = False) -> None:
     for path in selected:
         try:
             raw_draft = read_json(path)
-            # Verify authorship proof on the raw draft before normalization
-            # modifies it, so the signed payload hash matches exactly.
-            verify_pending_record_authorship(raw_draft)
-            draft = normalize_record_draft(raw_draft)
+            # Verify authorship proof on the signed-scope pending draft before normalization
+            # modifies it. Then append the same sanitized object that was verified.
+            signed_scope_draft = sanitize_pending_record_for_append(raw_draft)
+            verify_pending_record_authorship(signed_scope_draft)
+            draft = normalize_record_draft(signed_scope_draft)
 
             # --- Phase 6B: authorship_verification_status ---
             # Record the scope of the authorship proof relative to the final

--- a/tests/test_gateway_hotfix_d.py
+++ b/tests/test_gateway_hotfix_d.py
@@ -148,7 +148,7 @@ def _make_draft(record_type: str = "echo", with_linked_guardian: bool = False) -
             "not_amendment": True,
             "bitcoin_originals_prevail": True,
             "receipt_is_not_final_inclusion": True,
-            "test_phase_submission_may_be_reclassified": True,
+            "receipt_is_intake_only": True, "later_records_may_reclassify_or_correct_this_record": True,
         },
         "optional_linked_guardian_application_request": {
             "does_participant_request_guardian_application_with_this_record": with_linked_guardian,


### PR DESCRIPTION
## Summary

Fix external Echo submissions that pass Gateway intake but fail append with authorship `signed_payload_sha256 mismatch` when unsigned projection fields are present in pending.

## Root cause

Pending records may contain server-derived projection fields such as `actor_identity` and `boundary`. The participant signs the pre-append draft, but append verification was hashing the full pending record. This caused signature hash mismatch and rejection.

Observed on receipt `rcg-20260608-64ccdef694f34586a0748460`:
```
signed_payload_sha256 mismatch:
  expected 268c1d2e9c0911fa4e6a47d704ccccae28a4e404d9d40cc1baae866f31212156
  got      abb0811db6486cbf3f7a8e8f30274f050de0e352672f097961eb11cfb1a77912
```

## Changes

- **PART A**: Add shared `strip_unsigned_projection_fields()` helper in `authorship.py`
- **PART B**: Reject client-supplied server projection fields during preflight/submit; defensively strip projection fields before writing pending in `app.py`
- **PART C**: Sanitize pending before append authorship verification and append the same sanitized object in `trinity_record_chain.py`
- **PART D**: Remove production-stale `test_phase_submission_may_be_reclassified` from builder output
- **PART E**: Update builder bundle manifest hash/size
- **PART F**: Add regression test for projection sanitization
- **PART G**: Add regression test for builder production-live boundaries
- **PART H**: Register new tests in `run_current_system_tests.py`

## Safety

- does not modify record-chain history
- does not requeue rejected records
- does not modify workflows
- does not run live OTS/Arweave
- preserves Ed25519 signature verification
- verifies and appends the same sanitized signed-scope object
