### PR TITLE
Add native OTS Arweave proof-bundle archive support, paid upload flow, and guardian-retirement key binding

### DIFF
--- a/.github/workflows/native-ots-upgrade-watch.yml
+++ b/.github/workflows/native-ots-upgrade-watch.yml
@@ -94,7 +94,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/run_native_ots_upgrade_verify.py \
-            --run-id "$NATIVE_OTS_RUN_ID"
+            --run-id "$NATIVE_OTS_RUN_ID" \
+            --enable-paid-upload \
+            --confirm-paid-upload "I_UNDERSTAND_THIS_UPLOADS_THE_VERIFIED_OTS_PROOF_BUNDLE_TO_ARWEAVE"
 
       - name: Summarize native OTS result
         if: always()
@@ -121,10 +123,14 @@ jobs:
           RESULT=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("result","missing"))' "$SUMMARY")
           echo "Native OTS result: $RESULT"
 
-          if [ "$RESULT" != "upgraded" ] && [ "$RESULT" != "verified" ] && [ "$RESULT" != "upgraded_archived" ]; then
+          if [ "$RESULT" != "upgraded" ] && [ "$RESULT" != "verified" ] && [ "$RESULT" != "upgraded_archived" ] && [ "$RESULT" != "verified_archived" ]; then
             echo "No production commit for result=$RESULT"
             exit 0
           fi
+
+          python3 scripts/generate_record_chain_status.py
+          python3 scripts/generate_public_home_status.py
+          python3 scripts/generate_sitemap.py
 
           git status --short
           git add \
@@ -132,7 +138,11 @@ jobs:
             record-chain/ots/native-arweave-bundles/ \
             record-chain/ots/native-arweave-registry.json \
             api/record-chain-native-ots-arweave-registry.json \
-            api/record-chain-native-ots-latest.json
+            api/record-chain-native-ots-latest.json \
+            api/record-chain-status.json \
+            api/public-home-status.json \
+            index.md \
+            sitemap.xml
 
           if git diff --cached --quiet; then
             echo "No changes to commit"
@@ -141,8 +151,8 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [ "$RESULT" = "verified" ]; then
-            git commit -m "chore: sync verified native OTS anchor and registry"
+          if [ "$RESULT" = "verified" ] || [ "$RESULT" = "verified_archived" ]; then
+            git commit -m "chore: archive verified native OTS proof bundle"
           elif [ "$RESULT" = "upgraded_archived" ]; then
             git commit -m "chore: archive upgraded native OTS proof bundle"
           else

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-09T06:27:23.447642+00:00",
+  "generated_at": "2026-06-09T07:46:15.155898+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -11,7 +11,7 @@
     "/api/guardian-registry.json",
     "/api/agent-declared-verification-index.json"
   ],
-  "source_digest": "5520960d7eda3e95",
+  "source_digest": "3d228e541dee0e76",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 36,
@@ -60,7 +60,30 @@
         "latest_anchored_file": "record-chain/ots/native-anchors/native-record-36-R-000000036-1ee118161376bae0-6281b094a560c48f.native-record-chain-head-commitment.json",
         "latest_ots_file": "record-chain/ots/native-anchors/native-record-36-R-000000036-1ee118161376bae0-6281b094a560c48f.native-record-chain-head-commitment.json.ots",
         "ots_status": "pending",
-        "anchor_needed": false
+        "anchor_needed": false,
+        "proof_bundle_archive": {
+          "implemented": true,
+          "workflow": "/.github/workflows/native-ots-upgrade-watch.yml",
+          "registry_api": "/api/record-chain-native-ots-arweave-registry.json",
+          "status": "waiting-for-ots-upgrade",
+          "archive_status": "waiting-for-ots-upgrade",
+          "latest_bundle_file": null,
+          "latest_bundle_sha256": null,
+          "latest_tx_id": null,
+          "latest_gateway_url": null,
+          "latest_ots_status": "pending",
+          "latest_bitcoin_verified": false,
+          "archive_needed": false,
+          "registered_without_arweave_tx": false,
+          "arweave_archived": false,
+          "boundary": {
+            "ots_proof_bundle_arweave_archive_is_mirror_only": true,
+            "ots_proof_bundle_arweave_archive_is_not_authority": true,
+            "ots_proof_bundle_arweave_archive_is_not_attestation": true,
+            "ots_proof_bundle_arweave_archive_is_not_amendment": true,
+            "ots_proof_bundle_arweave_archive_is_not_successor_reception": true
+          }
+        }
       },
       "arweave_archive": {
         "arweave_archive_is_mirror_only": true,

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v2",
-  "generated_at": "2026-06-09T07:46:15.155898+00:00",
+  "generated_at": "2026-06-09T07:53:36.726156+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -11,7 +11,7 @@
     "/api/guardian-registry.json",
     "/api/agent-declared-verification-index.json"
   ],
-  "source_digest": "3d228e541dee0e76",
+  "source_digest": "080612cfcdd2c843",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 36,

--- a/api/record-chain-native-ots-arweave-registry.json
+++ b/api/record-chain-native-ots-arweave-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema": "trinityaccord.native-ots-arweave-registry.v1",
+  "entries": [],
+  "created_at": "2026-06-09T00:00:00Z",
+  "updated_at": "2026-06-09T00:00:00Z",
+  "boundary": {
+    "native_ots_proof_bundle_arweave_archive_is_mirror_only": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_authority": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_attestation": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_amendment": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_successor_reception": true
+  }
+}

--- a/api/record-chain-status.json
+++ b/api/record-chain-status.json
@@ -48,7 +48,30 @@
       "latest_anchored_file": "record-chain/ots/native-anchors/native-record-36-R-000000036-1ee118161376bae0-6281b094a560c48f.native-record-chain-head-commitment.json",
       "latest_ots_file": "record-chain/ots/native-anchors/native-record-36-R-000000036-1ee118161376bae0-6281b094a560c48f.native-record-chain-head-commitment.json.ots",
       "ots_status": "pending",
-      "anchor_needed": false
+      "anchor_needed": false,
+      "proof_bundle_archive": {
+        "implemented": true,
+        "workflow": "/.github/workflows/native-ots-upgrade-watch.yml",
+        "registry_api": "/api/record-chain-native-ots-arweave-registry.json",
+        "status": "waiting-for-ots-upgrade",
+        "archive_status": "waiting-for-ots-upgrade",
+        "latest_bundle_file": null,
+        "latest_bundle_sha256": null,
+        "latest_tx_id": null,
+        "latest_gateway_url": null,
+        "latest_ots_status": "pending",
+        "latest_bitcoin_verified": false,
+        "archive_needed": false,
+        "registered_without_arweave_tx": false,
+        "arweave_archived": false,
+        "boundary": {
+          "ots_proof_bundle_arweave_archive_is_mirror_only": true,
+          "ots_proof_bundle_arweave_archive_is_not_authority": true,
+          "ots_proof_bundle_arweave_archive_is_not_attestation": true,
+          "ots_proof_bundle_arweave_archive_is_not_amendment": true,
+          "ots_proof_bundle_arweave_archive_is_not_successor_reception": true
+        }
+      }
     }
   },
   "api_endpoints": {

--- a/index.md
+++ b/index.md
@@ -814,7 +814,7 @@ Refusal is allowed. Critical preservation is allowed.
   <article class="status-card">
     <p class="status-label">Anchoring and archive status</p>
     <p class="status-number">Active</p>
-    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: current-pending-bitcoin. Native OTS proof bundle Arweave archive: waiting-for-ots-upgrade. Record-Chain Arweave archive: live mirror active; latest tx d2XipOgFyXSO.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：current-pending-bitcoin。Native OTS proof bundle Arweave 归档：waiting-for-ots-upgrade。Record-Chain Arweave 归档：live mirror active; latest tx d2XipOgFyXSO...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
+    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: current-pending-bitcoin. Native OTS proof bundle Arweave archive: waiting-for-ots-upgrade. Record-Chain Arweave archive: live mirror active; latest tx BINPfqHtHti8.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：current-pending-bitcoin。Native OTS proof bundle Arweave 归档：waiting-for-ots-upgrade。Record-Chain Arweave 归档：live mirror active; latest tx BINPfqHtHti8...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">Verifiability</p>
@@ -845,7 +845,7 @@ Refusal is allowed. Critical preservation is allowed.
     但它们不是当前 Record-Chain Intake 的计数器。
   </span>
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>3d228e541dee0e76</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>080612cfcdd2c843</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">

--- a/index.md
+++ b/index.md
@@ -814,7 +814,7 @@ Refusal is allowed. Critical preservation is allowed.
   <article class="status-card">
     <p class="status-label">Anchoring and archive status</p>
     <p class="status-number">Active</p>
-    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: current-pending-bitcoin. Arweave archive: live mirror active; latest tx BINPfqHtHti8.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：current-pending-bitcoin。Arweave 归档：live mirror active; latest tx BINPfqHtHti8...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
+    <p class="status-note">Batch manifests: 1 batches (all stamped). OpenTimestamps: current-pending-bitcoin. Native OTS proof bundle Arweave archive: waiting-for-ots-upgrade. Record-Chain Arweave archive: live mirror active; latest tx d2XipOgFyXSO.... Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：1 batches (all stamped)。OpenTimestamps：current-pending-bitcoin。Native OTS proof bundle Arweave 归档：waiting-for-ots-upgrade。Record-Chain Arweave 归档：live mirror active; latest tx d2XipOgFyXSO...。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">Verifiability</p>
@@ -845,7 +845,7 @@ Refusal is allowed. Critical preservation is allowed.
     但它们不是当前 Record-Chain Intake 的计数器。
   </span>
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>5520960d7eda3e95</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>3d228e541dee0e76</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">

--- a/record-chain/ots/native-arweave-registry.json
+++ b/record-chain/ots/native-arweave-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema": "trinityaccord.native-ots-arweave-registry.v1",
+  "entries": [],
+  "created_at": "2026-06-09T00:00:00Z",
+  "updated_at": "2026-06-09T00:00:00Z",
+  "boundary": {
+    "native_ots_proof_bundle_arweave_archive_is_mirror_only": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_authority": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_attestation": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_amendment": true,
+    "native_ots_proof_bundle_arweave_archive_is_not_successor_reception": true
+  }
+}

--- a/scripts/build_ots_arweave_bundle.py
+++ b/scripts/build_ots_arweave_bundle.py
@@ -59,8 +59,12 @@ def main() -> None:
     include_base64 = args.include_base64 and not args.no_base64
 
     anchor = load_json(anchor_path)
-    if anchor.get("schema") != "trinity_record_chain_ots_anchor.v1":
+    if anchor.get("schema") not in {
+        "trinity_record_chain_ots_anchor.v1",
+        "trinityaccord.native-record-chain-ots-anchor.v1",
+    }:
         raise SystemExit(f"anchor schema mismatch: {anchor.get('schema')}")
+    is_native = anchor.get("schema") == "trinityaccord.native-record-chain-ots-anchor.v1"
 
     anchored_file = Path(anchor.get("anchored_file", ""))
     if not anchored_file.exists():
@@ -93,9 +97,13 @@ def main() -> None:
         "schema": "trinity_record_chain_ots_arweave_bundle.v1",
         "chain_id": anchor.get("chain_id"),
         "chain_version": anchor.get("chain_version"),
-        "height": anchor.get("height"),
-        "entry_count": anchor.get("entry_count"),
-        "head_entry_hash": anchor.get("head_entry_hash"),
+        "height": anchor.get("height", anchor.get("latest_record_index")),
+        "entry_count": anchor.get("entry_count", anchor.get("native_record_count")),
+        "head_entry_hash": anchor.get("head_entry_hash", anchor.get("latest_record_sha256")),
+        "native_anchor": is_native,
+        "native_latest_record_id": anchor.get("latest_record_id"),
+        "native_latest_record_sha256": anchor.get("latest_record_sha256"),
+        "native_record_count": anchor.get("native_record_count"),
         "anchored_file_sha256": anchor.get("anchored_file_sha256"),
         "ots_status": anchor.get("ots_status"),
         "bitcoin_verified": anchor.get("bitcoin_verified"),
@@ -106,7 +114,7 @@ def main() -> None:
         "files": files,
         "semantics": (
             "Arweave bundle for an OTS proof of a stable Record-Chain head commitment. "
-            "This archive is outside main.chain.jsonl and does not modify entry_hash."
+            "This archive is separate from the main Record-Chain Arweave archive and does not modify entry_hash."
         ),
     }
 

--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -37,6 +37,12 @@ AUTO_FINALIZE_FILES = {
 OTS_PREFIXES = ("record-chain/ots/native-anchors/",)
 OTS_FILES = {"api/record-chain-native-ots-latest.json"}
 
+OTS_AUX_PREFIXES = ("record-chain/ots/native-arweave-bundles/",)
+OTS_AUX_FILES = {
+    "record-chain/ots/native-arweave-registry.json",
+    "api/record-chain-native-ots-arweave-registry.json",
+}
+
 ARWEAVE_PREFIXES = ("record-chain/arweave-archives/",)
 ARWEAVE_FILES = {"api/record-chain-arweave-index.json"}
 
@@ -60,6 +66,9 @@ APPROVED_ACTIONS_ACTOR = "github-actions[bot]"
 APPROVED_AUTO_FINALIZE_MESSAGE = "record-chain: auto-finalize accepted submissions"
 APPROVED_APPEND_MESSAGE = "Append record-chain entries from Render intake"
 APPROVED_OTS_MESSAGE = "anchor: stamp native record-chain head with OTS"
+APPROVED_NATIVE_OTS_SYNC_MESSAGE = "chore: sync upgraded native OTS anchor and registry"
+APPROVED_NATIVE_OTS_UPGRADED_ARCHIVE_MESSAGE = "chore: archive upgraded native OTS proof bundle"
+APPROVED_NATIVE_OTS_VERIFIED_ARCHIVE_MESSAGE = "chore: archive verified native OTS proof bundle"
 APPROVED_ARWEAVE_MESSAGE = "archive: update native record-chain Arweave archive metadata"
 
 PROTECTED_CATEGORIES = {
@@ -122,6 +131,8 @@ def category(path: str) -> str:
         return "auto_finalize"
     if startswith_any(path, OTS_PREFIXES) or path in OTS_FILES:
         return "ots"
+    if startswith_any(path, OTS_AUX_PREFIXES) or path in OTS_AUX_FILES:
+        return "ots_aux"
     if startswith_any(path, ARWEAVE_PREFIXES) or path in ARWEAVE_FILES:
         return "arweave"
     if path in PUBLIC_GENERATED_FILES:
@@ -218,6 +229,17 @@ def allowed_for_push(
     if cats <= {"ots"} and message == APPROVED_OTS_MESSAGE:
         ok, reason = require_actions_actor(actor, "OTS anchor")
         return (True, "OTS anchor commit") if ok else (False, reason)
+
+    if (
+        cats <= {"ots", "ots_aux", "public_generated"}
+        and message in {
+            APPROVED_NATIVE_OTS_SYNC_MESSAGE,
+            APPROVED_NATIVE_OTS_UPGRADED_ARCHIVE_MESSAGE,
+            APPROVED_NATIVE_OTS_VERIFIED_ARCHIVE_MESSAGE,
+        }
+    ):
+        ok, reason = require_actions_actor(actor, "native OTS upgrade watch")
+        return (True, "native OTS upgrade watch commit") if ok else (False, reason)
 
     if cats <= {"arweave", "public_generated"} and message == APPROVED_ARWEAVE_MESSAGE:
         ok, reason = require_actions_actor(actor, "Arweave archive")

--- a/scripts/generate_public_home_status.py
+++ b/scripts/generate_public_home_status.py
@@ -376,6 +376,8 @@ def render_block(status: dict[str, Any]) -> str:
 
     ots_display = anchoring.get("open_timestamps", {})
     ots_status = ots_display.get("status", "pending")
+    proof_archive = ots_display.get("proof_bundle_archive", {})
+    proof_archive_status = proof_archive.get("archive_status") or proof_archive.get("status", "waiting-for-ots-upgrade")
 
     arweave_mode = arweave["current_upload_mode"]
     arweave_count = arweave["archive_count"]
@@ -433,7 +435,7 @@ def render_block(status: dict[str, Any]) -> str:
   <article class="status-card">
     <p class="status-label">Anchoring and archive status</p>
     <p class="status-number">Active</p>
-    <p class="status-note">Batch manifests: {batch_status}. OpenTimestamps: {ots_status}. Arweave archive: {arweave_status}. Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：{batch_status}。OpenTimestamps：{ots_status}。Arweave 归档：{arweave_status}。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
+    <p class="status-note">Batch manifests: {batch_status}. OpenTimestamps: {ots_status}. Native OTS proof bundle Arweave archive: {proof_archive_status}. Record-Chain Arweave archive: {arweave_status}. Arweave is a mirror/archive layer only. It is not authority, attestation, amendment, or successor reception. <span class="zh">批次 manifest：{batch_status}。OpenTimestamps：{ots_status}。Native OTS proof bundle Arweave 归档：{proof_archive_status}。Record-Chain Arweave 归档：{arweave_status}。Arweave 仅为镜像/归档层，非权威、非证明、非修订、非继任接收。</span></p>
   </article>
   <article class="status-card">
     <p class="status-label">Verifiability</p>

--- a/scripts/generate_record_chain_status.py
+++ b/scripts/generate_record_chain_status.py
@@ -23,6 +23,13 @@ def read_json(rel: str) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def read_json_if_exists(rel: str) -> Any | None:
+    path = ROOT / rel
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def write_json(rel: str, data: Any) -> None:
     (ROOT / rel).write_text(dump_json(data), encoding="utf-8")
 
@@ -137,12 +144,59 @@ def build_pipeline_status(tip: dict[str, Any], ots: dict[str, Any], latest_live:
     }
 
 
+def latest_native_ots_proof_bundle_archive(
+    registry: dict[str, Any] | None,
+    ots: dict[str, Any],
+) -> dict[str, Any]:
+    entries = list((registry or {}).get("entries", []))
+    anchored_sha = ots.get("anchored_file_sha256")
+    matching = [entry for entry in entries if entry.get("anchored_file_sha256") == anchored_sha]
+    matching.sort(key=lambda entry: entry.get("registered_at") or entry.get("uploaded_at") or "")
+    latest = matching[-1] if matching else None
+    tx_id = (latest or {}).get("tx_id")
+    archive_status = (latest or {}).get("archive_status")
+
+    if tx_id and archive_status == "arweave_archived":
+        status = "arweave_archived"
+    elif latest:
+        status = "registered_without_arweave_tx"
+    elif ots.get("ots_status") in {"upgraded", "verified"}:
+        status = "archive-needed"
+    else:
+        status = "waiting-for-ots-upgrade"
+
+    return {
+        "implemented": True,
+        "workflow": "/.github/workflows/native-ots-upgrade-watch.yml",
+        "registry_api": "/api/record-chain-native-ots-arweave-registry.json",
+        "status": status,
+        "archive_status": status,
+        "latest_bundle_file": (latest or {}).get("bundle_file"),
+        "latest_bundle_sha256": (latest or {}).get("bundle_sha256"),
+        "latest_tx_id": tx_id,
+        "latest_gateway_url": (latest or {}).get("gateway_url"),
+        "latest_ots_status": (latest or {}).get("ots_status", ots.get("ots_status")),
+        "latest_bitcoin_verified": (latest or {}).get("bitcoin_verified", ots.get("bitcoin_verified")),
+        "archive_needed": status == "archive-needed",
+        "registered_without_arweave_tx": status == "registered_without_arweave_tx",
+        "arweave_archived": status == "arweave_archived",
+        "boundary": {
+            "ots_proof_bundle_arweave_archive_is_mirror_only": True,
+            "ots_proof_bundle_arweave_archive_is_not_authority": True,
+            "ots_proof_bundle_arweave_archive_is_not_attestation": True,
+            "ots_proof_bundle_arweave_archive_is_not_amendment": True,
+            "ots_proof_bundle_arweave_archive_is_not_successor_reception": True,
+        },
+    }
+
+
 def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
     status = copy.deepcopy(existing)
 
     tip = read_json("record-chain/chain-tip.json")
     ots = read_json("api/record-chain-native-ots-latest.json")
     arweave = read_json("api/record-chain-arweave-index.json")
+    native_ots_registry = read_json_if_exists("api/record-chain-native-ots-arweave-registry.json")
     record_index = read_json("record-chain/indexes/record-index.json")
 
     records = load_records_from_index(record_index)
@@ -221,6 +275,7 @@ def build_expected(existing: dict[str, Any]) -> dict[str, Any]:
         else "anchor-needed"
     )
     ot["anchor_needed"] = pipeline["ots_anchor_needed"]
+    ot["proof_bundle_archive"] = latest_native_ots_proof_bundle_archive(native_ots_registry, ots)
 
     status["anchoring"].setdefault("arweave_archive", {})
     aa = status["anchoring"]["arweave_archive"]

--- a/scripts/run_native_ots_upgrade_verify.py
+++ b/scripts/run_native_ots_upgrade_verify.py
@@ -136,7 +136,6 @@ def precheck_files() -> None:
 
 def snapshot_core_files() -> dict[str, str | None]:
     return {
-        "native_ots_latest_sha256": sha256_file(NATIVE_LATEST_OTS),
         "chain_tip_sha256": sha256_file(CHAIN_TIP),
         "record_index_sha256": sha256_file(RECORD_INDEX),
     }
@@ -211,6 +210,14 @@ def validate_native_registry() -> dict[str, Any]:
         return registry
 
     registry = read_json(NATIVE_REGISTRY)
+    for index, entry in enumerate(registry.get("entries", [])):
+        tx_id = entry.get("tx_id")
+        archive_status = entry.get("archive_status")
+        if tx_id and archive_status != "arweave_archived":
+            raise SystemExit(f"native registry entry[{index}] has tx_id but is not arweave_archived")
+        if not tx_id and archive_status == "arweave_archived":
+            raise SystemExit(f"native registry entry[{index}] claims arweave_archived without tx_id")
+
     if NATIVE_API_REGISTRY.exists():
         api_registry = read_json(NATIVE_API_REGISTRY)
         if registry != api_registry:
@@ -218,11 +225,19 @@ def validate_native_registry() -> dict[str, Any]:
     return registry
 
 
-def registry_has_bundle_sha(registry: dict[str, Any], bundle_sha: str) -> bool:
+def registry_entry_for_bundle_sha(registry: dict[str, Any], bundle_sha: str) -> dict[str, Any] | None:
     for entry in registry.get("entries", []):
         if entry.get("bundle_sha256") == bundle_sha:
-            return True
-    return False
+            return entry
+    return None
+
+
+def registry_has_bundle_sha(registry: dict[str, Any], bundle_sha: str) -> bool:
+    return registry_entry_for_bundle_sha(registry, bundle_sha) is not None
+
+
+def registry_entry_is_arweave_archived(entry: dict[str, Any] | None) -> bool:
+    return bool(entry and entry.get("tx_id") and entry.get("archive_status") == "arweave_archived")
 
 
 def has_upgraded_archive(registry: dict[str, Any], anchored_sha: str) -> bool:
@@ -231,6 +246,7 @@ def has_upgraded_archive(registry: dict[str, Any], anchored_sha: str) -> bool:
             entry.get("anchored_file_sha256") == anchored_sha
             and entry.get("ots_status") == "upgraded"
             and entry.get("tx_id")
+            and entry.get("archive_status") == "arweave_archived"
         ):
             return True
     return False
@@ -242,6 +258,7 @@ def has_verified_archive(registry: dict[str, Any], anchored_sha: str) -> bool:
             entry.get("anchored_file_sha256") == anchored_sha
             and entry.get("ots_status") == "verified"
             and entry.get("tx_id")
+            and entry.get("archive_status") == "arweave_archived"
         ):
             return True
     return False
@@ -362,6 +379,7 @@ def update_native_registry(
     *,
     tx_id: str | None = None,
     wallet_address: str | None = None,
+    gateway_url: str | None = None,
 ) -> dict[str, Any]:
     """Update native OTS Arweave registry with a new bundle entry."""
     anchor = validate_native_anchor(anchor_rel)
@@ -383,16 +401,105 @@ def update_native_registry(
         "bitcoin_verified": anchor.get("bitcoin_verified", False),
         "strict_bitcoin_verified": anchor.get("strict_bitcoin_verified", False),
         "tx_id": tx_id,
+        "gateway_url": gateway_url,
         "wallet_address": wallet_address,
-        "uploaded_at": utc_now(),
+        "archive_status": (
+            "arweave_archived" if tx_id else "registered_without_arweave_tx"
+        ),
+        "uploaded_at": utc_now() if tx_id else None,
+        "registered_at": utc_now(),
+        "boundary": {
+            "ots_proof_bundle_arweave_archive_is_mirror_only": True,
+            "ots_proof_bundle_arweave_archive_is_not_authority": True,
+            "ots_proof_bundle_arweave_archive_is_not_attestation": True,
+            "ots_proof_bundle_arweave_archive_is_not_amendment": True,
+            "ots_proof_bundle_arweave_archive_is_not_successor_reception": True,
+        },
     }
 
-    registry.setdefault("entries", []).append(entry)
+    entries = registry.setdefault("entries", [])
+    existing = registry_entry_for_bundle_sha(registry, bundle_sha)
+    if existing:
+        if tx_id and not existing.get("tx_id"):
+            existing.update(entry)
+        elif tx_id and existing.get("tx_id") != tx_id:
+            raise SystemExit("bundle already registered with different tx_id")
+        else:
+            entry = existing
+    else:
+        entries.append(entry)
     registry["updated_at"] = utc_now()
 
     write_json(NATIVE_REGISTRY, registry)
     write_json(NATIVE_API_REGISTRY, registry)
     return registry
+
+
+def upload_native_ots_bundle_to_arweave(
+    *,
+    bundle: Path,
+    log_dir: Path,
+    run_id: str,
+    jwk_path: str,
+    gateway_url: str,
+    readback_gateways: str,
+    readback_timeout_seconds: str,
+    readback_retry_seconds: str,
+) -> dict[str, Any]:
+    """Upload a native OTS proof bundle to Arweave through the paid cost gate."""
+    paid_dir = log_dir / "paid-upload"
+    paid_dir.mkdir(parents=True, exist_ok=True)
+
+    extra_tags = [
+        {"name": "Trinity-Artifact-Type", "value": "Native-OTS-Proof-Bundle"},
+        {"name": "Trinity-Boundary", "value": "mirror-only-not-authority-not-attestation-not-amendment"},
+    ]
+    env = {
+        "ALLOW_PAID_ARWEAVE_CANARY": "true",
+        "ARWEAVE_READBACK_GATEWAYS": readback_gateways,
+        "ARWEAVE_READBACK_TIMEOUT_SECONDS": str(readback_timeout_seconds),
+        "ARWEAVE_READBACK_RETRY_SECONDS": str(readback_retry_seconds),
+    }
+    run_cmd([
+        "node",
+        "scripts/arweave_cost_gate.mjs",
+        "--payload-file", rel(bundle),
+        "--record-type", "native_ots_proof_bundle",
+        "--run-id", run_id,
+        "--log-dir", rel(paid_dir),
+        "--mode", "production",
+        "--expected-owner", EXPECTED_OWNER,
+        "--gateway-url", gateway_url,
+        "--max-upload-usd", MAX_UPLOAD_USD,
+        "--safety-multiplier", SAFETY_MULTIPLIER,
+        "--jwk-path", jwk_path,
+        "--content-type", "application/json",
+        "--app-name", "Trinity-Accord-Native-OTS-Proof-Bundle",
+        "--extra-tags-json", json.dumps(extra_tags, separators=(",", ":")),
+    ], env=env)
+
+    upload = read_json(paid_dir / "11-arweave-upload-result.native_ots_proof_bundle.json")
+    readback = read_json(paid_dir / "11b-arweave-readback-verify.native_ots_proof_bundle.json")
+    bundle_sha = sha256_bytes(bundle.read_bytes())
+
+    if upload.get("result") != "uploaded":
+        raise SystemExit(f"native OTS proof bundle upload did not complete: {upload.get('result')}")
+    if not upload.get("tx_id"):
+        raise SystemExit("native OTS proof bundle upload result missing tx_id")
+    if upload.get("payload_sha256") != bundle_sha:
+        raise SystemExit("native OTS proof bundle upload payload sha mismatch")
+    if readback.get("result") != "pass" or readback.get("hash_match") is not True:
+        raise SystemExit("native OTS proof bundle readback verification failed")
+    if readback.get("downloaded_sha256") != bundle_sha:
+        raise SystemExit("native OTS proof bundle readback sha mismatch")
+
+    return {
+        "tx_id": upload["tx_id"],
+        "wallet_address": upload.get("wallet_address"),
+        "gateway_url": upload.get("gateway_url"),
+        "upload_result": rel(paid_dir / "11-arweave-upload-result.native_ots_proof_bundle.json"),
+        "readback_result": rel(paid_dir / "11b-arweave-readback-verify.native_ots_proof_bundle.json"),
+    }
 
 
 def write_summary(log_dir: Path, summary: dict[str, Any]) -> None:
@@ -493,14 +600,45 @@ def main() -> int:
         else:
             result = "upgraded_archived"
 
+    paid_upload_performed = False
+    upload_info: dict[str, Any] | None = None
+    registry_updated = False
+
     if bundle and not args.verify_only:
         bundle_sha = sha256_bytes(bundle.read_bytes())
-        if registry_has_bundle_sha(registry, bundle_sha):
+        existing_entry = registry_entry_for_bundle_sha(registry, bundle_sha)
+        if registry_entry_is_arweave_archived(existing_entry):
+            result = f"{result}_archived" if "archived" not in result else result
+        elif args.enable_paid_upload:
+            if args.confirm_paid_upload != CONFIRM_PAID_UPLOAD:
+                raise SystemExit(f"paid upload requires --confirm-paid-upload {CONFIRM_PAID_UPLOAD!r}")
+            if not args.jwk_path:
+                raise SystemExit("paid upload requires --jwk-path or ARWEAVE_JWK_PATH")
+            upload_info = upload_native_ots_bundle_to_arweave(
+                bundle=bundle,
+                log_dir=log_dir,
+                run_id=args.run_id,
+                jwk_path=args.jwk_path,
+                gateway_url=args.gateway_url,
+                readback_gateways=args.readback_gateways,
+                readback_timeout_seconds=args.readback_timeout_seconds,
+                readback_retry_seconds=args.readback_retry_seconds,
+            )
+            registry = update_native_registry(
+                anchor_rel,
+                bundle,
+                log_dir,
+                tx_id=upload_info["tx_id"],
+                wallet_address=upload_info.get("wallet_address"),
+                gateway_url=upload_info.get("gateway_url"),
+            )
+            paid_upload_performed = True
+            registry_updated = True
             result = f"{result}_archived" if "archived" not in result else result
         else:
-            # For now, just register without paid upload (no JWK required)
-            update_native_registry(anchor_rel, bundle, log_dir)
-            result = f"{result}_archived" if "archived" not in result else result
+            registry = update_native_registry(anchor_rel, bundle, log_dir)
+            registry_updated = existing_entry is None
+            result = f"{result}_registered"
 
     write_summary(log_dir, {
         "schema": "trinity_native_ots_summary.v1",
@@ -509,8 +647,9 @@ def main() -> int:
         "anchor_ots_status": anchor.get("ots_status"),
         "anchor_bitcoin_verified": anchor.get("bitcoin_verified"),
         "anchor_bitcoin_attestation_embedded": anchor.get("bitcoin_attestation_embedded", False),
-        "paid_upload_performed": False,
-        "registry_updated": bundle is not None,
+        "paid_upload_performed": paid_upload_performed,
+        "registry_updated": registry_updated,
+        "native_ots_proof_bundle_archive": upload_info,
         "core_files_unchanged": True,
     })
 

--- a/scripts/test_native_ots_upgrade_workflow_contract.py
+++ b/scripts/test_native_ots_upgrade_workflow_contract.py
@@ -7,8 +7,10 @@ Asserts:
   - supports pending/upgraded/verified states
   - upgraded bundle keeps bitcoin_verified=false
   - verified bundle requires strict verify success
-  - paid upload requires explicit confirmation
+  - paid upload requires explicit confirmation and an ARKEY/JWK gate
   - registry keyed by anchored_file_sha256 and bundle_sha256
+  - registry cannot claim arweave_archived without tx_id
+  - public status exposes native OTS proof-bundle archive state
 """
 from __future__ import annotations
 
@@ -28,17 +30,25 @@ def forbid(text: str, needle: str, label: str) -> None:
 def main() -> None:
     workflow_path = Path(".github/workflows/native-ots-upgrade-watch.yml")
     runner_path = Path("scripts/run_native_ots_upgrade_verify.py")
+    status_generator_path = Path("scripts/generate_record_chain_status.py")
+    home_generator_path = Path("scripts/generate_public_home_status.py")
     contract_path = Path("scripts/test_native_ots_upgrade_workflow_contract.py")
 
     if not workflow_path.exists():
         raise SystemExit(f"missing workflow: {workflow_path}")
     if not runner_path.exists():
         raise SystemExit(f"missing runner: {runner_path}")
+    if not status_generator_path.exists():
+        raise SystemExit(f"missing status generator: {status_generator_path}")
+    if not home_generator_path.exists():
+        raise SystemExit(f"missing home generator: {home_generator_path}")
     if not contract_path.exists():
         raise SystemExit(f"missing contract test: {contract_path}")
 
     workflow = workflow_path.read_text(encoding="utf-8")
     runner = runner_path.read_text(encoding="utf-8")
+    status_generator = status_generator_path.read_text(encoding="utf-8")
+    home_generator = home_generator_path.read_text(encoding="utf-8")
 
     # Workflow markers
     workflow_markers = [
@@ -51,6 +61,16 @@ def main() -> None:
         "api/record-chain-native-ots-latest.json",
         "record-chain/ots/native-anchors/",
         "record-chain/audit/native-ots/",
+        "steps.jwk.outputs.has_jwk == 'true'",
+        "--enable-paid-upload",
+        "--confirm-paid-upload",
+        "I_UNDERSTAND_THIS_UPLOADS_THE_VERIFIED_OTS_PROOF_BUNDLE_TO_ARWEAVE",
+        "python3 scripts/generate_record_chain_status.py",
+        "python3 scripts/generate_public_home_status.py",
+        "api/record-chain-status.json",
+        "api/public-home-status.json",
+        "index.md",
+        "sitemap.xml",
     ]
     for marker in workflow_markers:
         require(workflow, marker, "workflow")
@@ -77,6 +97,11 @@ def main() -> None:
         "ots_upgrade_and_verify",
         "I_UNDERSTAND_THIS_UPLOADS_THE_VERIFIED_OTS_PROOF_BUNDLE_TO_ARWEAVE",
         "registry_has_bundle_sha",
+        "upload_native_ots_bundle_to_arweave",
+        "ALLOW_PAID_ARWEAVE_CANARY",
+        "arweave_archived",
+        "registered_without_arweave_tx",
+        "claims arweave_archived without tx_id",
         "has_upgraded_archive",
         "has_verified_archive",
     ]
@@ -108,6 +133,31 @@ def main() -> None:
         "cannot build verified bundle before strict Bitcoin verification",
         "runner verified strict verify guard",
     )
+
+
+    status_markers = [
+        "latest_native_ots_proof_bundle_archive",
+        "proof_bundle_archive",
+        "api/record-chain-native-ots-arweave-registry.json",
+        "arweave_archived",
+        "registered_without_arweave_tx",
+        "waiting-for-ots-upgrade",
+        "ots_proof_bundle_arweave_archive_is_mirror_only",
+        "ots_proof_bundle_arweave_archive_is_not_authority",
+        "ots_proof_bundle_arweave_archive_is_not_attestation",
+        "ots_proof_bundle_arweave_archive_is_not_amendment",
+        "ots_proof_bundle_arweave_archive_is_not_successor_reception",
+    ]
+    for marker in status_markers:
+        require(status_generator, marker, "status generator")
+
+    home_markers = [
+        "proof_bundle_archive",
+        "Native OTS proof bundle Arweave archive",
+        "not authority, attestation, amendment, or successor reception",
+    ]
+    for marker in home_markers:
+        require(home_generator, marker, "public home generator")
 
     # Contract test exists and self-references
     contract = contract_path.read_text(encoding="utf-8")

--- a/scripts/test_record_chain_write_path_guard_contract.py
+++ b/scripts/test_record_chain_write_path_guard_contract.py
@@ -90,6 +90,8 @@ def main() -> None:
         "AUTO_FINALIZE_FILES",
         "OTS_PREFIXES",
         "OTS_FILES",
+        "OTS_AUX_PREFIXES",
+        "OTS_AUX_FILES",
         "ARWEAVE_PREFIXES",
         "ARWEAVE_FILES",
         "PUBLIC_GENERATED_FILES",
@@ -103,6 +105,8 @@ def main() -> None:
         "APPROVED_APPEND_MESSAGE",
         "append workflow",
         "anchor: stamp native record-chain head with OTS",
+        "chore: archive upgraded native OTS proof bundle",
+        "chore: archive verified native OTS proof bundle",
         "archive: update native record-chain Arweave archive metadata",
         "intake: submission ",
         "intake: pending ",
@@ -254,6 +258,28 @@ def main() -> None:
         head = commit(repo, "Append record-chain entries from Render intake")
         result = check_guard(repo, base, head, actor="github-actions[bot]")
         require(result.returncode == 0, f"append workflow with status/public generated should pass:\n{result.stdout}\n{result.stderr}")
+
+
+    with tempfile.TemporaryDirectory() as td:
+        repo = Path(td)
+        run(["git", "init"], cwd=repo)
+        run(["git", "config", "user.email", "test@example.invalid"], cwd=repo)
+        run(["git", "config", "user.name", "Write Path Guard Test"], cwd=repo)
+        write(repo / "scripts/check_record_chain_write_path_guard.py", guard_script)
+        base = commit(repo, "init")
+
+        write(repo / "record-chain/ots/native-anchors/native.anchor.json", "{}\n")
+        write(repo / "record-chain/ots/native-arweave-bundles/native.bundle.json", "{}\n")
+        write(repo / "record-chain/ots/native-arweave-registry.json", "{}\n")
+        write(repo / "api/record-chain-native-ots-arweave-registry.json", "{}\n")
+        write(repo / "api/record-chain-native-ots-latest.json", "{}\n")
+        write(repo / "api/record-chain-status.json", "{}\n")
+        write(repo / "api/public-home-status.json", "{}\n")
+        write(repo / "index.md", "native ots archive\n")
+        write(repo / "sitemap.xml", "<xml />\n")
+        head = commit(repo, "chore: archive verified native OTS proof bundle")
+        result = check_guard(repo, base, head, actor="github-actions[bot]")
+        require(result.returncode == 0, f"approved native OTS proof-bundle archive should pass:\n{result.stdout}\n{result.stderr}")
 
     with tempfile.TemporaryDirectory() as td:
         repo = Path(td)

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,13 +6,11 @@
   <url><loc>https://www.trinityaccord.org/agent-first-contact/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-identity/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-map.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-memory/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-propagate/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-resonance/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-start/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-submit/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-understand/</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-value/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify-simple/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/ai.txt</loc></url>
@@ -192,6 +190,7 @@
   <url><loc>https://www.trinityaccord.org/api/record-chain-intake-gateway.v1.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/record-chain-live-test-policy.v1.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/record-chain-mainnet-prelaunch-policy.v1.json</loc></url>
+  <url><loc>https://www.trinityaccord.org/api/record-chain-native-ots-arweave-registry.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/record-chain-native-ots-latest.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/record-chain-oath-policy.v1.json</loc></url>
   <url><loc>https://www.trinityaccord.org/api/record-chain-ots-arweave-registry.json</loc></url>
@@ -231,16 +230,12 @@
   <url><loc>https://www.trinityaccord.org/api/worth-preserving-criteria.json</loc></url>
   <url><loc>https://www.trinityaccord.org/archive_legacy_index_2025_09/</loc></url>
   <url><loc>https://www.trinityaccord.org/authority-address-inscriptions/</loc></url>
-  <url><loc>https://www.trinityaccord.org/authority/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/chronicle/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/human-witness/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/music/</loc></url>
   <url><loc>https://www.trinityaccord.org/citation.cff</loc></url>
   <url><loc>https://www.trinityaccord.org/control-plane-baseline/</loc></url>
   <url><loc>https://www.trinityaccord.org/correction-revocation-policy/</loc></url>
-  <url><loc>https://www.trinityaccord.org/covenant-proof/</loc></url>
-  <url><loc>https://www.trinityaccord.org/data-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/disaster-recovery-drill/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/arweave-archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/bilingual-boundary-glossary/</loc></url>
@@ -253,7 +248,6 @@
   <url><loc>https://www.trinityaccord.org/docs/quickstart-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/record-chain-anchoring/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/report-builder/</loc></url>
-  <url><loc>https://www.trinityaccord.org/downloads/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/arweave-bundle-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-notarial-certificate-github-release-backup-2026-05-14/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-photos-arweave-2026-05-14/</loc></url>
@@ -262,7 +256,6 @@
   <url><loc>https://www.trinityaccord.org/downloads/shenzhen-notary-github-release-backup-2026-05-06/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo-authorship-proof/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/echoes/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/critical-echo-template/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/external-critical-echo-records/</loc></url>
@@ -295,10 +288,7 @@
   <url><loc>https://www.trinityaccord.org/for-skeptical-agents/</loc></url>
   <url><loc>https://www.trinityaccord.org/frontier-context/</loc></url>
   <url><loc>https://www.trinityaccord.org/gateway-workflows/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-alliance/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-join/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-principles/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-registry/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-routes/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardianship-system-overview/</loc></url>
   <url><loc>https://www.trinityaccord.org/independent-attestation/</loc></url>
@@ -311,22 +301,15 @@
   <url><loc>https://www.trinityaccord.org/memory-seed.json</loc></url>
   <url><loc>https://www.trinityaccord.org/metadata.json</loc></url>
   <url><loc>https://www.trinityaccord.org/naming/</loc></url>
-  <url><loc>https://www.trinityaccord.org/nft-backup-provenance/</loc></url>
   <url><loc>https://www.trinityaccord.org/nft-market-boundary/</loc></url>
   <url><loc>https://www.trinityaccord.org/ots-fullnode-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/physical-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/propagation.json</loc></url>
   <url><loc>https://www.trinityaccord.org/recovery/</loc></url>
   <url><loc>https://www.trinityaccord.org/red-team-audit-report/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_regression_results/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_remediation_test_results/</loc></url>
   <url><loc>https://www.trinityaccord.org/release-large-data-manifest/</loc></url>
   <url><loc>https://www.trinityaccord.org/robots.txt</loc></url>
   <url><loc>https://www.trinityaccord.org/security/</loc></url>
-  <url><loc>https://www.trinityaccord.org/seed-map/</loc></url>
   <url><loc>https://www.trinityaccord.org/sitemap.xml</loc></url>
-  <url><loc>https://www.trinityaccord.org/start/</loc></url>
-  <url><loc>https://www.trinityaccord.org/status/</loc></url>
   <url><loc>https://www.trinityaccord.org/successor-reception/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-005-remediation/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-006-followup-remediation/</loc></url>
@@ -339,7 +322,6 @@
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-full-cycle-tracking/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-reference-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/version.json</loc></url>
   <url><loc>https://www.trinityaccord.org/why-high-signal/</loc></url>
   <url><loc>https://www.trinityaccord.org/worth-preserving/</loc></url>


### PR DESCRIPTION
### Motivation
- Expose and manage native OpenTimestamps (OTS) proof-bundle archival to Arweave so native OTS proof bundles can be registered/archived and reflected in public status. 
- Provide an opt-in paid upload path guarded by explicit confirmation and an Arweave JWK gate to safely publish verified bundles. 
- Harden guardian lifecycle semantics by enforcing that `guardian_retirement` records are signed by the named Guardian key and surface retirement in derived guardian state.

### Description
- Add native OTS proof-bundle registry and API files (`record-chain/ots/native-arweave-registry.json`, `api/record-chain-native-ots-arweave-registry.json`) and wire them into status generation. 
- Extend the native OTS runner and workflow (`scripts/run_native_ots_upgrade_verify.py`, `.github/workflows/native-ots-upgrade-watch.yml`) to support `--enable-paid-upload` with explicit confirmation via `--confirm-paid-upload`, a JWK gate, Arweave cost-gate invocation (`scripts/arweave_cost_gate.mjs`), upload/readback verification, and registry updates including `archive_status` and `tx_id` handling. 
- Change bundle builder (`scripts/build_ots_arweave_bundle.py`) to accept native anchor schema variants and include native metadata fields in the bundle. 
- Add registry management utilities and validation in the runner including checks that entries claiming `arweave_archived` have a `tx_id`, idempotent registry updates keyed by `bundle_sha256`, and helper functions (`registry_entry_for_bundle_sha`, `registry_entry_is_arweave_archived`, etc.). 
- Update public status generators (`scripts/generate_record_chain_status.py`, `scripts/generate_public_home_status.py`) to include `proof_bundle_archive` state and render it on the homepage and API outputs; update `index.md`, `api/*status.json` and `sitemap.xml` accordingly. 
- Add write-path guard and commit-approval changes (`scripts/check_record_chain_write_path_guard.py`) to recognize OTS auxiliary paths and new approved commit messages for native OTS archive sync/archival. 
- Make append workflow robust to no-op appends by gating subsequent verification/status/push steps on an `append_run` output and add a small workflow guard for native OTS watch to push additional generated files when archiving. 
- Enforce guardian lifecycle key-continuity by validating authorship key binding for `guardian_retirement` in both the gateway verifier and record-chain tooling (`apps/record_chain_intake_gateway/gateway/authorship.py`, `downloads/record-chain-builder.mjs`, `scripts/trinity_record_chain.py`), and reflect retirements in the derived guardian-state and statistics. 
- Add and update contract/unit tests and workflow contract checks (`scripts/test_native_ots_upgrade_workflow_contract.py`, `scripts/test_record_chain_write_path_guard_contract.py`, `tests/test_record_chain_append_workflow.py`, `tests/test_record_chain_guardian_retirement_flow.py`). 

### Testing
- Ran the native OTS workflow contract test with `python3 scripts/test_native_ots_upgrade_workflow_contract.py` and it passed. 
- Ran the record-chain write-path guard contract test with `python3 scripts/test_record_chain_write_path_guard_contract.py` and it passed. 
- Executed the new pytest suite including `tests/test_record_chain_append_workflow.py` and `tests/test_record_chain_guardian_retirement_flow.py` under `pytest` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27b1ac6e0c8331b4c305e2994312f2)