### PR TITLE
ci: add scanner-backed record-chain archive pipeline

### DIFF
--- a/.github/workflows/record-chain-append.yml
+++ b/.github/workflows/record-chain-append.yml
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   append:
@@ -55,25 +56,41 @@ jobs:
           git pull --rebase origin "${GITHUB_REF_NAME:-main}"
       - run: python scripts/trinity_record_chain.py append --all
       - run: python scripts/trinity_record_chain.py verify
-      - name: Regenerate public homepage counters
+      - name: Regenerate phase-aware public status and homepage counters
         run: |
+          python scripts/generate_record_chain_status.py
           python scripts/generate_public_home_status.py
           python scripts/generate_sitemap.py
       - name: Commit and push append updates
+        id: append_commit
         run: |
           set -euo pipefail
+          printf '%s\n' "committed=false" >> "$GITHUB_OUTPUT"
+
           if ! git diff --quiet; then
             git config user.name "trinity-record-chain-bot"
             git config user.email "actions@github.com"
-            git add record-chain/ index.md api/public-home-status.json sitemap.xml
+            git add record-chain/ api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
             git commit -m "Append record-chain entries from Render intake"
+
             for attempt in 1 2 3; do
               if git push origin "HEAD:${GITHUB_REF_NAME:-main}"; then
+                printf '%s\n' "committed=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
-              echo "Push failed on attempt ${attempt}; rebasing and retrying."
+              printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
               git pull --rebase origin "${GITHUB_REF_NAME:-main}"
             done
-            echo "::error::Failed to push append updates after retries."
+
+            printf '%s\n' "::error::Failed to push append updates after retries."
             exit 1
           fi
+
+      - name: Dispatch native OTS anchor workflow
+        if: steps.append_commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "Dispatching Record Chain Head OTS Anchor on main"
+          gh workflow run record-chain-head-ots-anchor.yml --ref main

--- a/.github/workflows/record-chain-arweave-archive.yml
+++ b/.github/workflows/record-chain-arweave-archive.yml
@@ -18,7 +18,7 @@ on:
           - dry-run
           - live
   schedule:
-    - cron: "43 2 * * *"
+    - cron: "*/30 * * * *"
 
 concurrency:
   group: record-chain-arweave-archive
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -49,52 +50,32 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      - name: Rebase before Arweave scan
+        run: |
+          set -euo pipefail
+          git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+
+      - name: Detect Arweave backlog
+        id: backlog
+        run: |
+          python3 scripts/detect_record_chain_pipeline_backlog.py --github-output > /tmp/pipeline-backlog.env
+          cat /tmp/pipeline-backlog.env >> "$GITHUB_OUTPUT"
+          cat /tmp/pipeline-backlog.env
+
       - name: Resolve Arweave upload mode
         id: mode
         run: |
           printf 'ARWEAVE_UPLOAD_MODE=%s\n' "${ARWEAVE_UPLOAD_MODE}" >> "$GITHUB_OUTPUT"
           printf 'Resolved ARWEAVE_UPLOAD_MODE=%s\n' "${ARWEAVE_UPLOAD_MODE}"
 
-      - name: Check if latest live Arweave archive already matches native head
-        id: archive_check
+      - name: Wait for native OTS
+        if: steps.backlog.outputs.ots_matches_chain != 'true'
         run: |
-          python3 - <<'PY' > /tmp/archive-check.env
-          import json
-          from pathlib import Path
-
-          tip = json.loads(Path("record-chain/chain-tip.json").read_text())
-          arweave_path = Path("api/record-chain-arweave-index.json")
-          if not arweave_path.exists():
-              print("matched=false")
-              exit()
-
-          arweave = json.loads(arweave_path.read_text())
-          live = [
-              a for a in arweave.get("archives", [])
-              if a.get("source_type") == "native-record-chain"
-              and a.get("mode") == "live"
-              and a.get("arweave_txid")
-          ]
-          if not live:
-              print("matched=false")
-              exit()
-
-          live.sort(key=lambda a: (a.get("native_record_count") or 0, a.get("created_at") or ""))
-          latest = live[-1]
-          matched = (
-              latest.get("native_latest_record_id") == tip.get("latest_record_id")
-              and latest.get("native_latest_record_sha256") == tip.get("latest_record_sha256")
-              and latest.get("native_record_count") == tip.get("native_record_count")
-          )
-          if matched:
-              print("No new Arweave archive needed")
-          print(f"matched={'true' if matched else 'false'}")
-          PY
-          cat /tmp/archive-check.env >> "$GITHUB_OUTPUT"
-          cat /tmp/archive-check.env
+          printf '%s\n' "Native OTS is behind current chain-tip; waiting for OTS scanner."
+          printf 'chain=%s ots=%s\n' "${{ steps.backlog.outputs.chain_latest_record_id }}" "${{ steps.backlog.outputs.ots_latest_record_id }}"
 
       - name: Verify native OTS latest before archive
-        if: steps.archive_check.outputs.matched != 'true'
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         run: |
           python3 - <<'PY'
           import json
@@ -130,33 +111,49 @@ jobs:
           PY
 
       - name: Build Arweave archive manifest
-        if: steps.archive_check.outputs.matched != 'true'
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         env:
           ARKEY: ${{ secrets.ARKEY }}
           ARWEAVE_UPLOAD_TIMEOUT_SECONDS: "600"
         run: python scripts/build_record_chain_arweave_archive.py --mode "${ARWEAVE_UPLOAD_MODE}"
 
       - name: Verify Arweave archive metadata
-        if: steps.archive_check.outputs.matched != 'true'
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         run: python scripts/verify_record_chain_arweave_archive.py
 
       - name: Verify record chain
-        if: steps.archive_check.outputs.matched != 'true'
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         run: python scripts/trinity_record_chain.py verify
 
-      - name: Regenerate public homepage counters
-        if: steps.archive_check.outputs.matched != 'true'
+      - name: Regenerate public status and homepage counters
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         run: |
+          python scripts/generate_record_chain_status.py
           python scripts/generate_public_home_status.py
           python scripts/generate_sitemap.py
 
       - name: Commit Arweave archive metadata
-        if: steps.archive_check.outputs.matched != 'true'
+        if: steps.backlog.outputs.arweave_archive_needed == 'true'
         run: |
-          if ! git diff --quiet; then
-            git config user.name "trinity-record-chain-bot"
-            git config user.email "actions@github.com"
-            git add record-chain/arweave-archives/ api/record-chain-arweave-index.json index.md api/public-home-status.json sitemap.xml
-            git commit -m "archive: update native record-chain Arweave archive metadata"
-            git push
+          set -euo pipefail
+
+          if git diff --quiet; then
+            printf '%s\n' "No Arweave archive metadata changes."
+            exit 0
           fi
+
+          git config user.name "trinity-record-chain-bot"
+          git config user.email "actions@github.com"
+          git add record-chain/arweave-archives/ api/record-chain-arweave-index.json api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
+          git commit -m "archive: update native record-chain Arweave archive metadata"
+
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${GITHUB_REF_NAME:-main}"; then
+              exit 0
+            fi
+            printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+            git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+          done
+
+          printf '%s\n' "::error::Failed to push Arweave archive metadata after retries."
+          exit 1

--- a/.github/workflows/record-chain-head-ots-anchor.yml
+++ b/.github/workflows/record-chain-head-ots-anchor.yml
@@ -7,9 +7,12 @@ on:
       - "Record Chain Auto Finalize"
       - "Append Record Chain Entries"
     types: [completed]
+  schedule:
+    - cron: "*/15 * * * *"
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: record-chain-head-ots-anchor
@@ -23,6 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -31,42 +35,30 @@ jobs:
       - name: Install Python dependencies for native OTS
         run: python -m pip install -r requirements-ci.txt
 
+      - name: Rebase before native OTS scan
+        run: |
+          set -euo pipefail
+          git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+
       - name: Verify native record chain
         run: python3 scripts/trinity_record_chain.py verify
 
-      - name: Check if native OTS latest already matches native head
-        id: check
+      - name: Detect OTS backlog
+        id: backlog
         run: |
-          python3 - <<'PY' > /tmp/native-ots-check.env
-          import json
-          from pathlib import Path
-
-          tip = json.loads(Path("record-chain/chain-tip.json").read_text())
-          ots_path = Path("api/record-chain-native-ots-latest.json")
-          ots = json.loads(ots_path.read_text()) if ots_path.exists() else {}
-
-          matched = (
-              ots.get("latest_record_id") == tip.get("latest_record_id")
-              and ots.get("latest_record_sha256") == tip.get("latest_record_sha256")
-              and ots.get("native_record_count") == tip.get("native_record_count")
-              and ots.get("legacy_main_chain_jsonl_is_not_source") is True
-          )
-          print(f"matched={'true' if matched else 'false'}")
-          print(f"latest_record_id={tip.get('latest_record_id')}")
-          print(f"native_record_count={tip.get('native_record_count')}")
-          PY
-          cat /tmp/native-ots-check.env >> "$GITHUB_OUTPUT"
-          cat /tmp/native-ots-check.env
+          python3 scripts/detect_record_chain_pipeline_backlog.py --github-output > /tmp/pipeline-backlog.env
+          cat /tmp/pipeline-backlog.env >> "$GITHUB_OUTPUT"
+          cat /tmp/pipeline-backlog.env
 
       - name: Stamp native record-chain head
-        if: steps.check.outputs.matched != 'true'
+        if: steps.backlog.outputs.ots_anchor_needed == 'true'
         run: |
           python3 scripts/ots_anchor_native_record_chain_head.py \
             --mode stamp \
             --overwrite
 
       - name: Verify native OTS output
-        if: steps.check.outputs.matched != 'true'
+        if: steps.backlog.outputs.ots_anchor_needed == 'true'
         run: |
           python3 - <<'PY'
           import json
@@ -105,14 +97,40 @@ jobs:
           PY
 
       - name: Commit native OTS anchor
-        if: steps.check.outputs.matched != 'true'
+        id: ots_commit
+        if: steps.backlog.outputs.ots_anchor_needed == 'true'
         run: |
+          set -euo pipefail
+          printf '%s\n' "committed=false" >> "$GITHUB_OUTPUT"
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add record-chain/ots/native-anchors api/record-chain-native-ots-latest.json
+
           if git diff --cached --quiet; then
             printf '%s\n' "No native OTS anchor changes."
-          else
-            git commit -m "anchor: stamp native record-chain head with OTS"
-            git push
+            exit 0
           fi
+
+          git commit -m "anchor: stamp native record-chain head with OTS"
+
+          for attempt in 1 2 3; do
+            if git push origin "HEAD:${GITHUB_REF_NAME:-main}"; then
+              printf '%s\n' "committed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+            git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+          done
+
+          printf '%s\n' "::error::Failed to push native OTS anchor after retries."
+          exit 1
+
+      - name: Dispatch live Arweave archive workflow
+        if: steps.ots_commit.outputs.committed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          printf '%s\n' "Dispatching Record Chain Arweave Archive in live mode"
+          gh workflow run record-chain-arweave-archive.yml --ref main -f upload_mode=live

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-09T02:26:41.332016+00:00",
+  "generated_at": "2026-06-09T03:41:03.199201+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -59,7 +59,8 @@
         "latest_anchor_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.anchor.json",
         "latest_anchored_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.native-record-chain-head-commitment.json",
         "latest_ots_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.native-record-chain-head-commitment.json.ots",
-        "ots_status": "pending"
+        "ots_status": "pending",
+        "anchor_needed": true
       },
       "arweave_archive": {
         "arweave_archive_is_mirror_only": true,
@@ -81,7 +82,9 @@
         "latest_archive_id": "archive-native-R-000000034-aff1ad601f17",
         "latest_manifest_path": "record-chain/arweave-archives/archive-native-R-000000034-aff1ad601f17/manifest.json",
         "latest_native_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
-        "record_count": 34
+        "record_count": 34,
+        "status": "waiting-for-native-ots",
+        "archive_needed": false
       },
       "anchor_status": {
         "batch_count": 1,

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -53,7 +53,7 @@
         "native_head_workflow": "/.github/workflows/record-chain-head-ots-anchor.yml",
         "native_latest_api": "/api/record-chain-native-ots-latest.json",
         "native_record_count": 34,
-        "status": "pending-bitcoin",
+        "status": "anchor-needed",
         "status_api": "/api/record-chain-native-ots-latest.json",
         "latest_record_index": 34,
         "latest_anchor_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.anchor.json",

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -11,7 +11,7 @@
     "/api/guardian-registry.json",
     "/api/agent-declared-verification-index.json"
   ],
-  "source_digest": "5937f667408f9d34",
+  "source_digest": "c2e799a7cd3a7076",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 35,

--- a/api/record-chain-status.json
+++ b/api/record-chain-status.json
@@ -20,7 +20,9 @@
       "latest_archive_id": "archive-native-R-000000034-aff1ad601f17",
       "latest_manifest_path": "record-chain/arweave-archives/archive-native-R-000000034-aff1ad601f17/manifest.json",
       "latest_native_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
-      "record_count": 34
+      "record_count": 34,
+      "status": "waiting-for-native-ots",
+      "archive_needed": false
     },
     "batch_manifests": {
       "automated_workflow": "/.github/workflows/record-chain-anchor.yml",
@@ -39,13 +41,14 @@
       "native_head_workflow": "/.github/workflows/record-chain-head-ots-anchor.yml",
       "native_latest_api": "/api/record-chain-native-ots-latest.json",
       "native_record_count": 34,
-      "status": "pending-bitcoin",
+      "status": "anchor-needed",
       "status_api": "/api/record-chain-native-ots-latest.json",
       "latest_record_index": 34,
       "latest_anchor_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.anchor.json",
       "latest_anchored_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.native-record-chain-head-commitment.json",
       "latest_ots_file": "record-chain/ots/native-anchors/native-record-34-R-000000034-aac1593720622ba4-3ca459e1b9b74f60.native-record-chain-head-commitment.json.ots",
-      "ots_status": "pending"
+      "ots_status": "pending",
+      "anchor_needed": true
     }
   },
   "api_endpoints": {
@@ -79,7 +82,7 @@
     "legacy_jsonl_height": 15,
     "main_chain_jsonl_is_legacy_view": true,
     "main_chain_jsonl_is_not_current_native_head_source": true,
-    "native_record_count": 34,
+    "native_record_count": 35,
     "status": "non_blocking_post_m9_maintenance"
   },
   "ots_stamp_storage": "record-chain/ots-stamps/",
@@ -118,13 +121,13 @@
     "legacy_heavy_ci_retired": true
   },
   "post_m9_status": {
-    "m9_archive_status": "pass",
+    "m9_archive_status": "backlog",
     "m9_arweave_txid": "5qhNn7fSly2ftrY0EUHpdTFUwOZ8IxenFrs4LHblDpw",
-    "m9_latest_record_id": "R-000000034",
-    "m9_native_record_count": 34,
-    "m9_ots_status": "pending-bitcoin",
-    "m9_status": "pass",
-    "m9_latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+    "m9_latest_record_id": "R-000000035",
+    "m9_native_record_count": 35,
+    "m9_ots_status": "anchor-needed",
+    "m9_status": "backlog",
+    "m9_latest_record_sha256": "4ef3b8e23046eb7b00f1dd22522d769259ed133b3c2dcfca4597ee690e81b8f5",
     "m9_arweave_archive_id": "archive-native-R-000000034-aff1ad601f17",
     "m9_arweave_manifest_path": "record-chain/arweave-archives/archive-native-R-000000034-aff1ad601f17/manifest.json"
   },
@@ -197,17 +200,17 @@
     "chain_integrity_status": "healthy",
     "chain_type": "append_only_native_record_chain",
     "correction_policy": "later_records_may_correct_earlier_records",
-    "current_chain_length": 34,
+    "current_chain_length": 35,
     "hash_algorithm": "sha256",
     "immutability_policy": "append_only_no_deletion_no_mutation",
     "last_integrity_check_at": "2026-06-02T00:30:53Z",
-    "latest_record_created_at": "2026-06-08T10:08:35.724Z",
-    "latest_record_id": "R-000000034",
-    "latest_record_index": 34,
-    "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+    "latest_record_created_at": "2026-06-09T02:24:57.518Z",
+    "latest_record_id": "R-000000035",
+    "latest_record_index": 35,
+    "latest_record_sha256": "4ef3b8e23046eb7b00f1dd22522d769259ed133b3c2dcfca4597ee690e81b8f5",
     "latest_record_type": "echo",
     "legacy_main_chain_jsonl_is_not_current_source": true,
-    "native_record_count": 34,
+    "native_record_count": 35,
     "record_index": "record-chain/indexes/record-index.json",
     "source_of_current_head": "record-chain/chain-tip.json",
     "latest_batch_id": "batch-000001",
@@ -218,7 +221,7 @@
     "classification_update": 0,
     "context_insufficient_notice": 1,
     "correction": 0,
-    "echo": 17,
+    "echo": 18,
     "guardian_application": 5,
     "guardian_key_rotation": 0,
     "guardian_retirement": 0,
@@ -300,5 +303,33 @@
   "source_digest": "b8b376744fdb4167",
   "status": "production_live",
   "total_records": 1,
-  "updated_at": "2026-06-06T04:16:00Z"
+  "updated_at": "2026-06-06T04:16:00Z",
+  "pipeline_status": {
+    "chain_head": {
+      "latest_record_id": "R-000000035",
+      "latest_record_sha256": "4ef3b8e23046eb7b00f1dd22522d769259ed133b3c2dcfca4597ee690e81b8f5",
+      "native_record_count": 35
+    },
+    "ots_head": {
+      "latest_record_id": "R-000000034",
+      "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+      "native_record_count": 34,
+      "ots_status": "pending",
+      "bitcoin_pending": true,
+      "bitcoin_verified": false
+    },
+    "arweave_head": {
+      "latest_record_id": "R-000000034",
+      "latest_record_sha256": "aac1593720622ba45222856786a6f524b43541439b3f9ade6a573e26b8b987e6",
+      "native_record_count": 34,
+      "archive_id": "archive-native-R-000000034-aff1ad601f17",
+      "arweave_txid": "5qhNn7fSly2ftrY0EUHpdTFUwOZ8IxenFrs4LHblDpw"
+    },
+    "ots_matches_chain": false,
+    "arweave_matches_ots": true,
+    "arweave_matches_chain": false,
+    "ots_anchor_needed": true,
+    "arweave_archive_needed": false,
+    "pipeline_current": false
+  }
 }

--- a/index.md
+++ b/index.md
@@ -814,7 +814,7 @@ Refusal is allowed. Critical preservation is allowed.
   <article class="status-card">
     <p class="status-label">Anchoring and archive status</p>
     <p class="status-number">Active</p>
-    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: pending-bitcoin. Arweave archive: live mirror active; latest tx 5qhNn7fSly2f.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：pending-bitcoin。Arweave 归档：live mirror active; latest tx 5qhNn7fSly2f...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
+    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: anchor-needed. Arweave archive: live mirror active; latest tx 5qhNn7fSly2f.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：anchor-needed。Arweave 归档：live mirror active; latest tx 5qhNn7fSly2f...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">Verifiability</p>
@@ -845,7 +845,7 @@ Refusal is allowed. Critical preservation is allowed.
     但它们不是当前 Record-Chain Intake 的计数器。
   </span>
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>5937f667408f9d34</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>c2e799a7cd3a7076</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">
@@ -904,3 +904,4 @@ Refusal is allowed. Critical preservation is allowed.
 - Pure Echo
 - V0–V5 verification
 - Guardian Alliance Stage 1
+

--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -41,6 +41,7 @@ ARWEAVE_PREFIXES = ("record-chain/arweave-archives/",)
 ARWEAVE_FILES = {"api/record-chain-arweave-index.json"}
 
 PUBLIC_GENERATED_FILES = {
+    "api/record-chain-status.json",
     "api/public-home-status.json",
     "index.md",
     "sitemap.xml",
@@ -273,3 +274,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/detect_record_chain_pipeline_backlog.py
+++ b/scripts/detect_record_chain_pipeline_backlog.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN_TIP = ROOT / "record-chain/chain-tip.json"
+OTS_LATEST = ROOT / "api/record-chain-native-ots-latest.json"
+ARWEAVE_INDEX = ROOT / "api/record-chain-arweave-index.json"
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def latest_live_native_archive(index: dict[str, Any]) -> dict[str, Any] | None:
+    live = [
+        a for a in index.get("archives", [])
+        if a.get("source_type") == "native-record-chain"
+        and a.get("mode") == "live"
+        and a.get("arweave_txid")
+    ]
+    if not live:
+        return None
+    live.sort(key=lambda a: (a.get("native_record_count") or 0, a.get("created_at") or ""))
+    return live[-1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--github-output", action="store_true")
+    args = parser.parse_args()
+
+    tip = read_json(CHAIN_TIP)
+    ots = read_json(OTS_LATEST)
+    ar = latest_live_native_archive(read_json(ARWEAVE_INDEX)) or {}
+
+    chain_id = tip.get("latest_record_id") or ""
+    chain_sha = tip.get("latest_record_sha256") or ""
+    chain_count = tip.get("native_record_count") or ""
+
+    ots_id = ots.get("latest_record_id") or ""
+    ots_sha = ots.get("latest_record_sha256") or ""
+    ots_count = ots.get("native_record_count") or ""
+
+    ar_id = ar.get("native_latest_record_id") or ""
+    ar_sha = ar.get("native_latest_record_sha256") or ""
+    ar_count = ar.get("native_record_count") or ""
+
+    ots_matches_chain = (
+        ots_id == chain_id
+        and ots_sha == chain_sha
+        and ots_count == chain_count
+        and ots.get("legacy_main_chain_jsonl_is_not_source") is True
+    )
+
+    arweave_matches_ots = (
+        ar_id == ots_id
+        and ar_sha == ots_sha
+        and ar_count == ots_count
+        and bool(ar_id)
+    )
+
+    arweave_matches_chain = (
+        ar_id == chain_id
+        and ar_sha == chain_sha
+        and ar_count == chain_count
+        and bool(ar_id)
+    )
+
+    result = {
+        "chain_latest_record_id": chain_id,
+        "chain_latest_record_sha256": chain_sha,
+        "chain_native_record_count": str(chain_count),
+        "ots_latest_record_id": ots_id,
+        "ots_latest_record_sha256": ots_sha,
+        "ots_native_record_count": str(ots_count),
+        "arweave_latest_record_id": ar_id,
+        "arweave_latest_record_sha256": ar_sha,
+        "arweave_native_record_count": str(ar_count),
+        "ots_matches_chain": str(ots_matches_chain).lower(),
+        "arweave_matches_ots": str(arweave_matches_ots).lower(),
+        "arweave_matches_chain": str(arweave_matches_chain).lower(),
+        "ots_anchor_needed": str(not ots_matches_chain).lower(),
+        "arweave_archive_needed": str(ots_matches_chain and not arweave_matches_ots).lower(),
+        "pipeline_current": str(ots_matches_chain and arweave_matches_chain).lower(),
+    }
+
+    if args.github_output:
+        for key, value in result.items():
+            print(f"{key}={value}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_record_chain_status.py
+++ b/scripts/generate_record_chain_status.py
@@ -64,7 +64,11 @@ def record_type_counts(records: list[dict[str, Any]]) -> dict[str, int]:
     return dict(sorted(counts.items()))
 
 
-def latest_live_native_archive(arweave: dict[str, Any], tip: dict[str, Any]) -> dict[str, Any]:
+def latest_live_native_archive(arweave: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the latest live native Arweave archive, or None if none exist.
+
+    Does NOT require chain-tip equality — the caller decides what to do with lag.
+    """
     live = [
         a for a in arweave.get("archives", [])
         if a.get("source_type") == "native-record-chain"
@@ -72,16 +76,65 @@ def latest_live_native_archive(arweave: dict[str, Any], tip: dict[str, Any]) -> 
         and a.get("arweave_txid")
     ]
     if not live:
-        raise SystemExit("no live native Arweave archive found")
+        return None
     live.sort(key=lambda a: (a.get("native_record_count") or 0, a.get("created_at") or ""))
-    latest = live[-1]
-    if latest.get("native_latest_record_id") != tip.get("latest_record_id"):
-        raise SystemExit("latest live native Arweave record id does not match chain-tip")
-    if latest.get("native_latest_record_sha256") != tip.get("latest_record_sha256"):
-        raise SystemExit("latest live native Arweave sha does not match chain-tip")
-    if latest.get("native_record_count") != tip.get("native_record_count"):
-        raise SystemExit("latest live native Arweave count does not match chain-tip")
-    return latest
+    return live[-1]
+
+
+def build_pipeline_status(tip: dict[str, Any], ots: dict[str, Any], latest_live: dict[str, Any] | None) -> dict[str, Any]:
+    chain_head = {
+        "latest_record_id": tip.get("latest_record_id"),
+        "latest_record_sha256": tip.get("latest_record_sha256"),
+        "native_record_count": tip.get("native_record_count"),
+    }
+    ots_head = {
+        "latest_record_id": ots.get("latest_record_id"),
+        "latest_record_sha256": ots.get("latest_record_sha256"),
+        "native_record_count": ots.get("native_record_count"),
+        "ots_status": ots.get("ots_status"),
+        "bitcoin_pending": ots.get("bitcoin_pending"),
+        "bitcoin_verified": ots.get("bitcoin_verified"),
+    }
+    arweave_head = {
+        "latest_record_id": (latest_live or {}).get("native_latest_record_id"),
+        "latest_record_sha256": (latest_live or {}).get("native_latest_record_sha256"),
+        "native_record_count": (latest_live or {}).get("native_record_count"),
+        "archive_id": (latest_live or {}).get("archive_id"),
+        "arweave_txid": (latest_live or {}).get("arweave_txid"),
+    }
+
+    ots_matches_chain = (
+        ots_head["latest_record_id"] == chain_head["latest_record_id"]
+        and ots_head["latest_record_sha256"] == chain_head["latest_record_sha256"]
+        and ots_head["native_record_count"] == chain_head["native_record_count"]
+        and ots.get("legacy_main_chain_jsonl_is_not_source") is True
+    )
+
+    arweave_matches_ots = (
+        arweave_head["latest_record_id"] == ots_head["latest_record_id"]
+        and arweave_head["latest_record_sha256"] == ots_head["latest_record_sha256"]
+        and arweave_head["native_record_count"] == ots_head["native_record_count"]
+        and bool(arweave_head["latest_record_id"])
+    )
+
+    arweave_matches_chain = (
+        arweave_head["latest_record_id"] == chain_head["latest_record_id"]
+        and arweave_head["latest_record_sha256"] == chain_head["latest_record_sha256"]
+        and arweave_head["native_record_count"] == chain_head["native_record_count"]
+        and bool(arweave_head["latest_record_id"])
+    )
+
+    return {
+        "chain_head": chain_head,
+        "ots_head": ots_head,
+        "arweave_head": arweave_head,
+        "ots_matches_chain": ots_matches_chain,
+        "arweave_matches_ots": arweave_matches_ots,
+        "arweave_matches_chain": arweave_matches_chain,
+        "ots_anchor_needed": not ots_matches_chain,
+        "arweave_archive_needed": ots_matches_chain and not arweave_matches_ots,
+        "pipeline_current": ots_matches_chain and arweave_matches_chain,
+    }
 
 
 def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
@@ -111,16 +164,11 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
     if len(records) != native_count:
         raise SystemExit(f"record-index length {len(records)} != native_count {native_count}")
 
-    if ots.get("latest_record_id") != latest_id:
-        raise SystemExit("native OTS latest id does not match chain-tip")
-    if ots.get("latest_record_sha256") != latest_sha:
-        raise SystemExit("native OTS latest sha does not match chain-tip")
-    if ots.get("native_record_count") != native_count:
-        raise SystemExit("native OTS count does not match chain-tip")
     if ots.get("bitcoin_verified") is True and ots.get("ots_status") != "verified":
         raise SystemExit("invalid OTS state: bitcoin_verified true but ots_status is not verified")
 
-    latest_live = latest_live_native_archive(arweave, tip)
+    latest_live = latest_live_native_archive(arweave)
+    pipeline = build_pipeline_status(tip, ots, latest_live)
 
     latest_type = latest_record.get("record_type") or latest_record.get("type")
     latest_created_at = latest_record.get("created_at") or latest_record.get("assigned_at")
@@ -138,6 +186,8 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
         rc["latest_batch_id"] = tip.get("latest_batch_id")
     if "latest_batch_manifest_sha256" in tip:
         rc["latest_batch_manifest_sha256"] = tip.get("latest_batch_manifest_sha256")
+
+    status["pipeline_status"] = pipeline
 
     status.setdefault("legacy_compatibility", {})
     status["legacy_compatibility"]["native_record_count"] = native_count
@@ -163,7 +213,14 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
     ot["bitcoin_pending"] = ots.get("bitcoin_pending")
     ot["bitcoin_verified"] = ots.get("bitcoin_verified")
     ot["legacy_main_chain_jsonl_is_not_source"] = ots.get("legacy_main_chain_jsonl_is_not_source")
-    ot["status"] = "verified-bitcoin" if ots.get("bitcoin_verified") is True else "pending-bitcoin"
+    ot["status"] = (
+        "verified-bitcoin"
+        if ots.get("bitcoin_verified") is True
+        else "current-pending-bitcoin"
+        if pipeline["ots_matches_chain"] and ots.get("ots_status") == "pending"
+        else "anchor-needed"
+    )
+    ot["anchor_needed"] = pipeline["ots_anchor_needed"]
 
     status["anchoring"].setdefault("arweave_archive", {})
     aa = status["anchoring"]["arweave_archive"]
@@ -176,12 +233,20 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
     aa["live_upload_implemented"] = arweave.get("live_upload_implemented")
     aa["live_archive_count"] = arweave.get("live_archive_count")
     aa["latest_arweave_txid"] = arweave.get("latest_arweave_txid")
-    aa["latest_archive_id"] = latest_live.get("archive_id")
-    aa["latest_manifest_path"] = latest_live.get("manifest_path")
-    aa["latest_native_record_id"] = latest_live.get("native_latest_record_id")
-    aa["latest_native_record_sha256"] = latest_live.get("native_latest_record_sha256")
-    aa["native_record_count"] = latest_live.get("native_record_count")
-    aa["record_count"] = latest_live.get("record_count")
+    aa["latest_archive_id"] = (latest_live or {}).get("archive_id")
+    aa["latest_manifest_path"] = (latest_live or {}).get("manifest_path")
+    aa["latest_native_record_id"] = (latest_live or {}).get("native_latest_record_id")
+    aa["latest_native_record_sha256"] = (latest_live or {}).get("native_latest_record_sha256")
+    aa["native_record_count"] = (latest_live or {}).get("native_record_count")
+    aa["record_count"] = (latest_live or {}).get("record_count")
+    aa["status"] = (
+        "current"
+        if pipeline["arweave_matches_chain"]
+        else "archive-needed"
+        if pipeline["arweave_archive_needed"]
+        else "waiting-for-native-ots"
+    )
+    aa["archive_needed"] = pipeline["arweave_archive_needed"]
     aa.setdefault("default_mode", "dry-run")
     aa.setdefault("arweave_archive_is_mirror_only", True)
     aa.setdefault("arweave_archive_is_not_authority", True)
@@ -190,15 +255,15 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
 
     status.setdefault("post_m9_status", {})
     m9 = status["post_m9_status"]
-    m9["m9_status"] = "pass"
-    m9["m9_archive_status"] = "pass"
+    m9["m9_status"] = "pass" if pipeline["pipeline_current"] else "backlog"
+    m9["m9_archive_status"] = "pass" if pipeline["arweave_matches_chain"] else "backlog"
     m9["m9_latest_record_id"] = latest_id
     m9["m9_latest_record_sha256"] = latest_sha
     m9["m9_native_record_count"] = native_count
     m9["m9_ots_status"] = ot["status"]
     m9["m9_arweave_txid"] = arweave.get("latest_arweave_txid")
-    m9["m9_arweave_archive_id"] = latest_live.get("archive_id")
-    m9["m9_arweave_manifest_path"] = latest_live.get("manifest_path")
+    m9["m9_arweave_archive_id"] = (latest_live or {}).get("archive_id")
+    m9["m9_arweave_manifest_path"] = (latest_live or {}).get("manifest_path")
 
     return status
 

--- a/scripts/ots_anchor_native_record_chain_head.py
+++ b/scripts/ots_anchor_native_record_chain_head.py
@@ -51,13 +51,17 @@ def main() -> None:
     commitment_text = json.dumps(commitment, sort_keys=True)
     if "main.chain.jsonl" in commitment_text:
         raise SystemExit("native commitment must not reference legacy main.chain.jsonl")
-    if commitment.get("latest_record_id") != "R-000000034":
+
+    tip = json.loads((root / "record-chain" / "chain-tip.json").read_text(encoding="utf-8"))
+    expected_id = tip.get("latest_record_id")
+    expected_count = tip.get("native_record_count")
+    if commitment.get("latest_record_id") != expected_id:
         raise SystemExit(
-            f"M9.3 native archive must include R-000000034, got {commitment.get('latest_record_id')}"
+            f"M9.3 native archive must include {expected_id}, got {commitment.get('latest_record_id')}"
         )
-    if commitment.get("native_record_count") != 34:
+    if commitment.get("native_record_count") != expected_count:
         raise SystemExit(
-            f"M9.3 native archive must include native_record_count=34, got {commitment.get('native_record_count')}"
+            f"M9.3 native archive must include native_record_count={expected_count}, got {commitment.get('native_record_count')}"
         )
 
     commitment_bytes = canonical_json_bytes(commitment)

--- a/scripts/run_ci_group.py
+++ b/scripts/run_ci_group.py
@@ -139,6 +139,9 @@ GROUPS = {
         ["python3", "scripts/test_record_chain_write_path_guard_contract.py"],
         ["python3", "scripts/test_external_agent_full_auto_pipeline_contract.py"],
 
+        # Pipeline backlog detector
+        ["python3", "scripts/detect_record_chain_pipeline_backlog.py"],
+
         # Generated drift
         ["python3", "scripts/generate_record_chain_status.py", "--check"],
         ["python3", "scripts/generate_public_home_status.py", "--check"],
@@ -523,3 +526,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -106,6 +106,17 @@ def main() -> int:
         fail(f"record-chain status drift detected:\n{result.stdout}\n{result.stderr}")
     ok("record-chain status up to date")
 
+    # 1c2. pipeline backlog detector smoke
+    result = subprocess.run(
+        [sys.executable, "scripts/detect_record_chain_pipeline_backlog.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"pipeline backlog detector failed:\n{result.stdout}\n{result.stderr}")
+    ok("pipeline backlog detector")
+
     # 1d. public homepage status drift check
     result = subprocess.run(
         [sys.executable, "scripts/generate_public_home_status.py", "--check"],
@@ -658,3 +669,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/scripts/test_external_agent_full_auto_pipeline_contract.py
+++ b/scripts/test_external_agent_full_auto_pipeline_contract.py
@@ -29,6 +29,7 @@ def main() -> None:
     ots_workflow = read(".github/workflows/record-chain-head-ots-anchor.yml")
     arweave_workflow = read(".github/workflows/record-chain-arweave-archive.yml")
     guard_script = read("scripts/check_record_chain_write_path_guard.py")
+    detector_script = read("scripts/detect_record_chain_pipeline_backlog.py")
 
     # Gateway default append workflow
     require(
@@ -48,6 +49,40 @@ def main() -> None:
         "append workflow must use stable commit message 'Append record-chain entries from Render intake'",
     )
 
+    # Append must have actions: write permission
+    require(
+        "actions: write" in append_workflow,
+        "append workflow must have actions: write permission for dispatching OTS",
+    )
+
+    # Append must generate record-chain-status before public-home
+    require(
+        "generate_record_chain_status.py" in append_workflow,
+        "append workflow must generate record-chain-status",
+    )
+    status_pos = append_workflow.index("generate_record_chain_status.py")
+    home_pos = append_workflow.index("generate_public_home_status.py")
+    require(
+        status_pos < home_pos,
+        "record-chain-status must be generated before public-home status in append workflow",
+    )
+
+    # Append must commit api/record-chain-status.json
+    require(
+        "api/record-chain-status.json" in append_workflow,
+        "append workflow must commit api/record-chain-status.json",
+    )
+
+    # Append must dispatch OTS after successful commit
+    require(
+        "gh workflow run record-chain-head-ots-anchor.yml" in append_workflow,
+        "append workflow must dispatch native OTS anchor workflow after commit",
+    )
+    require(
+        "append_commit" in append_workflow,
+        "append workflow must track commit output for conditional dispatch",
+    )
+
     # OTS listens to Append Record Chain Entries
     require(
         '"Append Record Chain Entries"' in ots_workflow,
@@ -58,6 +93,48 @@ def main() -> None:
     require(
         '"Record Chain Auto Finalize"' in ots_workflow,
         "OTS workflow must still listen to 'Record Chain Auto Finalize'",
+    )
+
+    # OTS must have schedule scanner
+    require(
+        "schedule:" in ots_workflow,
+        "OTS workflow must have schedule scanner",
+    )
+    require(
+        "*/15 * * * *" in ots_workflow,
+        "OTS workflow must scan every 15 minutes",
+    )
+
+    # OTS must have actions: write permission
+    require(
+        "actions: write" in ots_workflow,
+        "OTS workflow must have actions: write permission for dispatching Arweave",
+    )
+
+    # OTS must use backlog detector
+    require(
+        "detect_record_chain_pipeline_backlog.py" in ots_workflow,
+        "OTS workflow must use pipeline backlog detector",
+    )
+    require(
+        "ots_anchor_needed" in ots_workflow,
+        "OTS workflow must check ots_anchor_needed from detector",
+    )
+
+    # OTS must dispatch Arweave after successful push
+    require(
+        "gh workflow run record-chain-arweave-archive.yml" in ots_workflow,
+        "OTS workflow must dispatch Arweave archive workflow after successful push",
+    )
+    require(
+        "-f upload_mode=live" in ots_workflow,
+        "OTS dispatch to Arweave must use live upload mode",
+    )
+
+    # OTS must have rebase/retry on push
+    require(
+        "git pull --rebase origin" in ots_workflow,
+        "OTS workflow must rebase before push retry",
     )
 
     # Arweave workflow_run from OTS resolves to live
@@ -75,18 +152,54 @@ def main() -> None:
         "Arweave workflow_run trigger must resolve to live upload mode",
     )
 
+    # Arweave must have 30-minute schedule scanner
+    require(
+        "*/30 * * * *" in arweave_workflow,
+        "Arweave workflow must scan every 30 minutes",
+    )
+
+    # Arweave must use backlog detector
+    require(
+        "detect_record_chain_pipeline_backlog.py" in arweave_workflow,
+        "Arweave workflow must use pipeline backlog detector",
+    )
+    require(
+        "arweave_archive_needed" in arweave_workflow,
+        "Arweave workflow must check arweave_archive_needed from detector",
+    )
+    require(
+        "ots_matches_chain" in arweave_workflow,
+        "Arweave workflow must check ots_matches_chain for OTS wait guard",
+    )
+
+    # Arweave must generate record-chain-status before public-home
+    require(
+        "generate_record_chain_status.py" in arweave_workflow,
+        "Arweave workflow must regenerate record-chain-status",
+    )
+    ar_status_pos = arweave_workflow.index("generate_record_chain_status.py")
+    ar_home_pos = arweave_workflow.index("generate_public_home_status.py")
+    require(
+        ar_status_pos < ar_home_pos,
+        "record-chain-status must be generated before public-home status in Arweave workflow",
+    )
+
+    # Arweave must commit api/record-chain-status.json
+    require(
+        "api/record-chain-status.json" in arweave_workflow,
+        "Arweave workflow must commit api/record-chain-status.json",
+    )
+
     # Arweave has early no-op for already archived head
     require(
-        "archive_check" in arweave_workflow,
-        "Arweave workflow must have early no-op check for already archived head",
+        "backlog" in arweave_workflow,
+        "Arweave workflow must have backlog detector step",
     )
+
+    # Arweave workflow must have rebase/retry on push
     require(
-        "No new Arweave archive needed" in arweave_workflow,
-        "Arweave workflow must print no-op message when archive is up to date",
-    )
-    require(
-        "matched" in arweave_workflow,
-        "Arweave workflow must use matched output for no-op guard",
+        "git pull --rebase origin" in arweave_workflow,
+        "Arweave workflow must rebase before push retry",
     )
 
     # Arweave workflow contains ARKEY but does not contain lowercase echo
@@ -94,9 +207,6 @@ def main() -> None:
         "ARKEY" in arweave_workflow,
         "Arweave workflow must reference ARKEY secret",
     )
-    # Check no lowercase "echo" in the workflow file (the word echo in comments/strings is ok
-    # but the actual workflow text should not have bare lowercase echo that triggers test failures)
-    # The test_record_chain_arweave_archive_contract.py checks for this specifically
 
     # Write-path guard allows append workflow commit message
     require(
@@ -110,6 +220,12 @@ def main() -> None:
     require(
         "append workflow" in guard_script,
         "write-path guard must have append workflow approval path",
+    )
+
+    # Write-path guard must include record-chain-status in public generated files
+    require(
+        "api/record-chain-status.json" in guard_script,
+        "write-path guard must include api/record-chain-status.json in PUBLIC_GENERATED_FILES",
     )
 
     # Append workflow must commit with actions bot identity
@@ -132,6 +248,24 @@ def main() -> None:
     require(
         "generate_sitemap.py" in append_workflow,
         "append workflow must regenerate sitemap",
+    )
+
+    # Backlog detector script must exist and have key outputs
+    require(
+        "ots_anchor_needed" in detector_script,
+        "backlog detector must output ots_anchor_needed",
+    )
+    require(
+        "arweave_archive_needed" in detector_script,
+        "backlog detector must output arweave_archive_needed",
+    )
+    require(
+        "pipeline_current" in detector_script,
+        "backlog detector must output pipeline_current",
+    )
+    require(
+        "--github-output" in detector_script,
+        "backlog detector must support --github-output flag",
     )
 
     print("External-agent full-auto pipeline contract PASSED.")

--- a/scripts/test_native_record_chain_archive_tooling.py
+++ b/scripts/test_native_record_chain_archive_tooling.py
@@ -37,22 +37,24 @@ def test_native_commitment_binds_current_head() -> None:
     if commitment.get("native_record_count") != tip.get("native_record_count"):
         fail("native commitment native_record_count must match chain-tip")
 
-    if commitment.get("latest_record_id") != "R-000000034":
-        fail("M9 native commitment must include R-000000034")
-    if commitment.get("native_record_count") != 34:
-        fail("M9 native commitment must include native_record_count=34")
+    expected_id = tip.get("latest_record_id")
+    expected_count = tip.get("native_record_count")
+    if commitment.get("latest_record_id") != expected_id:
+        fail(f"M9 native commitment must include {expected_id}")
+    if commitment.get("native_record_count") != expected_count:
+        fail(f"M9 native commitment must include native_record_count={expected_count}")
     if "main.chain.jsonl" in text:
         fail("native commitment must not reference legacy main.chain.jsonl")
 
     coverage = commitment.get("record_coverage", {})
     if coverage.get("source") != "record-chain/indexes/record-index.json":
         fail("native commitment record_coverage must use record-index")
-    if coverage.get("record_count") != 34:
-        fail("native commitment record_coverage must include 34 records")
-    if coverage.get("last_record_id") != "R-000000034":
-        fail("native commitment record_coverage must end at R-000000034")
-    if len(coverage.get("records", [])) != 34:
-        fail("native commitment records list must include 34 records")
+    if coverage.get("record_count") != expected_count:
+        fail(f"native commitment record_coverage must include {expected_count} records")
+    if coverage.get("last_record_id") != expected_id:
+        fail(f"native commitment record_coverage must end at {expected_id}")
+    if len(coverage.get("records", [])) != expected_count:
+        fail(f"native commitment records list must include {expected_count} records")
 
     source_files = commitment.get("source_files", {})
     for key in ["chain_tip", "record_index", "latest_record", "guardian_state", "statistics", "batch_index"]:
@@ -83,12 +85,13 @@ def test_native_ots_script_dry_run() -> None:
             fail("native OTS dry-run failed")
 
         latest = json.loads(api_out.read_text())
+        tip = json.loads((ROOT / "record-chain" / "chain-tip.json").read_text())
         if latest.get("schema") != "trinityaccord.native-record-chain-ots-latest.v1":
             fail("native latest schema mismatch")
-        if latest.get("latest_record_id") != "R-000000034":
-            fail("native latest must reference R-000000034")
-        if latest.get("native_record_count") != 34:
-            fail("native latest must reference native_record_count=34")
+        if latest.get("latest_record_id") != tip.get("latest_record_id"):
+            fail(f"native latest must reference {tip.get('latest_record_id')}")
+        if latest.get("native_record_count") != tip.get("native_record_count"):
+            fail(f"native latest must reference native_record_count={tip.get('native_record_count')}")
         if latest.get("legacy_main_chain_jsonl_is_not_source") is not True:
             fail("native latest must declare legacy main.chain.jsonl is not source")
 

--- a/scripts/test_p0_main_required_commands.py
+++ b/scripts/test_p0_main_required_commands.py
@@ -93,6 +93,9 @@ required = [
     # before_leaving exit/readback contract
     "python3 scripts/test_agent_output_policy_before_leaving_exit_contract.py",
 
+    # Pipeline backlog detector
+    "python3 scripts/detect_record_chain_pipeline_backlog.py",
+
     # Generated drift
     "python3 scripts/generate_record_chain_status.py --check",
     "python3 scripts/generate_public_home_status.py --check",
@@ -146,3 +149,4 @@ if missing:
     sys.exit(1)
 
 print("PASS: p0-current includes required record-chain-first mainline checks")
+

--- a/scripts/test_public_production_status_alignment.py
+++ b/scripts/test_public_production_status_alignment.py
@@ -113,16 +113,25 @@ def main() -> None:
     require(rc.get("legacy_main_chain_jsonl_is_not_current_source") is True, "legacy JSONL must not be current source")
 
     ots = record_status.get("anchoring", {}).get("open_timestamps", {})
-    expected_ots_status = "bitcoin-verified" if native_ots.get("bitcoin_verified") is True else "pending-bitcoin"
-    require(ots.get("status") == expected_ots_status, "OTS public status mismatch")
+    ots_matches_chain = (
+        native_ots.get("latest_record_id") == latest_record_id
+        and native_ots.get("latest_record_sha256") == latest_record_sha256
+        and native_ots.get("native_record_count") == native_record_count
+    )
+    if native_ots.get("bitcoin_verified") is True:
+        expected_ots_status = "verified-bitcoin"
+    elif ots_matches_chain and native_ots.get("ots_status") == "pending":
+        expected_ots_status = "current-pending-bitcoin"
+    else:
+        expected_ots_status = "anchor-needed"
+    require(ots.get("status") == expected_ots_status, f"OTS public status mismatch: expected {expected_ots_status}, got {ots.get('status')}")
     require(ots.get("latest_record_id") == native_ots.get("latest_record_id"), "OTS latest record mismatch")
     require(ots.get("latest_record_sha256") == native_ots.get("latest_record_sha256"), "OTS latest record sha mismatch")
     require(ots.get("native_record_count") == native_ots.get("native_record_count"), "OTS native record count mismatch")
     require(ots.get("bitcoin_pending") == (native_ots.get("bitcoin_pending") is True), "OTS bitcoin_pending mismatch")
     require(ots.get("bitcoin_verified") == (native_ots.get("bitcoin_verified") is True), "OTS bitcoin_verified mismatch")
     require(ots.get("legacy_main_chain_jsonl_is_not_source") is True, "OTS must not use legacy JSONL")
-    require(native_ots.get("latest_record_id") == latest_record_id, "native OTS must match chain-tip latest record")
-    require(native_ots.get("native_record_count") == native_record_count, "native OTS must match chain-tip count")
+    require(ots.get("anchor_needed") == (not ots_matches_chain), "OTS anchor_needed must reflect chain match state")
 
     ar = record_status.get("anchoring", {}).get("arweave_archive", {})
     require(ar.get("current_upload_mode") == arweave_index.get("current_upload_mode"), "Arweave mode mismatch")

--- a/scripts/test_record_chain_arweave_archive_contract.py
+++ b/scripts/test_record_chain_arweave_archive_contract.py
@@ -15,6 +15,8 @@ Asserts:
 - archive manifest has arweave.enabled = false in dry-run
 - archive boundary says not authority / not amendment
 - no ARV5/LV5/IPFS current terminology
+- backlog detector present
+- record-chain-status generated before public-home
 """
 from __future__ import annotations
 
@@ -46,24 +48,35 @@ def main() -> None:
             errors.append("arweave-archive workflow missing ARKEY reference")
         if "ARWEAVE_WALLET_JWK_B64" in text:
             errors.append("arweave-archive workflow must not use ARWEAVE_WALLET_JWK_B64 (use ARKEY)")
-        # Should not use the secret in a run: step directly
+        # Check no lowercase "echo" in the workflow file when ARKEY is present
         if "echo" in text.lower() and "ARKEY" in text:
             errors.append("arweave-archive workflow may echo wallet secret")
-        # Early no-op for already archived head
-        if "archive_check" not in text:
-            errors.append("arweave-archive workflow missing early no-op archive_check")
-        if "No new Arweave archive needed" not in text:
-            errors.append("arweave-archive workflow missing no-op message")
-        if "matched" not in text:
-            errors.append("arweave-archive workflow missing matched output for no-op guard")
+        # Backlog detector
+        if "detect_record_chain_pipeline_backlog.py" not in text:
+            errors.append("arweave-archive workflow missing backlog detector")
+        if "arweave_archive_needed" not in text:
+            errors.append("arweave-archive workflow missing arweave_archive_needed guard")
+        if "ots_matches_chain" not in text:
+            errors.append("arweave-archive workflow missing OTS wait guard")
+        # Must regenerate record-chain-status
+        if "generate_record_chain_status.py" not in text:
+            errors.append("arweave-archive workflow must regenerate record-chain-status")
+        # record-chain-status must be generated before public-home status
+        if text.index("generate_record_chain_status.py") > text.index("generate_public_home_status.py"):
+            errors.append("record-chain-status must be generated before public-home status")
+        if "api/record-chain-status.json" not in text:
+            errors.append("arweave archive commit must include api/record-chain-status.json")
         # workflow_run from OTS resolves to live
         if "workflow_run" not in text:
             errors.append("arweave-archive workflow missing workflow_run trigger")
         if "Record Chain Head OTS Anchor" not in text:
             errors.append("arweave-archive workflow must listen to OTS anchor workflow")
-        # All steps after early check must be conditional
-        if "steps.archive_check.outputs.matched" not in text:
-            errors.append("arweave-archive workflow steps must be conditional on archive_check")
+        # 30-minute schedule scanner
+        if "*/30 * * * *" not in text:
+            errors.append("arweave-archive workflow must have 30-minute schedule scanner")
+        # Rebase/retry
+        if "git pull --rebase origin" not in text:
+            errors.append("arweave-archive workflow must rebase before push retry")
 
     # 2. Scripts exist
     build_script = ROOT / "scripts" / "build_record_chain_arweave_archive.py"
@@ -118,6 +131,11 @@ def main() -> None:
             errors.append("verify script missing forbidden terminology check")
         if "not_authority" not in text:
             errors.append("verify script missing boundary check")
+
+    # 7. Backlog detector exists
+    detector = ROOT / "scripts" / "detect_record_chain_pipeline_backlog.py"
+    if not detector.exists():
+        errors.append("missing scripts/detect_record_chain_pipeline_backlog.py")
 
     if errors:
         print("Arweave archive contract tests FAILED:", file=sys.stderr)

--- a/scripts/test_record_chain_write_path_guard_contract.py
+++ b/scripts/test_record_chain_write_path_guard_contract.py
@@ -96,6 +96,7 @@ def main() -> None:
         "MAINTENANCE_OVERRIDE_TOKEN",
         "APPROVED_ACTIONS_ACTOR",
         "RECORD_CHAIN_GATEWAY_ACTORS",
+        "api/record-chain-status.json",
         "record-chain/maintenance-overrides/",
         "record-chain: auto-finalize accepted submissions",
         "Append record-chain entries from Render intake",
@@ -243,8 +244,28 @@ def main() -> None:
         write(repo / "scripts/check_record_chain_write_path_guard.py", guard_script)
         base = commit(repo, "init")
 
+        write(repo / "record-chain/records/R-999999999.json", "{}\n")
+        write(repo / "record-chain/chain-tip.json", "{}\n")
+        write(repo / "record-chain/indexes/record-index.json", "{}\n")
+        write(repo / "api/record-chain-status.json", "{}\n")
+        write(repo / "api/public-home-status.json", "{}\n")
+        write(repo / "index.md", "status\n")
+        write(repo / "sitemap.xml", "<urlset />\n")
+        head = commit(repo, "Append record-chain entries from Render intake")
+        result = check_guard(repo, base, head, actor="github-actions[bot]")
+        require(result.returncode == 0, f"append workflow with status/public generated should pass:\n{result.stdout}\n{result.stderr}")
+
+    with tempfile.TemporaryDirectory() as td:
+        repo = Path(td)
+        run(["git", "init"], cwd=repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=repo)
+        run(["git", "config", "user.name", "Write Path Guard Test"], cwd=repo)
+        write(repo / "scripts/check_record_chain_write_path_guard.py", guard_script)
+        base = commit(repo, "init")
+
         write(repo / "record-chain/arweave-archives/archive.json", "{}\n")
         write(repo / "api/record-chain-arweave-index.json", "{}\n")
+        write(repo / "api/record-chain-status.json", "{}\n")
         write(repo / "api/public-home-status.json", "{}\n")
         write(repo / "index.md", "archive\n")
         write(repo / "sitemap.xml", "<xml />\n")
@@ -272,3 +293,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary

- Make record-chain public status phase-aware instead of strict-all-equal.
- Add pipeline backlog detector (`detect_record_chain_pipeline_backlog.py`).
- Append workflow explicitly dispatches native OTS after successful commit.
- Native OTS adds 15-minute schedule scanner and dispatches live Arweave after successful OTS push.
- Arweave adds 30-minute schedule scanner, waits for OTS, archives latest OTS-covered head, and regenerates record-chain status.
- Update write-path guard and contracts so CI accepts phase-aware backlog states.

## Problem

Chain-tip is R35, but downstream state (OTS, Arweave) is stuck at R34. The current `generate_record_chain_status.py` hard-fails when OTS/Arweave don't match chain-tip, making CI red during valid intermediate states.

## Solution

### Phase-aware pipeline
```
Gateway accepted ✅
Append Record Chain Entries ✅
GitHub native chain R35 ✅
Native OTS R35 → scanner catches within 15 min
Live Arweave R35 → scanner catches within 30 min (after OTS)
Public record-chain-status R35 → updated by both workflows
```

### Scanner-backed recovery
- **Trigger = fast path**: Append → dispatch OTS → dispatch Arweave
- **Schedule scanner = recovery path**: OTS every 15 min, Arweave every 30 min
- Both are required for reliable downstream recovery.

## Files changed

- `.github/workflows/record-chain-append.yml` — add `actions: write`, generate status, dispatch OTS
- `.github/workflows/record-chain-head-ots-anchor.yml` — add schedule, detector, dispatch Arweave
- `.github/workflows/record-chain-arweave-archive.yml` — add detector, 30-min schedule, wait for OTS
- `scripts/detect_record_chain_pipeline_backlog.py` — new backlog detector
- `scripts/generate_record_chain_status.py` — phase-aware, no hard-fail on lag
- `scripts/check_record_chain_write_path_guard.py` — add `api/record-chain-status.json` to public generated
- Contract tests updated to match new pipeline behavior

## Safety

- No new records created
- No manual OTS stamp
- No manual Arweave upload in PR
- Runtime protected files changed only where necessary for generated public status

## Post-merge rescue

After merge, manually dispatch OTS to catch up R35:
```
gh workflow run record-chain-head-ots-anchor.yml --ref main
```