### PR TITLE
Guard append workflow: skip downstream steps when append makes no record-chain changes

### DIFF
--- a/.github/workflows/record-chain-append.yml
+++ b/.github/workflows/record-chain-append.yml
@@ -54,15 +54,29 @@ jobs:
         run: |
           set -euo pipefail
           git pull --rebase origin "${GITHUB_REF_NAME:-main}"
-      - run: python scripts/trinity_record_chain.py append --all
-      - run: python scripts/trinity_record_chain.py verify
+      - name: Append pending records
+        id: append_run
+        run: |
+          set -euo pipefail
+          python scripts/trinity_record_chain.py append --all
+          if git diff --quiet -- record-chain/; then
+            printf '%s\n' "changed=false" >> "$GITHUB_OUTPUT"
+            printf '%s\n' "No record-chain changes after append; skipping derived status commit."
+          else
+            printf '%s\n' "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Verify record chain after append
+        if: steps.append_run.outputs.changed == 'true'
+        run: python scripts/trinity_record_chain.py verify
       - name: Regenerate phase-aware public status and homepage counters
+        if: steps.append_run.outputs.changed == 'true'
         run: |
           python scripts/generate_record_chain_status.py
           python scripts/generate_public_home_status.py
           python scripts/generate_sitemap.py
       - name: Commit and push append updates
         id: append_commit
+        if: steps.append_run.outputs.changed == 'true'
         run: |
           set -euo pipefail
           printf '%s\n' "committed=false" >> "$GITHUB_OUTPUT"

--- a/apps/record_chain_intake_gateway/tests/test_record_chain_append_workflow.py
+++ b/apps/record_chain_intake_gateway/tests/test_record_chain_append_workflow.py
@@ -1,0 +1,44 @@
+"""Tests for the record-chain append GitHub Actions workflow."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "record-chain-append.yml"
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps() -> list[dict]:
+    return _workflow()["jobs"]["append"]["steps"]
+
+
+def _step_named(name: str) -> dict:
+    for step in _steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"Missing workflow step: {name}")
+
+
+class TestRecordChainAppendWorkflow:
+    def test_append_step_outputs_changed_only_from_record_chain_diff(self):
+        step = _step_named("Append pending records")
+        assert step.get("id") == "append_run"
+        run = step.get("run", "")
+        assert "python scripts/trinity_record_chain.py append --all" in run
+        assert "git diff --quiet -- record-chain/" in run
+        assert '"changed=false"' in run
+        assert '"changed=true"' in run
+
+    def test_status_commit_is_skipped_when_append_makes_no_record_chain_change(self):
+        gated_steps = [
+            "Verify record chain after append",
+            "Regenerate phase-aware public status and homepage counters",
+            "Commit and push append updates",
+        ]
+        for name in gated_steps:
+            step = _step_named(name)
+            assert step.get("if") == "steps.append_run.outputs.changed == 'true'"


### PR DESCRIPTION
### Motivation
- Prevent no-op append runs from producing status-only commits and accidentally triggering downstream OTS/anchor work when `record-chain/` was not modified. 
- Observed behavior: append workflow continued to regenerate status/home/sitemap and push commits even when there were no pending records to append, causing unnecessary churn.

### Description
- Update `.github/workflows/record-chain-append.yml` to add an `Append pending records` step (`id: append_run`) that runs `python scripts/trinity_record_chain.py append --all` and emits `changed=true|false` using `git diff --quiet -- record-chain/` to detect real changes. 
- Gate the follow-up verify/status/sitemap/commit steps with `if: steps.append_run.outputs.changed == 'true'` so they only run when the append actually modified `record-chain/`. 
- Add `apps/record_chain_intake_gateway/tests/test_record_chain_append_workflow.py` to assert the append change detector and the gated follow-up steps are present in the workflow to prevent regressions.

### Testing
- Ran workflow-text assertions with a small Python check that validated presence of `id: append_run`, the `python scripts/trinity_record_chain.py append --all` call, `git diff --quiet -- record-chain/`, and the `if: steps.append_run.outputs.changed == 'true'` guards, and the checks passed. 
- Ran `python scripts/trinity_record_chain.py verify` which completed successfully. 
- Ran `git diff --check` which reported no problems. 
- Attempted to run `pytest apps/record_chain_intake_gateway/tests/test_record_chain_append_workflow.py apps/record_chain_intake_gateway/tests/test_render_config.py` but it failed to import test fixtures because the `cryptography` package was not installed locally and `pip install` was blocked by a network/proxy `403`, so full pytest execution was blocked (environment dependency/network issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27b1ac6e0c8331b4c305e2994312f2)