### PR TITLE
ops: add arweave wallet ledger updater and deterministic balance snapshot

### DIFF
--- a/.github/workflows/archive-backlog-repair.yml
+++ b/.github/workflows/archive-backlog-repair.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Regenerate public status
         run: |
           python3 scripts/detect_archive_backlog.py --write
-          python3 scripts/generate_arweave_wallet_status.py --use-env-balance
+          python3 scripts/generate_arweave_wallet_status.py
           python3 scripts/generate_record_chain_status.py
           python3 scripts/generate_public_home_status.py
           python3 scripts/generate_sitemap.py

--- a/.github/workflows/arweave-wallet-status-update.yml
+++ b/.github/workflows/arweave-wallet-status-update.yml
@@ -1,0 +1,102 @@
+name: Arweave wallet status update
+
+on:
+  workflow_dispatch:
+    inputs:
+      balance_ar:
+        description: "Last known AR wallet balance"
+        required: true
+        type: string
+      wallet_address_sha256:
+        description: "SHA256 of public AR wallet address"
+        required: false
+        type: string
+      low_balance_threshold_ar:
+        description: "Low balance threshold in AR"
+        required: false
+        default: "0.25"
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: arweave-wallet-status-update-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-wallet-status:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authorize write workflow actor
+        run: |
+          set -euo pipefail
+          case "${{ github.actor }}" in
+            thechurchofagi|github-actions[bot])
+              echo "Authorized actor"
+              ;;
+            *)
+              echo "Unauthorized actor: ${{ github.actor }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.11"
+
+      - name: Update wallet balance snapshot
+        run: |
+          set -euo pipefail
+          args=(
+            python3 scripts/update_arweave_wallet_ledger.py set-balance
+            --balance-ar "${{ inputs.balance_ar }}"
+            --low-balance-threshold-ar "${{ inputs.low_balance_threshold_ar }}"
+          )
+          if [ -n "${{ inputs.wallet_address_sha256 }}" ]; then
+            args+=(--wallet-address-sha256 "${{ inputs.wallet_address_sha256 }}")
+          fi
+          "${args[@]}"
+
+      - name: Regenerate public status
+        run: |
+          python3 scripts/generate_arweave_wallet_status.py
+          python3 scripts/generate_public_home_status.py
+          python3 scripts/generate_sitemap.py
+          python3 scripts/run_current_system_tests.py
+
+      - name: Commit wallet status update
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No wallet status changes to commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add \
+            record-chain/arweave-wallet-ledger.json \
+            api/arweave-wallet-status.json \
+            api/public-home-status.json \
+            index.md \
+            sitemap.xml
+
+          git diff --cached --name-only | while read -r path; do
+            case "$path" in
+              record-chain/records/*|record-chain/pending/*|record-chain/processed/*|record-chain/rejected/*|record-chain/chain-tip.json|archive/authority-*|authority/*|Bitcoin\ Originals/*)
+                echo "Forbidden write path: $path" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+          git commit -m "ops: update arweave wallet status"
+          git push

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -721,6 +721,17 @@ def main() -> int:
         fail(f"arweave wallet status contract failed:\n{result.stdout}\n{result.stderr}")
     ok("arweave wallet status contract")
 
+    # Arweave wallet ledger update contract
+    result = subprocess.run(
+        [sys.executable, "scripts/test_arweave_wallet_ledger_update.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"arweave wallet ledger update contract failed:\n{result.stdout}\n{result.stderr}")
+    ok("arweave wallet ledger update contract")
+
     # Archive backlog detector contract
     result = subprocess.run(
         [sys.executable, "scripts/test_archive_backlog_detector.py"],

--- a/scripts/test_archive_backlog_repair_contract.py
+++ b/scripts/test_archive_backlog_repair_contract.py
@@ -43,7 +43,7 @@ def main() -> int:
         "archive: repair backlog and wallet status metadata",
         "Forbidden write path",
         "record-chain/chain-tip.json",
-        "generate_arweave_wallet_status.py --use-env-balance",
+        "generate_arweave_wallet_status.py",
         "arweave-wallet-ledger.json",
         "arweave-wallet-status.json",
     ]:

--- a/scripts/test_arweave_wallet_ledger_update.py
+++ b/scripts/test_arweave_wallet_ledger_update.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "record-chain/arweave-wallet-ledger.json"
+STATUS = ROOT / "api/arweave-wallet-status.json"
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.run(cmd, cwd=ROOT, check=True)
+
+
+def main() -> int:
+    if not LEDGER.exists():
+        raise SystemExit("missing record-chain/arweave-wallet-ledger.json")
+    if not STATUS.exists():
+        raise SystemExit("missing api/arweave-wallet-status.json")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        backup_ledger = Path(tmp) / "arweave-wallet-ledger.json"
+        backup_status = Path(tmp) / "arweave-wallet-status.json"
+        shutil.copy2(LEDGER, backup_ledger)
+        shutil.copy2(STATUS, backup_status)
+
+        try:
+            run([
+                "python3", "scripts/update_arweave_wallet_ledger.py",
+                "set-balance",
+                "--balance-ar", "1.5",
+                "--wallet-address-sha256", "0" * 64,
+                "--low-balance-threshold-ar", "0.25",
+                "--balance-at", "2026-06-10T08:00:00Z",
+            ])
+            run([
+                "python3", "scripts/update_arweave_wallet_ledger.py",
+                "append-upload",
+                "--tx-id", "TEST_TX_ID_FOR_WALLET_LEDGER_CONTRACT",
+                "--kind", "contract_test",
+                "--source-path", "contract/test",
+                "--amount-ar", "0.1",
+                "--paid-at", "2026-06-10T08:01:00Z",
+            ])
+            run(["python3", "scripts/generate_arweave_wallet_status.py"])
+
+            status = json.loads(STATUS.read_text(encoding="utf-8"))
+            assert status["schema"] == "trinityaccord.arweave-wallet-status.v1"
+            assert status["balance"]["balance_known"] is True
+            assert status["balance"]["balance_ar"] == "1.5"
+            assert status["balance"]["needs_recharge"] is False
+            assert status["spending"]["total_spent_ar"] == "0.1"
+            assert status["spending"]["total_paid_uploads"] >= 1
+            assert status["wallet"]["wallet_address_sha256"] == "0" * 64
+            assert status["boundary"]["wallet_status_is_operational_only"] is True
+
+            print("PASS: arweave wallet ledger update contract")
+        finally:
+            shutil.copy2(backup_ledger, LEDGER)
+            shutil.copy2(backup_status, STATUS)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_arweave_wallet_ledger.py
+++ b/scripts/update_arweave_wallet_ledger.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+LEDGER = ROOT / "record-chain" / "arweave-wallet-ledger.json"
+
+SCHEMA = "trinityaccord.arweave-wallet-ledger.v1"
+DEFAULT_LOW_BALANCE_AR = "0.25"
+HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def read_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def dump(data: Any) -> str:
+    return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
+
+
+def decimal_string(value: str | None, field_name: str) -> str | None:
+    if value in (None, ""):
+        return None
+    try:
+        d = Decimal(str(value))
+    except InvalidOperation:
+        raise SystemExit(f"{field_name} must be a decimal string")
+    if d < 0:
+        raise SystemExit(f"{field_name} must be >= 0")
+    return format(d.normalize(), "f")
+
+
+def validate_sha256(value: str | None, field_name: str) -> str | None:
+    if value in (None, ""):
+        return None
+    if not HEX64.match(value):
+        raise SystemExit(f"{field_name} must be a 64-character hex sha256")
+    return value.lower()
+
+
+def default_ledger() -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "updated_at": "2026-06-10T00:00:00Z",
+        "wallet": {
+            "wallet_address": None,
+            "wallet_address_sha256": None,
+            "public_address_allowed": False,
+            "currency": "AR",
+            "last_known_balance_ar": None,
+            "last_known_balance_at": None,
+            "low_balance_threshold_ar": DEFAULT_LOW_BALANCE_AR,
+        },
+        "entries": [],
+        "boundary": {
+            "wallet_status_is_operational_only": True,
+            "wallet_status_is_not_authority": True,
+            "wallet_status_is_not_attestation": True,
+            "wallet_status_is_not_reception": True,
+            "bitcoin_originals_prevail": True,
+        },
+    }
+
+
+def load_ledger() -> dict[str, Any]:
+    ledger = read_json(LEDGER, default_ledger())
+    if ledger.get("schema") != SCHEMA:
+        raise SystemExit(f"unexpected ledger schema: {ledger.get('schema')}")
+    ledger.setdefault("wallet", {})
+    ledger.setdefault("entries", [])
+    ledger.setdefault("boundary", default_ledger()["boundary"])
+    return ledger
+
+
+def write_ledger(ledger: dict[str, Any]) -> None:
+    LEDGER.parent.mkdir(parents=True, exist_ok=True)
+    ledger["updated_at"] = utc_now()
+    LEDGER.write_text(dump(ledger), encoding="utf-8")
+
+
+def set_balance(args: argparse.Namespace) -> int:
+    ledger = load_ledger()
+    wallet = ledger.setdefault("wallet", {})
+
+    balance_ar = decimal_string(args.balance_ar, "balance_ar")
+    threshold = decimal_string(args.low_balance_threshold_ar, "low_balance_threshold_ar")
+    explicit_hash = validate_sha256(args.wallet_address_sha256, "wallet_address_sha256")
+
+    wallet["currency"] = "AR"
+    wallet["last_known_balance_ar"] = balance_ar
+    wallet["last_known_balance_at"] = args.balance_at or utc_now()
+    wallet["low_balance_threshold_ar"] = threshold or DEFAULT_LOW_BALANCE_AR
+
+    if args.wallet_address:
+        if args.public_address:
+            wallet["wallet_address"] = args.wallet_address
+            wallet["public_address_allowed"] = True
+        else:
+            wallet["wallet_address"] = None
+            wallet["public_address_allowed"] = False
+        wallet["wallet_address_sha256"] = sha256_text(args.wallet_address)
+
+    if explicit_hash:
+        wallet["wallet_address_sha256"] = explicit_hash
+        if not args.public_address:
+            wallet["wallet_address"] = None
+            wallet["public_address_allowed"] = False
+
+    write_ledger(ledger)
+    print(f"Updated AR wallet balance snapshot: {balance_ar} AR")
+    return 0
+
+
+def append_upload(args: argparse.Namespace) -> int:
+    ledger = load_ledger()
+    entries = ledger.setdefault("entries", [])
+
+    if any(isinstance(e, dict) and e.get("tx_id") == args.tx_id for e in entries):
+        print(f"Ledger already contains tx_id={args.tx_id}; no-op")
+        return 0
+
+    amount_ar = decimal_string(args.amount_ar, "amount_ar")
+    winston = decimal_string(args.winston, "winston")
+
+    if amount_ar is None and winston is None:
+        print("WARNING: no amount_ar or winston provided; total_spent_ar will not increase for this entry")
+
+    entries.append({
+        "tx_id": args.tx_id,
+        "kind": args.kind,
+        "source_path": args.source_path,
+        "amount_ar": amount_ar,
+        "winston": winston,
+        "paid_at": args.paid_at or utc_now(),
+        "status": args.status,
+        "note": args.note,
+    })
+
+    write_ledger(ledger)
+    print(f"Appended AR wallet ledger upload: tx_id={args.tx_id}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update Trinity Accord AR wallet ledger")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_balance = sub.add_parser("set-balance", help="Set last known AR wallet balance")
+    p_balance.add_argument("--balance-ar", required=True)
+    p_balance.add_argument("--balance-at")
+    p_balance.add_argument("--low-balance-threshold-ar", default=DEFAULT_LOW_BALANCE_AR)
+    p_balance.add_argument("--wallet-address")
+    p_balance.add_argument("--wallet-address-sha256")
+    p_balance.add_argument("--public-address", action="store_true")
+    p_balance.set_defaults(func=set_balance)
+
+    p_upload = sub.add_parser("append-upload", help="Append a paid upload ledger entry")
+    p_upload.add_argument("--tx-id", required=True)
+    p_upload.add_argument("--kind", required=True)
+    p_upload.add_argument("--source-path")
+    p_upload.add_argument("--amount-ar")
+    p_upload.add_argument("--winston")
+    p_upload.add_argument("--paid-at")
+    p_upload.add_argument("--status", default="paid", choices=["paid", "refunded", "failed", "unknown"])
+    p_upload.add_argument("--note")
+    p_upload.set_defaults(func=append_upload)
+
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a deterministic Arweave wallet ledger updater so the homepage can show known AR wallet balance and paid upload cost instead of Unknown.

## Changes

- Remove `--use-env-balance` from archive backlog repair regeneration to avoid CI drift.
- Add `scripts/update_arweave_wallet_ledger.py`.
- Add `scripts/test_arweave_wallet_ledger_update.py`.
- Wire ledger update contract into current system tests.
- Add manual workflow for balance snapshot updates.

## Safety

- Does not commit private key, ARKEY, or JWK.
- Public address remains hidden unless explicitly allowed.
- Wallet status remains operational only, not authority, attestation, amendment, or reception.
- Ordinary CI is deterministic and does not depend on secrets.

## Verification

```bash
python3 scripts/generate_arweave_wallet_status.py --check
python3 scripts/generate_public_home_status.py --check
python3 scripts/test_arweave_wallet_status.py
python3 scripts/test_arweave_wallet_ledger_update.py
python3 scripts/test_workflow_action_pinning_contract.py
python3 scripts/run_current_system_tests.py
```