### PR TITLE
ci: fail-closed guard for Builder receipt-boundary drift

### DIFF
--- a/.github/workflows/current-system-integrity.yml
+++ b/.github/workflows/current-system-integrity.yml
@@ -15,7 +15,7 @@ on:
       - "requirements-ci.txt"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: current-system-integrity-${{ github.ref }}
@@ -33,97 +33,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync Builder receipt boundary fields
-        if: github.actor != 'github-actions[bot]'
-        run: |
-          python3 - <<'PY'
-          import hashlib
-          import json
-          from pathlib import Path
-
-          fields = [
-              "receipt_is_not_final_inclusion",
-              "receipt_is_intake_only",
-              "later_records_may_reclassify_or_correct_this_record",
-          ]
-
-          old = '''    submission_boundary: {
-                not_authority: true,
-                not_governance: true,
-                not_attestation: true,
-                not_successor_reception: true,
-                not_amendment: true,
-                bitcoin_originals_prevail: true,
-              },'''
-
-          new = '''    submission_boundary: {
-                not_authority: true,
-                not_governance: true,
-                not_attestation: true,
-                not_successor_reception: true,
-                not_amendment: true,
-                bitcoin_originals_prevail: true,
-                receipt_is_not_final_inclusion: true,
-                receipt_is_intake_only: true,
-                later_records_may_reclassify_or_correct_this_record: true,
-              },'''
-
-          builder = Path("downloads/record-chain-builder.mjs")
-          text = builder.read_text(encoding="utf-8")
-          if new not in text:
-              if old not in text:
-                  raise SystemExit("expected Builder submission_boundary block not found")
-              builder.write_text(text.replace(old, new, 1), encoding="utf-8")
-
-          schema_path = Path("api/record-chain-submission-schema.v1.json")
-          schema = json.loads(schema_path.read_text(encoding="utf-8"))
-          boundary = schema["properties"]["submission_boundary"]
-          required = boundary.setdefault("required", [])
-          props = boundary.setdefault("properties", {})
-          for field in fields:
-              if field not in required:
-                  required.append(field)
-              props[field] = {"const": True}
-          boundary["additionalProperties"] = False
-          schema_path.write_text(json.dumps(schema, indent=2) + "\n", encoding="utf-8")
-
-          phase5c = Path("scripts/test_phase_5c_hotfix.py")
-          phase5c_text = phase5c.read_text(encoding="utf-8")
-          needle = '''    "bitcoin_originals_prevail",
-}'''
-          replacement = '''    "bitcoin_originals_prevail",
-    "receipt_is_not_final_inclusion",
-    "receipt_is_intake_only",
-    "later_records_may_reclassify_or_correct_this_record",
-}'''
-          if replacement not in phase5c_text:
-              if needle not in phase5c_text:
-                  raise SystemExit("expected Phase 5C boundary allowlist block not found")
-              phase5c.write_text(phase5c_text.replace(needle, replacement, 1), encoding="utf-8")
-
-          manifest_path = Path("api/record-chain-builder-bundles.v1.json")
-          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-          data = builder.read_bytes()
-          manifest["canonical_builder"]["sha256"] = hashlib.sha256(data).hexdigest()
-          manifest["canonical_builder"]["size_bytes"] = len(data)
-          manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-          PY
-
-          if git diff --quiet; then
-            echo "Builder receipt boundary already synchronized."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add downloads/record-chain-builder.mjs api/record-chain-submission-schema.v1.json api/record-chain-builder-bundles.v1.json scripts/test_phase_5c_hotfix.py
-            git commit -m "fix: sync builder receipt boundary fields"
-            git push origin HEAD:main
-          fi
-
       - name: Setup Python
         # actions/setup-python@v5
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
+
+      - name: Verify Builder receipt boundary fields are synchronized
+        run: python3 scripts/check_builder_receipt_boundary_sync.py
 
       - name: Install CI dependencies
         run: python -m pip install -r requirements-ci.txt

--- a/.github/workflows/repository-integrity.yml
+++ b/.github/workflows/repository-integrity.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   current-system-integrity:
@@ -21,40 +21,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Sync receipt boundary test allowlist
-        if: github.actor != 'github-actions[bot]'
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          p = Path("scripts/test_phase_5c_hotfix.py")
-          text = p.read_text(encoding="utf-8")
-          needle = '''    "bitcoin_originals_prevail",
-}'''
-          replacement = '''    "bitcoin_originals_prevail",
-    "receipt_is_not_final_inclusion",
-    "receipt_is_intake_only",
-    "later_records_may_reclassify_or_correct_this_record",
-}'''
-          if replacement not in text:
-              if needle not in text:
-                  raise SystemExit("expected Phase 5C boundary allowlist block not found")
-              p.write_text(text.replace(needle, replacement, 1), encoding="utf-8")
-          PY
-          if git diff --quiet; then
-            echo "Phase 5C boundary allowlist already synchronized."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add scripts/test_phase_5c_hotfix.py
-            git commit -m "test: sync phase5c receipt boundary allowlist"
-            git push origin HEAD:main
-          fi
-
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: "pip"
           cache-dependency-path: requirements-ci.txt
+
+      - name: Verify Builder receipt boundary fields are synchronized
+        run: python3 scripts/check_builder_receipt_boundary_sync.py
 
       - name: Install Python dependencies
         run: python3 -m pip install -r requirements-ci.txt

--- a/scripts/check_builder_receipt_boundary_sync.py
+++ b/scripts/check_builder_receipt_boundary_sync.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Verify Builder receipt-boundary fields stay synchronized across CI surfaces.
+
+This check intentionally fails with a clear message instead of editing files in CI.
+It protects the Builder, submission schema, Phase 5C regression allowlist, and
+builder bundle manifest from drifting out of sync after receipt-boundary changes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+RECEIPT_BOUNDARY_FIELDS = [
+    "receipt_is_not_final_inclusion",
+    "receipt_is_intake_only",
+    "later_records_may_reclassify_or_correct_this_record",
+]
+
+BASE_BOUNDARY_FIELDS = [
+    "not_authority",
+    "not_governance",
+    "not_attestation",
+    "not_successor_reception",
+    "not_amendment",
+    "bitcoin_originals_prevail",
+]
+
+REQUIRED_SUBMISSION_BOUNDARY_FIELDS = BASE_BOUNDARY_FIELDS + RECEIPT_BOUNDARY_FIELDS
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    raise SystemExit(1)
+
+
+def load_json(relative_path: str) -> dict:
+    path = ROOT / relative_path
+    if not path.exists():
+        fail(f"missing {relative_path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def require_text(relative_path: str, needles: list[str]) -> str:
+    path = ROOT / relative_path
+    if not path.exists():
+        fail(f"missing {relative_path}")
+    text = path.read_text(encoding="utf-8")
+    for needle in needles:
+        if needle not in text:
+            fail(f"{relative_path} missing synchronized text: {needle}")
+    return text
+
+
+def check_submission_schema() -> None:
+    schema = load_json("api/record-chain-submission-schema.v1.json")
+    boundary = schema.get("properties", {}).get("submission_boundary")
+    if not isinstance(boundary, dict):
+        fail("schema properties.submission_boundary is missing or not an object")
+
+    required = boundary.get("required")
+    if required != REQUIRED_SUBMISSION_BOUNDARY_FIELDS:
+        fail(f"submission_boundary.required drifted: {required!r}")
+
+    properties = boundary.get("properties", {})
+    for field in REQUIRED_SUBMISSION_BOUNDARY_FIELDS:
+        if properties.get(field) != {"const": True}:
+            fail(f"submission_boundary.properties.{field} must be {{'const': True}}")
+
+    extra = sorted(set(properties) - set(REQUIRED_SUBMISSION_BOUNDARY_FIELDS))
+    if extra:
+        fail(f"submission_boundary has schema-invalid extra properties: {extra}")
+
+    if boundary.get("additionalProperties") is not False:
+        fail("submission_boundary.additionalProperties must be false")
+
+
+def check_builder_source() -> None:
+    require_text(
+        "downloads/record-chain-builder.mjs",
+        [f"{field}: true" for field in RECEIPT_BOUNDARY_FIELDS],
+    )
+
+
+def check_phase5_allowlist() -> None:
+    require_text(
+        "scripts/test_phase_5c_hotfix.py",
+        [f'"{field}"' for field in REQUIRED_SUBMISSION_BOUNDARY_FIELDS],
+    )
+
+
+def check_builder_manifest_hash() -> None:
+    builder_path = ROOT / "downloads/record-chain-builder.mjs"
+    manifest = load_json("api/record-chain-builder-bundles.v1.json")
+    canonical_builder = manifest.get("canonical_builder", {})
+    builder_bytes = builder_path.read_bytes()
+    expected_sha = hashlib.sha256(builder_bytes).hexdigest()
+    expected_size = len(builder_bytes)
+    if canonical_builder.get("sha256") != expected_sha:
+        fail("api/record-chain-builder-bundles.v1.json canonical_builder.sha256 is stale")
+    if canonical_builder.get("size_bytes") != expected_size:
+        fail("api/record-chain-builder-bundles.v1.json canonical_builder.size_bytes is stale")
+
+
+def main() -> int:
+    check_submission_schema()
+    check_builder_source()
+    check_phase5_allowlist()
+    check_builder_manifest_hash()
+    print("PASS: Builder receipt-boundary fields are synchronized")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -191,7 +191,18 @@ def main() -> int:
         fail(f"Phase 5C-HOTFIX tests failed: {result.stderr}\n{result.stdout}")
     ok("Phase 5C-HOTFIX regression tests")
 
-    # 2d. Record type separation contract
+    # 2d. Builder receipt-boundary synchronization guard
+    result = subprocess.run(
+        [sys.executable, "scripts/check_builder_receipt_boundary_sync.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"Builder receipt-boundary sync check failed: {result.stderr}\n{result.stdout}")
+    ok("Builder receipt-boundary synchronization guard")
+
+    # 2e. Record type separation contract
     result = subprocess.run(
         [sys.executable, "scripts/test_record_type_separation_contract.py"],
         cwd=ROOT,


### PR DESCRIPTION
### Motivation
- Prevent brittle self-mutating CI that silently edits the Builder and related artifacts when receipt-boundary fields change and instead fail loudly so maintainers must reconcile intentional changes.
- Ensure the Builder source, submission schema, Phase 5C regression allowlist, and builder bundle manifest remain synchronized across CI surfaces so downstream tests remain stable.

### Description
- Add a read-only synchronization guard at `scripts/check_builder_receipt_boundary_sync.py` that verifies builder source flags, `api/record-chain-submission-schema.v1.json` required properties, `scripts/test_phase_5c_hotfix.py` allowlist entries, and the canonical builder `sha256`/`size_bytes` in `api/record-chain-builder-bundles.v1.json`.
- Replace prior self-mutating sync steps in CI with read-only checks by changing workflows to run the new guard and lowering workflow permissions from `contents: write` to `contents: read` in `.github/workflows/current-system-integrity.yml` and `.github/workflows/repository-integrity.yml`.
- Wire the new guard into the full test runner by invoking `scripts/check_builder_receipt_boundary_sync.py` from `scripts/run_current_system_tests.py` so the full current-system test run fails fast on boundary drift.
- Remove the in-CI auto-commit/auto-patch logic and instead surface mismatches as failing checks so changes require an intentional code update and review.

### Testing
- Ran `PYENV_VERSION=3.12.13 python scripts/check_builder_receipt_boundary_sync.py` and it passed (`PASS: Builder receipt-boundary fields are synchronized`).
- Ran `PYENV_VERSION=3.12.13 python scripts/run_current_system_tests.py` and the full suite completed with `=== ALL CURRENT SYSTEM TESTS PASSED ===`.
- Ran `PYENV_VERSION=3.12.13 python scripts/run_ci_group.py p0-current` and the `CI_GROUP_P0_CURRENT_OK` group passed.
- Parsed the modified workflows with `python -c 'import yaml; yaml.safe_load(open(path))'` for both `.github/workflows/current-system-integrity.yml` and `.github/workflows/repository-integrity.yml` and both YAML files parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0bf56750833183f471233511d588)