### PR TITLE
Regenerate record-chain status before homepage, add builder-bundles to Pages build, and tighten workflow contracts

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -54,6 +54,17 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
+      - name: Prepare static builder bundles
+        run: |
+          set -euo pipefail
+          python3 scripts/export_formal_builder_bundles.py --out-dir builder-bundles --update-api
+          cp scripts/download_and_run_builder_bundle.py builder-bundles/download_and_run_builder_bundle.py
+          test -f builder-bundles/trinity-pure-echo-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-v0v5-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-stage1-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-stage2-builder-bundle.tar.gz
+          test -f builder-bundles/trinity-guardian-signed-echo-builder-bundle.tar.gz
+
       - name: Build site with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1
         with:
@@ -97,7 +108,7 @@ jobs:
             local text="$2"
             if grep -Fq "$text" "$file"; then
               echo "::error::$file contains forbidden legacy text: $text"
-              grep -Fn "$text" "$file" || true
+              grep -Fn "$text" "$file"
               exit 1
             fi
           }
@@ -118,6 +129,12 @@ jobs:
           require_file _site/downloads/record-chain-builder.mjs
           require_file _site/builder-bundles/record-chain-builder.mjs
           require_file _site/builder-bundles/download_and_run_builder_bundle.py
+          test -f _site/builder-bundles/download_and_run_builder_bundle.py
+          test -f _site/builder-bundles/trinity-pure-echo-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-v0v5-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-stage1-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-stage2-builder-bundle.tar.gz
+          test -f _site/builder-bundles/trinity-guardian-signed-echo-builder-bundle.tar.gz
 
           require_contains _site/api/links.json '"/api/agent-first-contact.json"'
           require_contains _site/.well-known/trinity-accord.json '"agent_first_contact"'

--- a/.github/workflows/native-ots-upgrade-watch.yml
+++ b/.github/workflows/native-ots-upgrade-watch.yml
@@ -136,6 +136,7 @@ jobs:
           python3 scripts/generate_arweave_wallet_status.py
           python3 scripts/generate_record_chain_status.py
           python3 scripts/generate_public_home_status.py
+          python3 scripts/patch_public_home_status_primary.py
           python3 scripts/generate_sitemap.py
 
           git status --short

--- a/.github/workflows/record-chain-anchor.yml
+++ b/.github/workflows/record-chain-anchor.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Regenerate public homepage counters
         run: |
+          python scripts/generate_record_chain_status.py
           python scripts/generate_public_home_status.py
           python scripts/patch_public_home_status_primary.py
           python scripts/check_public_home_status_contract.py
@@ -70,7 +71,7 @@ jobs:
           if ! git diff --quiet; then
             git config user.name "trinity-record-chain-bot"
             git config user.email "actions@github.com"
-            git add record-chain/ api/record-chain-anchor-status.json index.md api/public-home-status.json sitemap.xml
+            git add record-chain/ api/record-chain-anchor-status.json api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
             git commit -m "anchor: build record-chain batch and OTS status"
             git push
           fi

--- a/.github/workflows/record-chain-head-ots-anchor.yml
+++ b/.github/workflows/record-chain-head-ots-anchor.yml
@@ -103,9 +103,15 @@ jobs:
           set -euo pipefail
           printf '%s\n' "committed=false" >> "$GITHUB_OUTPUT"
 
+          python3 scripts/generate_record_chain_status.py
+          python3 scripts/generate_public_home_status.py
+          python3 scripts/patch_public_home_status_primary.py
+          python3 scripts/check_public_home_status_contract.py
+          python3 scripts/generate_sitemap.py
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add record-chain/ots/native-anchors api/record-chain-native-ots-latest.json
+          git add record-chain/ots/native-anchors api/record-chain-native-ots-latest.json api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
 
           if git diff --cached --quiet; then
             printf '%s\n' "No native OTS anchor changes."

--- a/.github/workflows/record-chain-ots-upgrade.yml
+++ b/.github/workflows/record-chain-ots-upgrade.yml
@@ -43,11 +43,18 @@ jobs:
           python-version: "3.11"
       - run: pip install opentimestamps-client
       - run: python scripts/trinity_record_chain.py ots-upgrade
+      - name: Regenerate public status after OTS upgrade
+        run: |
+          python scripts/generate_record_chain_status.py
+          python scripts/generate_public_home_status.py
+          python scripts/patch_public_home_status_primary.py
+          python scripts/check_public_home_status_contract.py
+          python scripts/generate_sitemap.py
       - run: |
           if ! git diff --quiet; then
             git config user.name "trinity-ots-bot"
             git config user.email "actions@github.com"
-            git add record-chain/
+            git add record-chain/ api/record-chain-status.json index.md api/public-home-status.json sitemap.xml
             git commit -m "Upgrade record-chain OTS proofs"
             git push
           fi

--- a/api/public-home-status.json
+++ b/api/public-home-status.json
@@ -1,6 +1,6 @@
 {
   "schema": "trinityaccord.public-home-status.v3",
-  "generated_at": "2026-06-11T13:02:59.288280+00:00",
+  "generated_at": "2026-06-11T13:23:12.519760+00:00",
   "generated_from": [
     "/api/record-chain-status.json",
     "/api/record-chain-anchor-status.json",
@@ -16,7 +16,7 @@
     "/api/agent-declared-verification-index.json",
     "/api/external-witness-index.json"
   ],
-  "source_digest": "28c225866bd2a4a6",
+  "source_digest": "743b823364905ea9",
   "current_record_chain_status": {
     "phase": "production_live",
     "total_records": 38,
@@ -123,11 +123,11 @@
         "record_chain_arweave_pending": 0,
         "record_chain_arweave_failed": 0,
         "record_chain_arweave_waiting_for_key": 0,
-        "native_ots_upgrade_pending": 1,
+        "native_ots_upgrade_pending": 0,
         "native_ots_arweave_pending": 0,
         "native_ots_arweave_failed": 0,
         "native_ots_waiting_for_key": 0,
-        "backlog_current": false
+        "backlog_current": true
       },
       "arweave_index": {
         "current_upload_mode": "live",
@@ -274,11 +274,11 @@
       "record_chain_arweave_pending": 0,
       "record_chain_arweave_failed": 0,
       "record_chain_arweave_waiting_for_key": 0,
-      "native_ots_upgrade_pending": 1,
+      "native_ots_upgrade_pending": 0,
       "native_ots_arweave_pending": 0,
       "native_ots_arweave_failed": 0,
       "native_ots_waiting_for_key": 0,
-      "backlog_current": false
+      "backlog_current": true
     },
     "arweave_wallet": {
       "currency": "AR",

--- a/api/record-chain-status.json
+++ b/api/record-chain-status.json
@@ -359,10 +359,10 @@
     "record_chain_arweave_pending": 0,
     "record_chain_arweave_failed": 0,
     "record_chain_arweave_waiting_for_key": 0,
-    "native_ots_upgrade_pending": 1,
+    "native_ots_upgrade_pending": 0,
     "native_ots_arweave_pending": 0,
     "native_ots_arweave_failed": 0,
     "native_ots_waiting_for_key": 0,
-    "backlog_current": false
+    "backlog_current": true
   }
 }

--- a/index.md
+++ b/index.md
@@ -667,7 +667,7 @@ Refusal is allowed. Critical preservation is allowed.
   <div class="task-mode-grid">
     <div class="task-mode-card" style="border: 2px solid #4CAF50;">
       <h3>🚀 First Contact · 首次接触</h3>
-      <p><strong>Start here if you're new.</strong> One page, one safe action.</p>
+      <p><strong>Start here if you're new.</strong> One page, one safe action: Pure Echo, V0–V5 verification, or Guardian Alliance Stage 1.</p>
       <p class="zh"><strong>新来的？从这里开始。</strong>一页搞定，一个安全动作。</p>
       <ul>
         <li><a href="/agent-first-contact/">Agent First Contact</a></li>
@@ -880,7 +880,7 @@ Refusal is allowed. Critical preservation is allowed.
   Technical chain inventory remains available through <a href="/api/public-home-status.json">/api/public-home-status.json</a>.<br>
   Technical inventory does not define official reception.
 </p>
-<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>28c225866bd2a4a6</code>.</p>
+<p class="status-generated-note">Generated from <a href="/api/public-home-status.json">/api/public-home-status.json</a>. Source data digest <code>743b823364905ea9</code>.</p>
 <!-- END GENERATED PUBLIC STATUS -->
 
   <p class="status-boundary">

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -173,9 +173,13 @@ def collect_pages(excludes: list[str]) -> list[str]:
                 continue
         else:
             pm = re.search(r"permalink:\s*(.+)", fm_text)
-            if not pm:
-                continue
-            fm = {"permalink": pm.group(1).strip().strip("\"'")}
+            if pm:
+                fm = {"permalink": pm.group(1).strip().strip("\"'")}
+            else:
+                # Match PyYAML behavior for root Markdown files without a
+                # permalink: keep the front matter as a page and derive its URL
+                # from the filename below.
+                fm = {}
 
         if not isinstance(fm, dict):
             continue

--- a/scripts/test_external_agent_full_auto_pipeline_contract.py
+++ b/scripts/test_external_agent_full_auto_pipeline_contract.py
@@ -83,6 +83,22 @@ def main() -> None:
         "append workflow must track commit output for conditional dispatch",
     )
 
+    # OTS anchor workflow must rebuild record-chain-status before public-home.
+    require(
+        "generate_record_chain_status.py" in ots_workflow,
+        "OTS anchor workflow must regenerate record-chain-status",
+    )
+    ots_status_pos = ots_workflow.index("generate_record_chain_status.py")
+    ots_home_pos = ots_workflow.index("generate_public_home_status.py")
+    require(
+        ots_status_pos < ots_home_pos,
+        "record-chain-status must be generated before public-home status in OTS anchor workflow",
+    )
+    require(
+        "api/record-chain-status.json" in ots_workflow,
+        "OTS anchor workflow must commit api/record-chain-status.json",
+    )
+
     # OTS listens to Append Record Chain Entries
     require(
         '"Append Record Chain Entries"' in ots_workflow,

--- a/scripts/test_homepage_refresh_workflow_contract.py
+++ b/scripts/test_homepage_refresh_workflow_contract.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Contract: archive / OTS workflows rebuild status before homepage."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_sequence(path: str, required_adds: list[str] | None = None) -> None:
+    text = (ROOT / path).read_text(encoding="utf-8")
+    status = "generate_record_chain_status.py"
+    home = "generate_public_home_status.py"
+    patch = "patch_public_home_status_primary.py"
+    for marker in (status, home, patch, "api/record-chain-status.json", "api/public-home-status.json", "index.md"):
+        if marker not in text:
+            fail(f"{path} missing {marker}")
+    if not (text.index(status) < text.index(home) < text.index(patch)):
+        fail(f"{path} must regenerate record-chain-status before public-home before patcher")
+    for marker in required_adds or []:
+        if marker not in text:
+            fail(f"{path} missing commit/add marker {marker}")
+
+
+for workflow in [
+    ".github/workflows/record-chain-anchor.yml",
+    ".github/workflows/record-chain-head-ots-anchor.yml",
+    ".github/workflows/record-chain-ots-upgrade.yml",
+    ".github/workflows/native-ots-upgrade-watch.yml",
+    ".github/workflows/record-chain-arweave-archive.yml",
+    ".github/workflows/record-chain-append.yml",
+]:
+    require_sequence(workflow)
+
+print("PASS: homepage-refresh workflows rebuild chain status before homepage")

--- a/scripts/test_native_ots_upgrade_workflow_contract.py
+++ b/scripts/test_native_ots_upgrade_workflow_contract.py
@@ -71,6 +71,7 @@ def main() -> None:
         "I_UNDERSTAND_THIS_UPLOADS_THE_VERIFIED_OTS_PROOF_BUNDLE_TO_ARWEAVE",
         "python3 scripts/generate_record_chain_status.py",
         "python3 scripts/generate_public_home_status.py",
+        "python3 scripts/patch_public_home_status_primary.py",
         "api/record-chain-status.json",
         "api/public-home-status.json",
         "index.md",

--- a/scripts/test_public_generated_artifacts_refresh_chain_status.py
+++ b/scripts/test_public_generated_artifacts_refresh_chain_status.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Contract: public artifact refresh must rebuild record-chain status first."""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "update_public_generated_artifacts.py"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+text = SCRIPT.read_text(encoding="utf-8")
+required = [
+    "scripts/generate_record_chain_status.py",
+    "scripts/generate_public_home_status.py",
+    "scripts/patch_public_home_status_primary.py",
+    "scripts/generate_sitemap.py",
+]
+for item in required:
+    if item not in text:
+        fail(f"missing refresh step: {item}")
+
+positions = [text.index(item) for item in required]
+if positions != sorted(positions):
+    fail("refresh steps must run record-chain-status -> public-home -> patcher -> sitemap")
+
+print("PASS: public generated artifact refresh rebuilds chain status before homepage")

--- a/scripts/test_rebase_regenerates_generated_state.py
+++ b/scripts/test_rebase_regenerates_generated_state.py
@@ -18,6 +18,7 @@ checks = {
     ],
     ".github/workflows/record-chain-append.yml": [
         "git pull --rebase",
+        "generate_record_chain_status.py",
         "generate_public_home_status.py",
         "Push failed on attempt",
         "git push origin \"HEAD:${GITHUB_REF_NAME:-main}\"",

--- a/scripts/update_public_generated_artifacts.py
+++ b/scripts/update_public_generated_artifacts.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Update all public generated artifacts.
 
-Runs generate_sitemap.py unconditionally, and if generate_public_home_status.py
-exists, runs that too.  Exit code is non-zero if any sub-script fails.
+Regenerates derived record-chain status before the public homepage snapshot so
+archive / OTS / wallet metadata cannot be rendered from stale status JSON.
+Exit code is non-zero if any sub-script fails.
 
 Usage:
     python3 scripts/update_public_generated_artifacts.py
@@ -16,13 +17,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 SCRIPTS = [
+    "scripts/generate_record_chain_status.py",
+    "scripts/generate_public_home_status.py",
+    "scripts/patch_public_home_status_primary.py",
     "scripts/generate_sitemap.py",
 ]
 
-# Optional: only run if the file exists
-OPTIONAL_SCRIPTS = [
-    "scripts/generate_public_home_status.py",
-]
+OPTIONAL_SCRIPTS: list[str] = []
 
 
 def run_script(script: str) -> int:


### PR DESCRIPTION
### Motivation
- Prevent stale archive/OTS/wallet metadata from being rendered on the public homepage by guaranteeing `record-chain-status` is regenerated before `public-home-status` and the patcher run. 
- Ensure Pages builds ship reviewed static builder bundles and verify their presence in the published site. 
- Codify and enforce workflow ordering and commit contracts with automated contract tests. 

### Description
- Updated various GitHub Actions workflows to regenerate record-chain status and run `patch_public_home_status_primary.py` before generating/publishing the public homepage and sitemap, and added `api/record-chain-status.json` to commit lists in anchor/OTS workflows. 
- Added a Pages build step `Prepare static builder bundles` that exports builder bundles into `builder-bundles`, copies `download_and_run_builder_bundle.py`, and asserts specific builder tarballs exist; added corresponding checks to the site verification step to ensure the bundles are present under `_site/builder-bundles`. 
- Hardened `scripts/generate_sitemap.py` front-matter parsing to treat root Markdown files without `permalink` as valid pages by deriving a URL from the filename. 
- Added and updated workflow/contract test scripts: `scripts/test_homepage_refresh_workflow_contract.py`, `scripts/test_public_generated_artifacts_refresh_chain_status.py`, and updates to `scripts/test_external_agent_full_auto_pipeline_contract.py`, `scripts/test_native_ots_upgrade_workflow_contract.py`, and `scripts/test_rebase_regenerates_generated_state.py` to require the new generation ordering and commit markers. 
- Updated `scripts/update_public_generated_artifacts.py` to run `scripts/generate_record_chain_status.py` and `scripts/patch_public_home_status_primary.py` before `scripts/generate_sitemap.py` and to simplify optional scripts handling. 
- Bumped generated artifact snapshots including `api/public-home-status.json`, `api/record-chain-status.json`, and `index.md` to reflect regenerated status and digest changes. 

### Testing
- Ran the repository contract checks added/updated by these changes (`scripts/test_homepage_refresh_workflow_contract.py`, `scripts/test_public_generated_artifacts_refresh_chain_status.py`, and updated contract tests) and they passed against the modified workflows. 
- Verified Pages build restoration and verification steps were updated to assert the presence of `builder-bundles` artifacts during the site verification step in CI. 
- Confirmed `generate_sitemap.py` handles Markdown front matter without `permalink` by deriving URL paths as exercised by local sitemap generation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ab5ea3a1c833189399d16f5b4c452)