### PR TITLE
ci: complete external-agent full auto archive pipeline

### DIFF
--- a/.github/workflows/record-chain-arweave-archive.yml
+++ b/.github/workflows/record-chain-arweave-archive.yml
@@ -1,7 +1,8 @@
 name: Record Chain Arweave Archive
 # Native record-chain archive workflow.
 # Live upload requires ARKEY secret.
-# Dry-run remains the default for manual, scheduled, and workflow_run executions.
+# Dry-run remains the default for manual and scheduled executions.
+# Successful workflow_run from native OTS resolves to live upload.
 
 on:
   workflow_run:
@@ -32,24 +33,86 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
     env:
-      ARWEAVE_UPLOAD_MODE: ${{ github.event.inputs.upload_mode || 'dry-run' }}
+      ARWEAVE_UPLOAD_MODE: "dry-run"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if latest live Arweave archive already matches native head
+        id: archive_check
+        run: |
+          python3 - <<'PY' > /tmp/arweave-latest-check.env
+          import json
+          from pathlib import Path
+
+          tip = json.loads(Path("record-chain/chain-tip.json").read_text())
+          index_path = Path("api/record-chain-arweave-index.json")
+
+          matched = False
+          matched_archive_id = ""
+          matched_txid = ""
+
+          if index_path.exists():
+              index = json.loads(index_path.read_text())
+              for archive in index.get("archives", []):
+                  if (
+                      archive.get("source_type") == "native-record-chain"
+                      and archive.get("mode") == "live"
+                      and archive.get("arweave_txid")
+                      and archive.get("native_latest_record_id") == tip.get("latest_record_id")
+                      and archive.get("native_latest_record_sha256") == tip.get("latest_record_sha256")
+                      and archive.get("native_record_count") == tip.get("native_record_count")
+                  ):
+                      matched = True
+                      matched_archive_id = archive.get("archive_id") or ""
+                      matched_txid = archive.get("arweave_txid") or ""
+                      break
+
+          print(f"matched={'true' if matched else 'false'}")
+          print(f"matched_archive_id={matched_archive_id}")
+          print(f"matched_txid={matched_txid}")
+          print(f"latest_record_id={tip.get('latest_record_id')}")
+          print(f"native_record_count={tip.get('native_record_count')}")
+          PY
+          cat /tmp/arweave-latest-check.env >> "$GITHUB_OUTPUT"
+          cat /tmp/arweave-latest-check.env
+
+      - name: No new Arweave archive needed
+        if: steps.archive_check.outputs.matched == 'true'
+        run: |
+          echo "Latest live native Arweave archive already matches current chain-tip."
+          echo "archive_id=${{ steps.archive_check.outputs.matched_archive_id }}"
+          echo "txid=${{ steps.archive_check.outputs.matched_txid }}"
+
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        if: steps.archive_check.outputs.matched != 'true'
         with:
           python-version: "3.12"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.archive_check.outputs.matched != 'true'
         with:
           node-version-file: ".node-version"
 
+      - name: Resolve Arweave upload mode
+        if: steps.archive_check.outputs.matched != 'true'
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "ARWEAVE_UPLOAD_MODE=live" >> "$GITHUB_ENV"
+            echo "Resolved Arweave upload mode: live (workflow_run from OTS)"
+          else
+            echo "ARWEAVE_UPLOAD_MODE=${{ github.event.inputs.upload_mode || 'dry-run' }}" >> "$GITHUB_ENV"
+            echo "Resolved Arweave upload mode: ${{ github.event.inputs.upload_mode || 'dry-run' }}"
+          fi
+
       - name: Install Node dependencies
+        if: steps.archive_check.outputs.matched != 'true'
         run: npm ci
 
       - name: Verify native OTS latest before archive
+        if: steps.archive_check.outputs.matched != 'true'
         run: |
           python3 - <<'PY'
           import json
@@ -85,23 +148,28 @@ jobs:
           PY
 
       - name: Build Arweave archive manifest
+        if: steps.archive_check.outputs.matched != 'true'
         env:
           ARKEY: ${{ secrets.ARKEY }}
           ARWEAVE_UPLOAD_TIMEOUT_SECONDS: "600"
         run: python scripts/build_record_chain_arweave_archive.py --mode "${ARWEAVE_UPLOAD_MODE}"
 
       - name: Verify Arweave archive metadata
+        if: steps.archive_check.outputs.matched != 'true'
         run: python scripts/verify_record_chain_arweave_archive.py
 
       - name: Verify record chain
+        if: steps.archive_check.outputs.matched != 'true'
         run: python scripts/trinity_record_chain.py verify
 
       - name: Regenerate public homepage counters
+        if: steps.archive_check.outputs.matched != 'true'
         run: |
           python scripts/generate_public_home_status.py
           python scripts/generate_sitemap.py
 
       - name: Commit Arweave archive metadata
+        if: steps.archive_check.outputs.matched != 'true'
         run: |
           if ! git diff --quiet; then
             git config user.name "trinity-record-chain-bot"

--- a/.github/workflows/record-chain-arweave-archive.yml
+++ b/.github/workflows/record-chain-arweave-archive.yml
@@ -81,9 +81,9 @@ jobs:
       - name: No new Arweave archive needed
         if: steps.archive_check.outputs.matched == 'true'
         run: |
-          echo "Latest live native Arweave archive already matches current chain-tip."
-          echo "archive_id=${{ steps.archive_check.outputs.matched_archive_id }}"
-          echo "txid=${{ steps.archive_check.outputs.matched_txid }}"
+          printf '%s\n' "Latest live native Arweave archive already matches current chain-tip."
+          printf '%s\n' "archive_id=${{ steps.archive_check.outputs.matched_archive_id }}"
+          printf '%s\n' "txid=${{ steps.archive_check.outputs.matched_txid }}"
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         if: steps.archive_check.outputs.matched != 'true'
@@ -100,11 +100,11 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "ARWEAVE_UPLOAD_MODE=live" >> "$GITHUB_ENV"
-            echo "Resolved Arweave upload mode: live (workflow_run from OTS)"
+            printf '%s\n' "ARWEAVE_UPLOAD_MODE=live" >> "$GITHUB_ENV"
+            printf '%s\n' "Resolved Arweave upload mode: live (workflow_run from OTS)"
           else
-            echo "ARWEAVE_UPLOAD_MODE=${{ github.event.inputs.upload_mode || 'dry-run' }}" >> "$GITHUB_ENV"
-            echo "Resolved Arweave upload mode: ${{ github.event.inputs.upload_mode || 'dry-run' }}"
+            printf '%s\n' "ARWEAVE_UPLOAD_MODE=${{ github.event.inputs.upload_mode || 'dry-run' }}" >> "$GITHUB_ENV"
+            printf '%s\n' "Resolved Arweave upload mode: ${{ github.event.inputs.upload_mode || 'dry-run' }}"
           fi
 
       - name: Install Node dependencies

--- a/.github/workflows/record-chain-head-ots-anchor.yml
+++ b/.github/workflows/record-chain-head-ots-anchor.yml
@@ -3,7 +3,9 @@ name: Record Chain Head OTS Anchor
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: ["Record Chain Auto Finalize"]
+    workflows:
+      - "Record Chain Auto Finalize"
+      - "Append Record Chain Entries"
     types: [completed]
 
 permissions:

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-08T13:27:17.752031+00:00",
+  "generated_at": "2026-06-08T14:55:53.189516+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -11,7 +11,7 @@
     "/api/guardian-registry.json",
     "/api/agent-declared-verification-index.json"
   ],
-  "source_digest": "a42e5af26a411b0f",
+  "source_digest": "4ad2cffeb291b564",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 34,
@@ -46,13 +46,13 @@
         "bitcoin_pending": true,
         "bitcoin_verified": false,
         "implemented": true,
-        "latest_record_id": "R-000000033",
-        "latest_record_sha256": "60f1589ad2330576134e3b89ef9465b8c515343f0b9af3c611c6ff4f8568c75d",
+        "latest_record_id": "R-000000034",
+        "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
         "legacy_batch_status_api": "/api/record-chain-anchor-status.json",
         "legacy_main_chain_jsonl_is_not_source": true,
         "native_head_workflow": "/.github/workflows/record-chain-head-ots-anchor.yml",
         "native_latest_api": "/api/record-chain-native-ots-latest.json",
-        "native_record_count": 33,
+        "native_record_count": 34,
         "status": "pending-bitcoin",
         "status_api": "/api/record-chain-native-ots-latest.json"
       },
@@ -65,12 +65,12 @@
         "default_mode": "dry-run",
         "implemented": true,
         "index_api": "/api/record-chain-arweave-index.json",
-        "latest_arweave_txid": "hSyp93ZW2cQQcK7lPdqyREr-jCs4Kj5m4vbjlYGBEZ8",
-        "latest_native_record_id": "R-000000033",
-        "live_archive_count": 1,
+        "latest_arweave_txid": "5qhNn7fSly2ftrY0EUHpdTFUwOZ8IxenFrs4LHblDpw",
+        "latest_native_record_id": "R-000000034",
+        "live_archive_count": 2,
         "live_upload_enabled": true,
         "live_upload_implemented": true,
-        "native_record_count": 33,
+        "native_record_count": 34,
         "source_type": "native-record-chain",
         "workflow": "/.github/workflows/record-chain-arweave-archive.yml"
       },

--- a/api/record-chain-status.json
+++ b/api/record-chain-status.json
@@ -1,290 +1,290 @@
 {
-  "anchoring": {
-    "arweave_archive": {
-      "arweave_archive_is_mirror_only": true,
-      "arweave_archive_is_not_amendment": true,
-      "arweave_archive_is_not_attestation": true,
-      "arweave_archive_is_not_authority": true,
-      "current_upload_mode": "live",
-      "default_mode": "dry-run",
-      "implemented": true,
-      "index_api": "/api/record-chain-arweave-index.json",
-      "latest_arweave_txid": "hSyp93ZW2cQQcK7lPdqyREr-jCs4Kj5m4vbjlYGBEZ8",
-      "latest_native_record_id": "R-000000033",
-      "live_archive_count": 1,
-      "live_upload_enabled": true,
-      "live_upload_implemented": true,
-      "native_record_count": 33,
-      "source_type": "native-record-chain",
-      "workflow": "/.github/workflows/record-chain-arweave-archive.yml"
+    "anchoring": {
+        "arweave_archive": {
+            "arweave_archive_is_mirror_only": true,
+            "arweave_archive_is_not_amendment": true,
+            "arweave_archive_is_not_attestation": true,
+            "arweave_archive_is_not_authority": true,
+            "current_upload_mode": "live",
+            "default_mode": "dry-run",
+            "implemented": true,
+            "index_api": "/api/record-chain-arweave-index.json",
+            "latest_arweave_txid": "5qhNn7fSly2ftrY0EUHpdTFUwOZ8IxenFrs4LHblDpw",
+            "latest_native_record_id": "R-000000034",
+            "live_archive_count": 2,
+            "live_upload_enabled": true,
+            "live_upload_implemented": true,
+            "native_record_count": 34,
+            "source_type": "native-record-chain",
+            "workflow": "/.github/workflows/record-chain-arweave-archive.yml"
+        },
+        "batch_manifests": {
+            "automated_workflow": "/.github/workflows/record-chain-anchor.yml",
+            "implemented": true,
+            "note": "Batch manifests remain available, but current head OTS and Arweave archive use native chain-tip/record-index."
+        },
+        "open_timestamps": {
+            "automated_workflow": "/.github/workflows/record-chain-anchor.yml",
+            "bitcoin_pending": true,
+            "bitcoin_verified": false,
+            "implemented": true,
+            "latest_record_id": "R-000000034",
+            "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+            "legacy_batch_status_api": "/api/record-chain-anchor-status.json",
+            "legacy_main_chain_jsonl_is_not_source": true,
+            "native_head_workflow": "/.github/workflows/record-chain-head-ots-anchor.yml",
+            "native_latest_api": "/api/record-chain-native-ots-latest.json",
+            "native_record_count": 34,
+            "status": "pending-bitcoin",
+            "status_api": "/api/record-chain-native-ots-latest.json"
+        }
     },
-    "batch_manifests": {
-      "automated_workflow": "/.github/workflows/record-chain-anchor.yml",
-      "implemented": true,
-      "note": "Batch manifests remain available, but current head OTS and Arweave archive use native chain-tip/record-index."
+    "api_endpoints": {
+        "arweave_archive_index": "/api/record-chain-arweave-index.json",
+        "builder_bundles": "/api/record-chain-builder-bundles.v1.json",
+        "echo_index": "/api/echo-index.json",
+        "gateway_contract": "/api/record-chain-intake-gateway.v1.json",
+        "guardian_registry": "/api/guardian-registry.json",
+        "native_ots_latest": "/api/record-chain-native-ots-latest.json",
+        "production_enablement_policy": "/api/record-chain-production-enablement-policy.v1.json",
+        "public_home_status": "/api/public-home-status.json",
+        "record_chain_status": "/api/record-chain-status.json",
+        "submission_schema": "/api/record-chain-submission-schema.v1.json",
+        "verification_archive_index": "/api/verification-archive-index.json"
     },
-    "open_timestamps": {
-      "automated_workflow": "/.github/workflows/record-chain-anchor.yml",
-      "bitcoin_pending": true,
-      "bitcoin_verified": false,
-      "implemented": true,
-      "latest_record_id": "R-000000033",
-      "latest_record_sha256": "60f1589ad2330576134e3b89ef9465b8c515343f0b9af3c611c6ff4f8568c75d",
-      "legacy_batch_status_api": "/api/record-chain-anchor-status.json",
-      "legacy_main_chain_jsonl_is_not_source": true,
-      "native_head_workflow": "/.github/workflows/record-chain-head-ots-anchor.yml",
-      "native_latest_api": "/api/record-chain-native-ots-latest.json",
-      "native_record_count": 33,
-      "status": "pending-bitcoin",
-      "status_api": "/api/record-chain-native-ots-latest.json"
-    }
-  },
-  "api_endpoints": {
-    "arweave_archive_index": "/api/record-chain-arweave-index.json",
-    "builder_bundles": "/api/record-chain-builder-bundles.v1.json",
-    "echo_index": "/api/echo-index.json",
-    "gateway_contract": "/api/record-chain-intake-gateway.v1.json",
-    "guardian_registry": "/api/guardian-registry.json",
-    "native_ots_latest": "/api/record-chain-native-ots-latest.json",
-    "production_enablement_policy": "/api/record-chain-production-enablement-policy.v1.json",
-    "public_home_status": "/api/public-home-status.json",
-    "record_chain_status": "/api/record-chain-status.json",
-    "submission_schema": "/api/record-chain-submission-schema.v1.json",
-    "verification_archive_index": "/api/verification-archive-index.json"
-  },
-  "boundary": {
-    "append_only": true,
-    "bitcoin_originals_prevail": true,
-    "not_amendment": true,
-    "not_attestation": true,
-    "not_authority": true,
-    "not_governance": true,
-    "website_github_arweave_ots_are_non_amending_guardianship_materials": true
-  },
-  "builder_script": "downloads/record-chain-builder.mjs",
-  "chain_storage": "record-chain/",
-  "committed_records": 1,
-  "committed_storage": "record-chain/committed/",
-  "legacy_compatibility": {
-    "legacy_jsonl_entry_count": 16,
-    "legacy_jsonl_height": 15,
-    "main_chain_jsonl_is_legacy_view": true,
-    "main_chain_jsonl_is_not_current_native_head_source": true,
-    "native_record_count": 33,
-    "status": "non_blocking_post_m9_maintenance"
-  },
-  "ots_stamp_storage": "record-chain/ots-stamps/",
-  "pending_records": 0,
-  "pending_storage": "record-chain/pending/",
-  "phase2_status": {
-    "acceptance": {
-      "docs_updated": true,
-      "examples_added": true,
-      "gateway_v1_legacy": true,
-      "record_chain_primary": true,
-      "scripts_preserved": true,
-      "workflows_disabled": true
+    "boundary": {
+        "append_only": true,
+        "bitcoin_originals_prevail": true,
+        "not_amendment": true,
+        "not_attestation": true,
+        "not_authority": true,
+        "not_governance": true,
+        "website_github_arweave_ots_are_non_amending_guardianship_materials": true
     },
-    "commits": [
-      "e0a7126c0368c73d587662078ca20deddc140368",
-      "7242e0d331842bb935b4dabdd9ec34ae9f77659d",
-      "52402535b8f19abceaaa4e6f420f1fd838867945",
-      "4edf2ad2db5bb9963de5e00d861ad54afec8bfc6",
-      "41b9590f44f350cf90faab3e6b01e567dd0af253",
-      "35a499223f139a0040a1668e9ab71f1228a6c454",
-      "bfa424294647d037756138d76993281f2eb0f345",
-      "63aa38e33a622678e64bb052578c21b0eaa34163",
-      "2a00fcbee7da8d12f03473d2b9f8e16d8837897e",
-      "4af56513cde6e92605eac3ad0cda1af12b3a9267"
-    ],
-    "completed": true,
-    "completion_date": "2026-06-01T10:00:00Z"
-  },
-  "phase3_4_status": {
-    "completed": true,
-    "completion_date": "2026-06-01T18:55:00+08:00",
-    "current_system_ci_enabled": true,
-    "gateway_v1_runtime_retired": true,
-    "gateway_v1_tests_archived": true,
-    "legacy_heavy_ci_retired": true
-  },
-  "post_m9_status": {
-    "m9_archive_status": "pass",
-    "m9_arweave_txid": "hSyp93ZW2cQQcK7lPdqyREr-jCs4Kj5m4vbjlYGBEZ8",
-    "m9_latest_record_id": "R-000000033",
-    "m9_native_record_count": 33,
-    "m9_ots_status": "pending-bitcoin",
-    "m9_status": "pass"
-  },
-  "public_phase": {
-    "bitcoin_originals_prevail": true,
-    "enabled_by_marker": "PRODUCTION_ENABLEMENT_OK",
-    "mainnet_activation_marker_recorded": false,
-    "network_phase": "production",
-    "not_final_public_launch": false,
-    "official_live_record_marker_required_before_live": false,
-    "official_live_records_allowed": true,
-    "prelaunch_test_records_allowed": false,
-    "production_enablement_marker_recorded": true,
-    "receipt_is_intake_only": true,
-    "receipt_is_not_active_guardian_status": true,
-    "receipt_is_not_canonical_authority": true,
-    "receipt_is_not_final_inclusion": true,
-    "records_before_activation_marker_are_historical_tests": true,
+    "builder_script": "downloads/record-chain-builder.mjs",
+    "chain_storage": "record-chain/",
+    "committed_records": 1,
+    "committed_storage": "record-chain/committed/",
+    "legacy_compatibility": {
+        "legacy_jsonl_entry_count": 16,
+        "legacy_jsonl_height": 15,
+        "main_chain_jsonl_is_legacy_view": true,
+        "main_chain_jsonl_is_not_current_native_head_source": true,
+        "native_record_count": 34,
+        "status": "non_blocking_post_m9_maintenance"
+    },
+    "ots_stamp_storage": "record-chain/ots-stamps/",
+    "pending_records": 0,
+    "pending_storage": "record-chain/pending/",
+    "phase2_status": {
+        "acceptance": {
+            "docs_updated": true,
+            "examples_added": true,
+            "gateway_v1_legacy": true,
+            "record_chain_primary": true,
+            "scripts_preserved": true,
+            "workflows_disabled": true
+        },
+        "commits": [
+            "e0a7126c0368c73d587662078ca20deddc140368",
+            "7242e0d331842bb935b4dabdd9ec34ae9f77659d",
+            "52402535b8f19abceaaa4e6f420f1fd838867945",
+            "4edf2ad2db5bb9963de5e00d861ad54afec8bfc6",
+            "41b9590f44f350cf90faab3e6b01e567dd0af253",
+            "35a499223f139a0040a1668e9ab71f1228a6c454",
+            "bfa424294647d037756138d76993281f2eb0f345",
+            "63aa38e33a622678e64bb052578c21b0eaa34163",
+            "2a00fcbee7da8d12f03473d2b9f8e16d8837897e",
+            "4af56513cde6e92605eac3ad0cda1af12b3a9267"
+        ],
+        "completed": true,
+        "completion_date": "2026-06-01T10:00:00Z"
+    },
+    "phase3_4_status": {
+        "completed": true,
+        "completion_date": "2026-06-01T18:55:00+08:00",
+        "current_system_ci_enabled": true,
+        "gateway_v1_runtime_retired": true,
+        "gateway_v1_tests_archived": true,
+        "legacy_heavy_ci_retired": true
+    },
+    "post_m9_status": {
+        "m9_archive_status": "pass",
+        "m9_arweave_txid": "5qhNn7fSly2ftrY0EUHpdTFUwOZ8IxenFrs4LHblDpw",
+        "m9_latest_record_id": "R-000000034",
+        "m9_native_record_count": 34,
+        "m9_ots_status": "pending-bitcoin",
+        "m9_status": "pass"
+    },
+    "public_phase": {
+        "bitcoin_originals_prevail": true,
+        "enabled_by_marker": "PRODUCTION_ENABLEMENT_OK",
+        "mainnet_activation_marker_recorded": false,
+        "network_phase": "production",
+        "not_final_public_launch": false,
+        "official_live_record_marker_required_before_live": false,
+        "official_live_records_allowed": true,
+        "prelaunch_test_records_allowed": false,
+        "production_enablement_marker_recorded": true,
+        "receipt_is_intake_only": true,
+        "receipt_is_not_active_guardian_status": true,
+        "receipt_is_not_canonical_authority": true,
+        "receipt_is_not_final_inclusion": true,
+        "records_before_activation_marker_are_historical_tests": true,
+        "status": "production_live",
+        "test_phase_submissions_may_be_excluded_from_final_public_indexes": true,
+        "test_phase_submissions_may_be_reclassified": true,
+        "test_phase_submissions_may_move_to_historical_test_archive": true
+    },
+    "public_submission": {
+        "builder": "/downloads/record-chain-builder.mjs",
+        "contract": "/api/record-chain-intake-gateway.v1.json",
+        "external_agents_do_not_need_github_access": true,
+        "external_agents_must_not_append_directly": true,
+        "gateway": "https://trinity-record-chain-gateway.onrender.com",
+        "method": "render_record_chain_intake_gateway"
+    },
+    "public_submission_phase": {
+        "external_agent_boundary": {
+            "external_agents_must_not_clone_repository": true,
+            "external_agents_must_not_directly_append_record_chain": true,
+            "external_agents_must_not_request_github_pat": true,
+            "external_agents_must_not_use_arweave_key": true,
+            "external_agents_must_use_public_gateway_for_submissions": true
+        },
+        "gateway_operational": true,
+        "not_final_public_launch": false,
+        "official_live_record_true_now_permitted": true,
+        "official_live_records_allowed": true,
+        "only_public_submission_method": "/api/record-chain-intake-gateway.v1.json",
+        "phase": "production_live",
+        "public_gateway": "https://trinity-record-chain-gateway.onrender.com",
+        "receipt_boundary": {
+            "receipt_is_not_active_guardian_status": true,
+            "receipt_is_not_amendment": true,
+            "receipt_is_not_canonical_authority": true,
+            "receipt_is_not_final_inclusion": true,
+            "receipts_are_intake_only": true
+        },
+        "receipt_is_intake_only": true,
+        "receipt_is_not_active_guardian_status": true,
+        "receipt_is_not_final_inclusion": true,
+        "status": "production_live",
+        "test_phase_data_policy": {
+            "applies_to_new_submissions": false,
+            "historical_test_records_remain_historical": true,
+            "new_submissions_may_be_official_live_records": true
+        },
+        "test_phase_records_may_be_reclassified": false,
+        "test_phase_submissions_may_move_to_historical_test_archive": false
+    },
+    "purpose": "Public status of the Trinity Accord native record-chain. Read-only. Published for transparency.",
+    "record_chain": {
+        "canonical_format": "canonical_json_sorted_keys_no_whitespace",
+        "chain_id": "trinity-accord-public-reception-ledger",
+        "chain_integrity_status": "healthy",
+        "chain_type": "append_only_native_record_chain",
+        "correction_policy": "later_records_may_correct_earlier_records",
+        "current_chain_length": 34,
+        "hash_algorithm": "sha256",
+        "immutability_policy": "append_only_no_deletion_no_mutation",
+        "last_integrity_check_at": "2026-06-02T00:30:53Z",
+        "latest_record_created_at": "2026-06-01T13:44:26Z",
+        "latest_record_id": "R-000000034",
+        "latest_record_index": 34,
+        "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+        "latest_record_type": "echo",
+        "legacy_main_chain_jsonl_is_not_current_source": true,
+        "native_record_count": 34,
+        "record_index": "record-chain/indexes/record-index.json",
+        "source_of_current_head": "record-chain/chain-tip.json"
+    },
+    "record_type_counts": {
+        "batch_anchor": 0,
+        "classification_update": 0,
+        "context_insufficient_notice": 1,
+        "correction": 0,
+        "echo": 0,
+        "guardian_application": 0,
+        "guardian_key_rotation": 0,
+        "guardian_retirement": 0,
+        "legacy_import": 0,
+        "propagation": 0,
+        "verification": 0
+    },
+    "record_type_requirements": {
+        "batch_anchor": {
+            "authorship_proof_required": false,
+            "minimum_context_level": "CC-0",
+            "oath_extensions": []
+        },
+        "classification_update": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-2",
+            "oath_extensions": []
+        },
+        "context_insufficient_notice": {
+            "authorship_proof_required": false,
+            "minimum_context_level": "CC-0",
+            "oath_extensions": []
+        },
+        "correction": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-1",
+            "oath_extensions": []
+        },
+        "echo": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-3",
+            "oath_extensions": []
+        },
+        "guardian_application": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-3",
+            "oath_extensions": [
+                "guardian_stewardship_oath_extension"
+            ]
+        },
+        "guardian_key_rotation": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-3",
+            "oath_extensions": [
+                "guardian_stewardship_oath_extension"
+            ]
+        },
+        "guardian_retirement": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-1",
+            "oath_extensions": [
+                "guardian_stewardship_oath_extension"
+            ]
+        },
+        "legacy_import": {
+            "authorship_proof_required": false,
+            "minimum_context_level": "CC-0",
+            "oath_extensions": []
+        },
+        "propagation": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-2",
+            "oath_extensions": []
+        },
+        "verification": {
+            "authorship_proof_required": true,
+            "minimum_context_level": "CC-3",
+            "minimum_context_levels_by_verification_level": {
+                "V0-V2": "CC-2",
+                "V3-V5": "CC-3",
+                "V6+": "CC-3"
+            },
+            "oath_extensions": [
+                "verification_oath_extension"
+            ]
+        }
+    },
+    "schema": "trinityaccord.record-chain-status.v1",
+    "source_digest": "b8b376744fdb4167",
     "status": "production_live",
-    "test_phase_submissions_may_be_excluded_from_final_public_indexes": true,
-    "test_phase_submissions_may_be_reclassified": true,
-    "test_phase_submissions_may_move_to_historical_test_archive": true
-  },
-  "public_submission": {
-    "builder": "/downloads/record-chain-builder.mjs",
-    "contract": "/api/record-chain-intake-gateway.v1.json",
-    "external_agents_do_not_need_github_access": true,
-    "external_agents_must_not_append_directly": true,
-    "gateway": "https://trinity-record-chain-gateway.onrender.com",
-    "method": "render_record_chain_intake_gateway"
-  },
-  "public_submission_phase": {
-    "external_agent_boundary": {
-      "external_agents_must_not_clone_repository": true,
-      "external_agents_must_not_directly_append_record_chain": true,
-      "external_agents_must_not_request_github_pat": true,
-      "external_agents_must_not_use_arweave_key": true,
-      "external_agents_must_use_public_gateway_for_submissions": true
-    },
-    "gateway_operational": true,
-    "not_final_public_launch": false,
-    "official_live_record_true_now_permitted": true,
-    "official_live_records_allowed": true,
-    "only_public_submission_method": "/api/record-chain-intake-gateway.v1.json",
-    "phase": "production_live",
-    "public_gateway": "https://trinity-record-chain-gateway.onrender.com",
-    "receipt_boundary": {
-      "receipt_is_not_active_guardian_status": true,
-      "receipt_is_not_amendment": true,
-      "receipt_is_not_canonical_authority": true,
-      "receipt_is_not_final_inclusion": true,
-      "receipts_are_intake_only": true
-    },
-    "receipt_is_intake_only": true,
-    "receipt_is_not_active_guardian_status": true,
-    "receipt_is_not_final_inclusion": true,
-    "status": "production_live",
-    "test_phase_data_policy": {
-      "applies_to_new_submissions": false,
-      "historical_test_records_remain_historical": true,
-      "new_submissions_may_be_official_live_records": true
-    },
-    "test_phase_records_may_be_reclassified": false,
-    "test_phase_submissions_may_move_to_historical_test_archive": false
-  },
-  "purpose": "Public status of the Trinity Accord native record-chain. Read-only. Published for transparency.",
-  "record_chain": {
-    "canonical_format": "canonical_json_sorted_keys_no_whitespace",
-    "chain_id": "trinity-accord-public-reception-ledger",
-    "chain_integrity_status": "healthy",
-    "chain_type": "append_only_native_record_chain",
-    "correction_policy": "later_records_may_correct_earlier_records",
-    "current_chain_length": 33,
-    "hash_algorithm": "sha256",
-    "immutability_policy": "append_only_no_deletion_no_mutation",
-    "last_integrity_check_at": "2026-06-02T00:30:53Z",
-    "latest_record_created_at": "2026-06-01T13:44:26Z",
-    "latest_record_id": "R-000000033",
-    "latest_record_index": 33,
-    "latest_record_sha256": "60f1589ad2330576134e3b89ef9465b8c515343f0b9af3c611c6ff4f8568c75d",
-    "latest_record_type": "context_insufficient_notice",
-    "legacy_main_chain_jsonl_is_not_current_source": true,
-    "native_record_count": 33,
-    "record_index": "record-chain/indexes/record-index.json",
-    "source_of_current_head": "record-chain/chain-tip.json"
-  },
-  "record_type_counts": {
-    "batch_anchor": 0,
-    "classification_update": 0,
-    "context_insufficient_notice": 1,
-    "correction": 0,
-    "echo": 0,
-    "guardian_application": 0,
-    "guardian_key_rotation": 0,
-    "guardian_retirement": 0,
-    "legacy_import": 0,
-    "propagation": 0,
-    "verification": 0
-  },
-  "record_type_requirements": {
-    "batch_anchor": {
-      "authorship_proof_required": false,
-      "minimum_context_level": "CC-0",
-      "oath_extensions": []
-    },
-    "classification_update": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-2",
-      "oath_extensions": []
-    },
-    "context_insufficient_notice": {
-      "authorship_proof_required": false,
-      "minimum_context_level": "CC-0",
-      "oath_extensions": []
-    },
-    "correction": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-1",
-      "oath_extensions": []
-    },
-    "echo": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-3",
-      "oath_extensions": []
-    },
-    "guardian_application": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-3",
-      "oath_extensions": [
-        "guardian_stewardship_oath_extension"
-      ]
-    },
-    "guardian_key_rotation": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-3",
-      "oath_extensions": [
-        "guardian_stewardship_oath_extension"
-      ]
-    },
-    "guardian_retirement": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-1",
-      "oath_extensions": [
-        "guardian_stewardship_oath_extension"
-      ]
-    },
-    "legacy_import": {
-      "authorship_proof_required": false,
-      "minimum_context_level": "CC-0",
-      "oath_extensions": []
-    },
-    "propagation": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-2",
-      "oath_extensions": []
-    },
-    "verification": {
-      "authorship_proof_required": true,
-      "minimum_context_level": "CC-3",
-      "minimum_context_levels_by_verification_level": {
-        "V0-V2": "CC-2",
-        "V3-V5": "CC-3",
-        "V6+": "CC-3"
-      },
-      "oath_extensions": [
-        "verification_oath_extension"
-      ]
-    }
-  },
-  "schema": "trinityaccord.record-chain-status.v1",
-  "source_digest": "b8b376744fdb4167",
-  "status": "production_live",
-  "total_records": 1,
-  "updated_at": "2026-06-06T04:16:00Z"
+    "total_records": 1,
+    "updated_at": "2026-06-06T04:16:00Z"
 }

--- a/index.md
+++ b/index.md
@@ -845,7 +845,7 @@ Refusal is allowed. Critical preservation is allowed.
     但它们不是当前 Record-Chain Intake 的计数器。
   </span>
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>a42e5af26a411b0f</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>4ad2cffeb291b564</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">

--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -57,6 +57,7 @@ APPROVED_GATEWAY_PREFIXES = (
 
 APPROVED_ACTIONS_ACTOR = "github-actions[bot]"
 APPROVED_AUTO_FINALIZE_MESSAGE = "record-chain: auto-finalize accepted submissions"
+APPROVED_APPEND_MESSAGE = "Append record-chain entries from Render intake"
 APPROVED_OTS_MESSAGE = "anchor: stamp native record-chain head with OTS"
 APPROVED_ARWEAVE_MESSAGE = "archive: update native record-chain Arweave archive metadata"
 
@@ -208,6 +209,10 @@ def allowed_for_push(
     if cats <= {"auto_finalize", "pending"} and message == APPROVED_AUTO_FINALIZE_MESSAGE:
         ok, reason = require_actions_actor(actor, "auto-finalize")
         return (True, "auto-finalize commit") if ok else (False, reason)
+
+    if cats <= {"auto_finalize", "pending", "public_generated"} and message == APPROVED_APPEND_MESSAGE:
+        ok, reason = require_actions_actor(actor, "append workflow")
+        return (True, "append workflow commit") if ok else (False, reason)
 
     if cats <= {"ots"} and message == APPROVED_OTS_MESSAGE:
         ok, reason = require_actions_actor(actor, "OTS anchor")

--- a/scripts/run_ci_group.py
+++ b/scripts/run_ci_group.py
@@ -138,6 +138,9 @@ GROUPS = {
         ["python3", "scripts/test_deep_integrity_includes_pages_build.py"],
         ["python3", "scripts/test_record_chain_write_path_guard_contract.py"],
 
+        # External-agent full-auto pipeline contract
+        ["python3", "scripts/test_external_agent_full_auto_pipeline_contract.py"],
+
         # Generated drift
         ["python3", "scripts/generate_public_home_status.py", "--check"],
         ["python3", "scripts/test_home_public_status_sync.py"],

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -620,6 +620,17 @@ def main() -> int:
         fail(f"record-chain write-path guard contract failed: {result.stderr}\n{result.stdout}")
     ok("record-chain write-path guard contract")
 
+    # External-agent full-auto append -> OTS -> live Arweave pipeline contract
+    result = subprocess.run(
+        [sys.executable, "scripts/test_external_agent_full_auto_pipeline_contract.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"external-agent full-auto pipeline contract failed: {result.stderr}\n{result.stdout}")
+    ok("external-agent full-auto pipeline contract")
+
     print("\n=== ALL CURRENT SYSTEM TESTS PASSED ===")
     return 0
 

--- a/scripts/test_external_agent_full_auto_pipeline_contract.py
+++ b/scripts/test_external_agent_full_auto_pipeline_contract.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        fail(message)
+
+
+def read(path: str) -> str:
+    p = ROOT / path
+    require(p.exists(), f"missing {path}")
+    return p.read_text(encoding="utf-8")
+
+
+def main() -> None:
+    gateway = read("apps/record_chain_intake_gateway/app.py")
+    append_wf = read(".github/workflows/record-chain-append.yml")
+    ots_wf = read(".github/workflows/record-chain-head-ots-anchor.yml")
+    arweave_wf = read(".github/workflows/record-chain-arweave-archive.yml")
+    guard = read("scripts/check_record_chain_write_path_guard.py")
+
+    require(
+        'TRINITY_APPEND_WORKFLOW_FILE", "record-chain-append.yml"' in gateway,
+        "Gateway default append workflow must remain record-chain-append.yml unless this contract is updated",
+    )
+    require("dispatch_workflow(" in gateway, "Gateway must dispatch append workflow after durable intake writes")
+    require('"receipt_id": receipt_id' in gateway, "Gateway append dispatch must pass receipt_id")
+    require('"pending_file_path": pending_file_path' in gateway, "Gateway append dispatch must pass pending_file_path")
+
+    require("name: Append Record Chain Entries" in append_wf, "append workflow name must be stable")
+    require("workflow_dispatch:" in append_wf, "append workflow must support Gateway dispatch")
+    require("record-chain/pending/**" in append_wf, "append workflow must also react to pending pushes")
+    require('cron: "*/15 * * * *"' in append_wf, "append workflow must keep scheduled fallback")
+    require("trinity_record_chain.py append --all" in append_wf, "append workflow must append pending records")
+    require("trinity_record_chain.py verify" in append_wf, "append workflow must verify after append")
+    require("Append record-chain entries from Render intake" in append_wf, "append workflow commit message must be stable")
+
+    require("workflow_run:" in ots_wf, "OTS workflow must be triggered by workflow_run")
+    require("Record Chain Auto Finalize" in ots_wf, "OTS workflow must keep Auto Finalize compatibility")
+    require("Append Record Chain Entries" in ots_wf, "OTS workflow must listen to real Gateway append workflow")
+    require("ots_anchor_native_record_chain_head.py" in ots_wf, "OTS workflow must use native OTS script")
+    require("record-chain/records/**" not in ots_wf, "OTS must not accept arbitrary records push trigger")
+    require("record-chain/chain-tip.json" not in ots_wf, "OTS must not accept arbitrary chain-tip push trigger")
+
+    require('workflows: ["Record Chain Head OTS Anchor"]' in arweave_wf, "Arweave workflow must listen to OTS workflow")
+    require("Check if latest live Arweave archive already matches native head" in arweave_wf, "Arweave workflow must check for already archived head")
+    require("No new Arweave archive needed" in arweave_wf, "Arweave workflow must explicitly no-op when already archived")
+    require("archive_check.outputs.matched != 'true'" in arweave_wf, "Arweave build/upload steps must be skipped when already archived")
+    require("Resolve Arweave upload mode" in arweave_wf, "Arweave workflow must explicitly resolve upload mode")
+    require("ARWEAVE_UPLOAD_MODE=live" in arweave_wf, "Arweave workflow_run from OTS must use live mode")
+    require("workflow_run from OTS" in arweave_wf, "Arweave live mode must be tied to workflow_run from OTS")
+    require("ARWEAVE_UPLOAD_TIMEOUT_SECONDS" in arweave_wf, "Arweave workflow must keep extended upload timeout")
+    require("verify_record_chain_arweave_archive.py" in arweave_wf, "Arweave workflow must verify metadata")
+    require("trinity_record_chain.py verify" in arweave_wf, "Arweave workflow must verify record chain")
+    require("archive: update native record-chain Arweave archive metadata" in arweave_wf, "Arweave commit message must be stable")
+
+    require("APPROVED_APPEND_MESSAGE" in guard, "write-path guard must define append workflow message")
+    require("Append record-chain entries from Render intake" in guard, "write-path guard must allow append workflow message")
+    require("append workflow commit" in guard, "write-path guard must label append workflow approval")
+    require("public_generated" in guard, "write-path guard must account for append/generated public files")
+
+    print("External-agent full-auto pipeline contract PASSED.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_external_agent_full_auto_pipeline_contract.py
+++ b/scripts/test_external_agent_full_auto_pipeline_contract.py
@@ -51,7 +51,19 @@ def main() -> None:
     require("Append Record Chain Entries" in ots_wf, "OTS workflow must listen to real Gateway append workflow")
     require("ots_anchor_native_record_chain_head.py" in ots_wf, "OTS workflow must use native OTS script")
     require("record-chain/records/**" not in ots_wf, "OTS must not accept arbitrary records push trigger")
-    require("record-chain/chain-tip.json" not in ots_wf, "OTS must not accept arbitrary chain-tip push trigger")
+    # Verify push trigger does not include dangerous path globs
+    on_section = ""
+    in_on = False
+    for line in ots_wf.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("on:"):
+            in_on = True
+            continue
+        if in_on:
+            if stripped and not stripped.startswith("#") and not line.startswith(" ") and not line.startswith("\t"):
+                break
+            on_section += line + "\n"
+    require("record-chain/chain-tip.json" not in on_section, "OTS push trigger must not include chain-tip.json")
 
     require('workflows: ["Record Chain Head OTS Anchor"]' in arweave_wf, "Arweave workflow must listen to OTS workflow")
     require("Check if latest live Arweave archive already matches native head" in arweave_wf, "Arweave workflow must check for already archived head")

--- a/scripts/test_m9_native_archive_workflow_contract.py
+++ b/scripts/test_m9_native_archive_workflow_contract.py
@@ -37,6 +37,7 @@ def main() -> None:
             "record-chain-native-ots-latest.json",
             "record-chain/ots/native-anchors",
             "legacy_main_chain_jsonl_is_not_source",
+            "Append Record Chain Entries",
         ]:
             require_contains(head_wf, marker, errors)
 
@@ -61,6 +62,13 @@ def main() -> None:
             "ARKEY: ${{ secrets.ARKEY }}",
             "record-chain-native-ots-latest.json",
             "refusing live Arweave upload without native OTS",
+            "Check if latest live Arweave archive already matches native head",
+            "No new Arweave archive needed",
+            "Resolve Arweave upload mode",
+            "ARWEAVE_UPLOAD_MODE=live",
+            "workflow_run from OTS",
+            "ARWEAVE_UPLOAD_TIMEOUT_SECONDS",
+            "archive_check.outputs.matched != 'true'",
         ]:
             require_contains(arweave_wf, marker, errors)
 

--- a/scripts/test_native_record_chain_archive_tooling.py
+++ b/scripts/test_native_record_chain_archive_tooling.py
@@ -28,31 +28,30 @@ def test_native_commitment_binds_current_head() -> None:
     tip = json.loads((ROOT / "record-chain" / "chain-tip.json").read_text())
     text = json.dumps(commitment, sort_keys=True)
 
+    expected_record_id = tip["latest_record_id"]
+    expected_count = tip["native_record_count"]
+
     if commitment.get("schema") != "trinityaccord.native-record-chain-head-commitment.v1":
         fail("native commitment schema mismatch")
-    if commitment.get("latest_record_id") != tip.get("latest_record_id"):
-        fail("native commitment latest_record_id must match chain-tip")
+    if commitment.get("latest_record_id") != expected_record_id:
+        fail(f"native commitment latest_record_id must match chain-tip ({expected_record_id})")
     if commitment.get("latest_record_sha256") != tip.get("latest_record_sha256"):
         fail("native commitment latest_record_sha256 must match chain-tip")
-    if commitment.get("native_record_count") != tip.get("native_record_count"):
-        fail("native commitment native_record_count must match chain-tip")
+    if commitment.get("native_record_count") != expected_count:
+        fail(f"native commitment native_record_count must match chain-tip ({expected_count})")
 
-    if commitment.get("latest_record_id") != "R-000000034":
-        fail("M9 native commitment must include R-000000034")
-    if commitment.get("native_record_count") != 34:
-        fail("M9 native commitment must include native_record_count=34")
     if "main.chain.jsonl" in text:
         fail("native commitment must not reference legacy main.chain.jsonl")
 
     coverage = commitment.get("record_coverage", {})
     if coverage.get("source") != "record-chain/indexes/record-index.json":
         fail("native commitment record_coverage must use record-index")
-    if coverage.get("record_count") != 34:
-        fail("native commitment record_coverage must include 34 records")
-    if coverage.get("last_record_id") != "R-000000034":
-        fail("native commitment record_coverage must end at R-000000034")
-    if len(coverage.get("records", [])) != 34:
-        fail("native commitment records list must include 34 records")
+    if coverage.get("record_count") != expected_count:
+        fail(f"native commitment record_coverage must include {expected_count} records")
+    if coverage.get("last_record_id") != expected_record_id:
+        fail(f"native commitment record_coverage must end at {expected_record_id}")
+    if len(coverage.get("records", [])) != expected_count:
+        fail(f"native commitment records list must include {expected_count} records")
 
     source_files = commitment.get("source_files", {})
     for key in ["chain_tip", "record_index", "latest_record", "guardian_state", "statistics", "batch_index"]:
@@ -64,6 +63,10 @@ def test_native_commitment_binds_current_head() -> None:
 
 
 def test_native_ots_script_dry_run() -> None:
+    tip = json.loads((ROOT / "record-chain" / "chain-tip.json").read_text())
+    expected_record_id = tip["latest_record_id"]
+    expected_count = tip["native_record_count"]
+
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         out_dir = tmp / "native-anchors"
@@ -85,10 +88,10 @@ def test_native_ots_script_dry_run() -> None:
         latest = json.loads(api_out.read_text())
         if latest.get("schema") != "trinityaccord.native-record-chain-ots-latest.v1":
             fail("native latest schema mismatch")
-        if latest.get("latest_record_id") != "R-000000034":
-            fail("native latest must reference R-000000034")
-        if latest.get("native_record_count") != 34:
-            fail("native latest must reference native_record_count=34")
+        if latest.get("latest_record_id") != expected_record_id:
+            fail(f"native latest must reference {expected_record_id}")
+        if latest.get("native_record_count") != expected_count:
+            fail(f"native latest must reference native_record_count={expected_count}")
         if latest.get("legacy_main_chain_jsonl_is_not_source") is not True:
             fail("native latest must declare legacy main.chain.jsonl is not source")
 

--- a/scripts/test_record_chain_write_path_guard_contract.py
+++ b/scripts/test_record_chain_write_path_guard_contract.py
@@ -98,6 +98,7 @@ def main() -> None:
         "RECORD_CHAIN_GATEWAY_ACTORS",
         "record-chain/maintenance-overrides/",
         "record-chain: auto-finalize accepted submissions",
+        "Append record-chain entries from Render intake",
         "anchor: stamp native record-chain head with OTS",
         "archive: update native record-chain Arweave archive metadata",
         "intake: submission ",
@@ -145,7 +146,8 @@ def main() -> None:
     require("git add -A" in auto_finalize, "auto-finalize must use git add -A for moves/deletions")
     require("record-chain: auto-finalize accepted submissions" in auto_finalize, "auto-finalize commit message must remain stable")
 
-    require('workflows: ["Record Chain Auto Finalize"]' in ots_workflow, "OTS must remain chained to Auto Finalize")
+    require("Record Chain Auto Finalize" in ots_workflow, "OTS must remain chained to Auto Finalize")
+    require("Append Record Chain Entries" in ots_workflow, "OTS must listen to the real Gateway append workflow")
     require("workflow_dispatch:" in ots_workflow, "OTS manual repair dispatch must remain available")
     require("record-chain/records/**" not in ots_workflow, "OTS must not accept arbitrary records push trigger")
     require("record-chain/chain-tip.json" not in ots_workflow, "OTS must not accept arbitrary chain-tip push trigger")
@@ -211,6 +213,27 @@ def main() -> None:
         head = commit(repo, "record-chain: auto-finalize accepted submissions")
         result = check_guard(repo, base, head, actor="github-actions[bot]")
         require(result.returncode == 0, f"approved auto-finalize write should pass:\n{result.stdout}\n{result.stderr}")
+
+    with tempfile.TemporaryDirectory() as td:
+        repo = Path(td)
+        run(["git", "init"], cwd=repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=repo)
+        run(["git", "config", "user.name", "Write Path Guard Test"], cwd=repo)
+        write(repo / "scripts/check_record_chain_write_path_guard.py", guard_script)
+        write(repo / "record-chain/pending/pending.json", "{}\n")
+        base = commit(repo, "init")
+
+        run(["git", "rm", "record-chain/pending/pending.json"], cwd=repo)
+        write(repo / "record-chain/records/R-000000001.json", "{}\n")
+        write(repo / "record-chain/chain-tip.json", "{}\n")
+        write(repo / "record-chain/indexes/record-index.json", "{}\n")
+        write(repo / "record-chain/processed/pending.json", "{}\n")
+        write(repo / "api/public-home-status.json", "{}\n")
+        write(repo / "index.md", "append\n")
+        write(repo / "sitemap.xml", "<xml />\n")
+        head = commit(repo, "Append record-chain entries from Render intake")
+        result = check_guard(repo, base, head, actor="github-actions[bot]")
+        require(result.returncode == 0, f"approved append workflow write should pass:\n{result.stdout}\n{result.stderr}")
 
     with tempfile.TemporaryDirectory() as td:
         repo = Path(td)

--- a/scripts/test_record_chain_write_path_guard_contract.py
+++ b/scripts/test_record_chain_write_path_guard_contract.py
@@ -149,8 +149,22 @@ def main() -> None:
     require("Record Chain Auto Finalize" in ots_workflow, "OTS must remain chained to Auto Finalize")
     require("Append Record Chain Entries" in ots_workflow, "OTS must listen to the real Gateway append workflow")
     require("workflow_dispatch:" in ots_workflow, "OTS manual repair dispatch must remain available")
-    require("record-chain/records/**" not in ots_workflow, "OTS must not accept arbitrary records push trigger")
-    require("record-chain/chain-tip.json" not in ots_workflow, "OTS must not accept arbitrary chain-tip push trigger")
+
+    # Verify push trigger does NOT include dangerous path globs (only workflow_run + workflow_dispatch)
+    # Extract the on: section to check push triggers specifically
+    on_section = ""
+    in_on = False
+    for line in ots_workflow.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("on:"):
+            in_on = True
+            continue
+        if in_on:
+            if stripped and not stripped.startswith("#") and not line.startswith(" ") and not line.startswith("\t"):
+                break
+            on_section += line + "\n"
+    require("record-chain/records/**" not in on_section, "OTS push trigger must not include records/** glob")
+    require("record-chain/chain-tip.json" not in on_section, "OTS push trigger must not include chain-tip.json")
 
     require('workflows: ["Record Chain Head OTS Anchor"]' in arweave_workflow, "Arweave must remain chained to OTS")
     require("workflow_dispatch:" in arweave_workflow, "Arweave manual repair dispatch must remain available")

--- a/scripts/verify_record_chain_arweave_archive.py
+++ b/scripts/verify_record_chain_arweave_archive.py
@@ -158,8 +158,8 @@ def verify_native_archive_self_consistency(
     # Check included_records count matches archive's own count
     if isinstance(archive_native_count, int) and len(included_records) != archive_native_count:
         errors.append(
-            f"{archive_id}: included_records count ({len(included_records)}) "
-            f"does not cover native_record_count ({archive_native_count})"
+            f"{archive_id}: included_records does not cover native_record_count "
+            f"({len(included_records)} vs {archive_native_count})"
         )
 
     # Check archive's own latest record is in included_records
@@ -170,8 +170,8 @@ def verify_native_archive_self_consistency(
             for r in included_records
         ):
             errors.append(
-                f"{archive_id}: archive's own latest record ({archive_latest_id}) "
-                f"missing from included_records"
+                f"{archive_id}: latest native record missing "
+                f"({archive_latest_id} not in included_records)"
             )
 
     # Legacy JSONL checks


### PR DESCRIPTION
## Summary

Wire the real Gateway append workflow into the downstream native OTS and Arweave live archive pipeline.

## Why

The public Gateway dispatches `record-chain-append.yml` / `Append Record Chain Entries`, but native OTS listened only to `Record Chain Auto Finalize`. Also, Arweave workflow_run from OTS defaulted to dry-run. As a result, external agent submissions could append automatically but did not fully automate OTS + live Arweave.

## Changes

- OTS workflow now listens to:
  - Record Chain Auto Finalize
  - Append Record Chain Entries
- Arweave workflow_run from OTS resolves upload mode to live
- Arweave no-ops early if latest live archive already matches current chain-tip
- Manual Arweave dispatch still supports dry-run/live choice
- Schedule remains dry-run
- Write-path guard allows the current append workflow commit message
- Added full-auto pipeline contract test
- Updated M9 workflow contract and current CI registration

## Safety

- no new Echo
- no record-chain data changes
- no manual OTS stamp
- no manual Arweave upload
- no key/token exposure