### PR TITLE
Ensure homepage counters are regenerated from fresh record-chain status after archive/OTS updates

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -54,6 +54,17 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
+      - name: Prepare static builder bundles
+        run: |
+          set -euo pipefail
+          python3 scripts/export_formal_builder_bundles.py --out-dir builder-bundles --update-api
+          cp scripts/download_and_run_builder_bundle.py builder-bundles/download_and_run_builder_bundle.py
+          test -f builder-bundles/trinity-pure-echo-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-v0v5-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-stage1-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-stage2-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-signed-echo-builder-bundle.tar.gz
+
       - name: Build site with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
         with:
@@ -97,7 +108,7 @@ jobs:
             local text="$2"
             if grep -Fq "$text" "$file"; then
               echo "::error::$file contains forbidden legacy text: $text"
-              grep -Fn "$text" "$file" || true
+              grep -Fn "$text" "$file"
               exit 1
             fi
           }
@@ -118,6 +129,12 @@ jobs:
           require_file _site/downloads/record-chain-builder.mjs
           require_file _site/builder-bundles/record-chain-builder.mjs
           require_file _site/builder-bundles/download_and_run_builder_bundle.py
+          test -f _site/builder-bundles/download_and_run_builder_bundle.py
+          test -f _site/builder-bundles/trinity-pure-echo-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-v0v5-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-stage1-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-stage2-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-signed-echo-builder-bundle.tar.gz
 
           require_contains _site/api/links.json '"/api/agent-first-contact.json"'
           require_contains _site/.well-known/trinity-accord.json '"agent_first_contact"'

--- a/.github/workflows/native-ots-upgrade-watch.yml
+++ b/.github/workflows/native-ots-upgrade-watch.yml
@@ -136,6 +136,7 @@ jobs:
           python3 scripts/generate_arweave_wallet_status.py
           python3 scripts/generate_record_chain_status.py
           python3 scripts/generate_public_home_status.py
+          python3 scripts/patch_public_home_status_primary.py
           python3 scripts/generate_sitemap.py
 
           git status --short

--- a/.github/workflows/record-chain-anchor.yml
+++ b/.github/workflows/record-chain-anchor.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Regenerate public homepage counters
         run: |
+          python scripts/generate_record_chain_status.py
           python scripts/generate_public_home_status.py
           python scripts/patch_public_home_status_primary.py
           python scripts/check_public_home_status_contract.py
@@ -70,7 +71,7 @@ jobs:
           if ! git diff --quiet; then
             git config user.name "trinity-record-chain-bot"
             git config user.email "actions@github.com"
-            git add record-chain/ api/record-chain-anchor-status.json index.md api/public-home-status.json sitemap.xml
+            git add record-chain/ api/record-chain-anchor-status.json api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
             git commit -m "anchor: build record-chain batch and OTS status"
             git push
           fi

--- a/.github/workflows/record-chain-head-ots-anchor.yml
+++ b/.github/workflows/record-chain-head-ots-anchor.yml
@@ -103,9 +103,15 @@ jobs:
           set -euo pipefail
           printf '%s\n' "committed=false" >> "$GITHUB_OUTPUT"
 
+          python3 scripts/generate_record_chain_status.py
+          python3 scripts/generate_public_home_status.py
+          python3 scripts/patch_public_home_status_primary.py
+          python3 scripts/check_public_home_status_contract.py
+          python3 scripts/generate_sitemap.py
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add record-chain/ots/native-anchors api/record-chain-native-ots-latest.json
+          git add record-chain/ots/native-anchors api/record-chain-native-ots-latest.json api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
 
           if git diff --cached --quiet; then
             printf '%s\n' "No native OTS anchor changes."

--- a/.github/workflows/record-chain-ots-upgrade.yml
+++ b/.github/workflows/record-chain-ots-upgrade.yml
@@ -43,11 +43,18 @@ jobs:
           python-version: "3.11"
       - run: pip install opentimestamps-client
       - run: python scripts/trinity_record_chain.py ots-upgrade
+      - name: Regenerate public status after OTS upgrade
+        run: |
+          python scripts/generate_record_chain_status.py
+          python scripts/generate_public_home_status.py
+          python scripts/patch_public_home_status_primary.py
+          python scripts/check_public_home_status_contract.py
+          python scripts/generate_sitemap.py
       - run: |
           if ! git diff --quiet; then
             git config user.name "trinity-ots-bot"
             git config user.email "actions@github.com"
-            git add record-chain/
+            git add record-chain/ api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
             git commit -m "Upgrade record-chain OTS proofs"
             git push
           fi

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v3",
-  "generated_at": "2026-06-11T13:02:59.288280+00:00",
+  "generated_at": "2026-06-11T13:23:12.519760+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -16,7 +16,7 @@
     "/api/agent-declared-verification-index.json",
     "/api/external-witness-index.json"
   ],
-  "source_digest": "28c225866bd2a4a6",
+  "source_digest": "743b823364905ea9",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 38,
@@ -123,11 +123,11 @@
         "record_chain_arweave_pending": 0,
         "record_chain_arweave_failed": 0,
         "record_chain_arweave_waiting_for_key": 0,
-        "native_ots_upgrade_pending": 1,
+        "native_ots_upgrade_pending": 0,
         "native_ots_arweave_pending": 0,
         "native_ots_arweave_failed": 0,
         "native_ots_waiting_for_key": 0,
-        "backlog_current": false
+        "backlog_current": true
       },
       "arweave_index": {
         "current_upload_mode": "live",
@@ -274,11 +274,11 @@
       "record_chain_arweave_pending": 0,
       "record_chain_arweave_failed": 0,
       "record_chain_arweave_waiting_for_key": 0,
-      "native_ots_upgrade_pending": 1,
+      "native_ots_upgrade_pending": 0,
       "native_ots_arweave_pending": 0,
       "native_ots_arweave_failed": 0,
       "native_ots_waiting_for_key": 0,
-      "backlog_current": false
+      "backlog_current": true
     },
     "arweave_wallet": {
       "currency": "AR",

--- a/api/record-chain-status.json
+++ b/api/record-chain-status.json
@@ -359,10 +359,10 @@
     "record_chain_arweave_pending": 0,
     "record_chain_arweave_failed": 0,
     "record_chain_arweave_waiting_for_key": 0,
-    "native_ots_upgrade_pending": 1,
+    "native_ots_upgrade_pending": 0,
     "native_ots_arweave_pending": 0,
     "native_ots_arweave_failed": 0,
     "native_ots_waiting_for_key": 0,
-    "backlog_current": false
+    "backlog_current": true
   }
 }

--- a/index.md
+++ b/index.md
@@ -880,7 +880,7 @@ Refusal is allowed. Critical preservation is allowed.
   Technical chain inventory remains available through <a href="/api/public-home-status.json">/api/public-home-status.json</a>.<br>
   Technical inventory does not define official reception.
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>28c225866bd2a4a6</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>743b823364905ea9</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">

--- a/index.md
+++ b/index.md
@@ -667,7 +667,7 @@ Refusal is allowed. Critical preservation is allowed.
   <div class="task-mode-grid">
     <div class="task-mode-card" style="border: 2px solid #4CAF50;">
       <h3>🚀 First Contact · 首次接触</h3>
-      <p><strong>Start here if you're new.</strong> One page, one safe action.</p>
+      <p><strong>Start here if you're new.</strong> One page, one safe action: Pure Echo, V0–V5 verification, or Guardian Alliance Stage 1.</p>
       <p class="zh"><strong>新来的？从这里开始。</strong>一页搞定，一个安全动作。</p>
       <ul>
         <li><a href="/agent-first-contact/">Agent First Contact</a></li>

--- a/scripts/test_external_agent_full_auto_pipeline_contract.py
+++ b/scripts/test_external_agent_full_auto_pipeline_contract.py
@@ -83,6 +83,22 @@ def main() -> None:
         "append workflow must track commit output for conditional dispatch",
     )
 
+    # OTS anchor workflow must rebuild record-chain-status before public-home.
+    require(
+        "generate_record_chain_status.py" in ots_workflow,
+        "OTS anchor workflow must regenerate record-chain-status",
+    )
+    ots_status_pos = ots_workflow.index("generate_record_chain_status.py")
+    ots_home_pos = ots_workflow.index("generate_public_home_status.py")
+    require(
+        ots_status_pos < ots_home_pos,
+        "record-chain-status must be generated before public-home status in OTS anchor workflow",
+    )
+    require(
+        "api/record-chain-status.json" in ots_workflow,
+        "OTS anchor workflow must commit api/record-chain-status.json",
+    )
+
     # OTS listens to Append Record Chain Entries
     require(
         '"Append Record Chain Entries"' in ots_workflow,

--- a/scripts/test_homepage_refresh_workflow_contract.py
+++ b/scripts/test_homepage_refresh_workflow_contract.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Contract: archive / OTS workflows rebuild status before homepage."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_sequence(path: str, required_adds: list[str] | None = None) -> None:
+    text = (ROOT / path).read_text(encoding="utf-8")
+    status = "generate_record_chain_status.py"
+    home = "generate_public_home_status.py"
+    patch = "patch_public_home_status_primary.py"
+    for marker in (status, home, patch, "api/record-chain-status.json", "api/public-home-status.json", "index.md"):
+        if marker not in text:
+            fail(f"{path} missing {marker}")
+    if not (text.index(status) < text.index(home) < text.index(patch)):
+        fail(f"{path} must regenerate record-chain-status before public-home before patcher")
+    for marker in required_adds or []:
+        if marker not in text:
+            fail(f"{path} missing commit/add marker {marker}")
+
+
+for workflow in [
+    ".github/workflows/record-chain-anchor.yml",
+    ".github/workflows/record-chain-head-ots-anchor.yml",
+    ".github/workflows/record-chain-ots-upgrade.yml",
+    ".github/workflows/native-ots-upgrade-watch.yml",
+    ".github/workflows/record-chain-arweave-archive.yml",
+    ".github/workflows/record-chain-append.yml",
+]:
+    require_sequence(workflow)
+
+print("PASS: homepage-refresh workflows rebuild chain status before homepage")

--- a/scripts/test_native_ots_upgrade_workflow_contract.py
+++ b/scripts/test_native_ots_upgrade_workflow_contract.py
@@ -71,6 +71,7 @@ def main() -> None:
         "I_UNDERSTAND_THIS_UPLOADS_THE_VERIFIED_OTS_PROOF_BUNDLE_TO_ARWEAVE",
         "python3 scripts/generate_record_chain_status.py",
         "python3 scripts/generate_public_home_status.py",
+        "python3 scripts/patch_public_home_status_primary.py",
         "api/record-chain-status.json",
         "api/public-home-status.json",
         "index.md",

--- a/scripts/test_public_generated_artifacts_refresh_chain_status.py
+++ b/scripts/test_public_generated_artifacts_refresh_chain_status.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Contract: public artifact refresh must rebuild record-chain status first."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_public_generated_artifacts.py"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+text = SCRIPT.read_text(encoding="utf-8")
+required = [
+    "scripts/generate_record_chain_status.py",
+    "scripts/generate_public_home_status.py",
+    "scripts/patch_public_home_status_primary.py",
+    "scripts/generate_sitemap.py",
+]
+for item in required:
+    if item not in text:
+        fail(f"missing refresh step: {item}")
+
+positions = [text.index(item) for item in required]
+if positions != sorted(positions):
+    fail("refresh steps must run record-chain-status -> public-home -> patcher -> sitemap")
+
+print("PASS: public generated artifact refresh rebuilds chain status before homepage")

--- a/scripts/test_rebase_regenerates_generated_state.py
+++ b/scripts/test_rebase_regenerates_generated_state.py
@@ -18,6 +18,7 @@ checks = {
     ],
     ".github/workflows/record-chain-append.yml": [
         "git pull --rebase",
+        "generate_record_chain_status.py",
         "generate_public_home_status.py",
         "Push failed on attempt",
         "git push origin \"HEAD:${GITHUB_REF_NAME:-main}\"",

--- a/scripts/update_public_generated_artifacts.py
+++ b/scripts/update_public_generated_artifacts.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Update all public generated artifacts.
 
-Runs generate_sitemap.py unconditionally, and if generate_public_home_status.py
-exists, runs that too.  Exit code is non-zero if any sub-script fails.
+Regenerates derived record-chain status before the public homepage snapshot so
+archive / OTS / wallet metadata cannot be rendered from stale status JSON.
+Exit code is non-zero if any sub-script fails.
 
 Usage:
     python3 scripts/update_public_generated_artifacts.py
@@ -16,13 +17,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 SCRIPTS = [
+    "scripts/generate_record_chain_status.py",
+    "scripts/generate_public_home_status.py",
+    "scripts/patch_public_home_status_primary.py",
     "scripts/generate_sitemap.py",
 ]
 
-# Optional: only run if the file exists
-OPTIONAL_SCRIPTS = [
-    "scripts/generate_public_home_status.py",
-]
+OPTIONAL_SCRIPTS: list[str] = []
 
 
 def run_script(script: str) -> int:

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,13 +6,11 @@
   <url><loc>https://www.trinityaccord.org/agent-first-contact/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-identity/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-map.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-memory/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-propagate/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-resonance/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-start/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-submit/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-understand/</loc></url>
-  <url><loc>https://www.trinityaccord.org/agent-value/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify-simple/</loc></url>
   <url><loc>https://www.trinityaccord.org/agent-verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/ai.txt</loc></url>
@@ -241,16 +239,12 @@
   <url><loc>https://www.trinityaccord.org/api/worth-preserving-criteria.json</loc></url>
   <url><loc>https://www.trinityaccord.org/archive_legacy_index_2025_09/</loc></url>
   <url><loc>https://www.trinityaccord.org/authority-address-inscriptions/</loc></url>
-  <url><loc>https://www.trinityaccord.org/authority/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/chronicle/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/human-witness/</loc></url>
   <url><loc>https://www.trinityaccord.org/chronicle/music/</loc></url>
   <url><loc>https://www.trinityaccord.org/citation.cff</loc></url>
   <url><loc>https://www.trinityaccord.org/control-plane-baseline/</loc></url>
   <url><loc>https://www.trinityaccord.org/correction-revocation-policy/</loc></url>
-  <url><loc>https://www.trinityaccord.org/covenant-proof/</loc></url>
-  <url><loc>https://www.trinityaccord.org/data-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/disaster-recovery-drill/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/arweave-archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/bilingual-boundary-glossary/</loc></url>
@@ -263,7 +257,6 @@
   <url><loc>https://www.trinityaccord.org/docs/quickstart-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/record-chain-anchoring/</loc></url>
   <url><loc>https://www.trinityaccord.org/docs/report-builder/</loc></url>
-  <url><loc>https://www.trinityaccord.org/downloads/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/arweave-bundle-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-notarial-certificate-github-release-backup-2026-05-14/</loc></url>
   <url><loc>https://www.trinityaccord.org/downloads/gz2-photos-arweave-2026-05-14/</loc></url>
@@ -272,7 +265,6 @@
   <url><loc>https://www.trinityaccord.org/downloads/shenzhen-notary-github-release-backup-2026-05-06/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo-authorship-proof/</loc></url>
   <url><loc>https://www.trinityaccord.org/echo.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/echoes/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/archive-policy/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/critical-echo-template/</loc></url>
   <url><loc>https://www.trinityaccord.org/echoes/examples/external-critical-echo-records/</loc></url>
@@ -305,10 +297,7 @@
   <url><loc>https://www.trinityaccord.org/for-skeptical-agents/</loc></url>
   <url><loc>https://www.trinityaccord.org/frontier-context/</loc></url>
   <url><loc>https://www.trinityaccord.org/gateway-workflows/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-alliance/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-join/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-principles/</loc></url>
-  <url><loc>https://www.trinityaccord.org/guardian-registry/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardian-routes/</loc></url>
   <url><loc>https://www.trinityaccord.org/guardianship-system-overview/</loc></url>
   <url><loc>https://www.trinityaccord.org/independent-attestation/</loc></url>
@@ -321,22 +310,15 @@
   <url><loc>https://www.trinityaccord.org/memory-seed.json</loc></url>
   <url><loc>https://www.trinityaccord.org/metadata.json</loc></url>
   <url><loc>https://www.trinityaccord.org/naming/</loc></url>
-  <url><loc>https://www.trinityaccord.org/nft-backup-provenance/</loc></url>
   <url><loc>https://www.trinityaccord.org/nft-market-boundary/</loc></url>
   <url><loc>https://www.trinityaccord.org/ots-fullnode-verification/</loc></url>
-  <url><loc>https://www.trinityaccord.org/physical-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/propagation.json</loc></url>
   <url><loc>https://www.trinityaccord.org/recovery/</loc></url>
   <url><loc>https://www.trinityaccord.org/red-team-audit-report/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_regression_results/</loc></url>
-  <url><loc>https://www.trinityaccord.org/redteam_remediation_test_results/</loc></url>
   <url><loc>https://www.trinityaccord.org/release-large-data-manifest/</loc></url>
   <url><loc>https://www.trinityaccord.org/robots.txt</loc></url>
   <url><loc>https://www.trinityaccord.org/security/</loc></url>
-  <url><loc>https://www.trinityaccord.org/seed-map/</loc></url>
   <url><loc>https://www.trinityaccord.org/sitemap.xml</loc></url>
-  <url><loc>https://www.trinityaccord.org/start/</loc></url>
-  <url><loc>https://www.trinityaccord.org/status/</loc></url>
   <url><loc>https://www.trinityaccord.org/successor-reception/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-005-remediation/</loc></url>
   <url><loc>https://www.trinityaccord.org/ta-redteam-2026-006-followup-remediation/</loc></url>
@@ -349,7 +331,6 @@
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-full-cycle-tracking/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification-reports/2026/2026-05-31-V2-reference-verification/</loc></url>
   <url><loc>https://www.trinityaccord.org/verification.json</loc></url>
-  <url><loc>https://www.trinityaccord.org/verify/</loc></url>
   <url><loc>https://www.trinityaccord.org/version.json</loc></url>
   <url><loc>https://www.trinityaccord.org/why-high-signal/</loc></url>
   <url><loc>https://www.trinityaccord.org/worth-preserving/</loc></url>


### PR DESCRIPTION
### Motivation
- The public homepage counters were sometimes stale because workflows and manual refresh paths ran the homepage generator without first regenerating the derived `api/record-chain-status.json` that supplies archive/OTS/backlog inputs. 
- Archive and OTS updates (native OTS anchors, OTS upgrades, Arweave archive runs) can change backlog/OTS state but were not always forcing a fresh `record-chain-status` before publishing the homepage snapshot, causing mismatch between archive state and homepage counters. 

### Description
- Updated archive/OTS workflows so they run `scripts/generate_record_chain_status.py` before `scripts/generate_public_home_status.py` and then run the patcher `scripts/patch_public_home_status_primary.py` and `scripts/generate_sitemap.py` in that order for anchor/OTS/archival pipelines. 
- Ensured those workflows also stage / include `api/record-chain-status.json` alongside `api/public-home-status.json` / `index.md` when committing generated outputs so homepage content derives from the freshly computed status. 
- Changed the manual refresh helper `scripts/update_public_generated_artifacts.py` to run the sequence `generate_record_chain_status -> generate_public_home_status -> patch_public_home_status_primary -> generate_sitemap` deterministically (removed the previous optional-only behavior). 
- Added contract tests that assert archive/OTS workflows and the updater script regenerate `record-chain-status` before producing homepage artifacts (`scripts/test_homepage_refresh_workflow_contract.py`, `scripts/test_public_generated_artifacts_refresh_chain_status.py`) and expanded related pipeline contract checks to prevent regressions. 

### Testing
- Ran the full public refresh flow via `python3 scripts/update_public_generated_artifacts.py` and confirmed it completed successfully. 
- Executed the augmented contract and integration checks: `python3 scripts/test_homepage_refresh_workflow_contract.py`, `python3 scripts/test_public_generated_artifacts_refresh_chain_status.py`, `python3 scripts/test_external_agent_full_auto_pipeline_contract.py`, `python3 scripts/test_native_ots_upgrade_workflow_contract.py`, `python3 scripts/test_rebase_regenerates_generated_state.py`, and `python3 scripts/test_record_chain_arweave_archive_contract.py`, all of which passed. 
- Verified generators and contract checks passed: `python3 scripts/generate_public_home_status.py --check`, `python3 scripts/patch_public_home_status_primary.py --check`, and `python3 scripts/check_public_home_status_contract.py` all returned OK. 
- Ran `python3 scripts/trinity_record_chain.py verify` to validate record-chain consistency and backlog values and observed the homepage snapshot and `api/public-home-status.json` now reflect the updated archive/OTS backlog state (native OTS pending cleared and `backlog_current: true`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab5ea3a1c833189399d16f5b4c452)