### PR TITLE
fix: extend Arweave upload timeout

### DIFF
--- a/.github/workflows/record-chain-arweave-archive.yml
+++ b/.github/workflows/record-chain-arweave-archive.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Build Arweave archive manifest
         env:
           ARKEY: ${{ secrets.ARKEY }}
+          ARWEAVE_UPLOAD_TIMEOUT_SECONDS: "600"
         run: python scripts/build_record_chain_arweave_archive.py --mode "${ARWEAVE_UPLOAD_MODE}"
 
       - name: Verify Arweave archive metadata

--- a/scripts/build_record_chain_arweave_archive.py
+++ b/scripts/build_record_chain_arweave_archive.py
@@ -229,7 +229,9 @@ def upload_to_arweave(payload_path: Path, archive_dir: Path) -> dict:
     cmd = ["node", str(uploader), "--payload", str(payload_path), "--out", str(result_path)]
     env = os.environ.copy()
 
-    result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=120)
+    timeout_seconds = int(os.environ.get("ARWEAVE_UPLOAD_TIMEOUT_SECONDS", "600"))
+    print(f"Arweave upload timeout: {timeout_seconds}s")
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=timeout_seconds)
     if result.returncode != 0:
         print(f"Arweave upload failed:\nstdout: {result.stdout}\nstderr: {result.stderr}", file=sys.stderr)
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
Increase Record-Chain Arweave live upload timeout from 120s to 600s.

## Why
R-000000034 native OTS is ready, but Arweave live upload timed out after 120 seconds before metadata could be committed.

## Changes
- : timeout now configurable via  env var (default 600s)
- : passes  to build step

## Safety
- No record-chain history changes
- No manual txid injection
- No archive metadata hand edit
- Upload timeout is configurable through ARWEAVE_UPLOAD_TIMEOUT_SECONDS