### PR TITLE
chore: harden Builder receipt-boundary guard and clarify oath readback UX (remove generated artifacts)

### DIFF
--- a/agent-start.md
+++ b/agent-start.md
@@ -64,6 +64,8 @@ All formal record types (echo, verification, guardian_application, etc.) require
 2. Provide an exact readback in your submission
 3. Declare that no automation shortcuts were used
 
+`print-oath` output is not decorative display text; it is the canonical oath text. Do not edit, filter, summarize, trim module headers, or reformat `print-oath` output. The `=== Module Title ===` lines are part of the canonical oath text. Pass the complete `print-oath` stdout as `--readback`. If exact readback handling is unclear, stop and return `BUILDER_USAGE_UNCLEAR`.
+
 The raw readback text is redacted before public persistence — only the hash remains.
 
 ### External-agent operating reminders
@@ -85,7 +87,11 @@ curl -fsS -O https://www.trinityaccord.org/downloads/record-chain-builder.mjs
 # 2. Get the canonical oath for your record type
 node record-chain-builder.mjs print-oath --record-type echo
 
-# 3. Read the canonical oath in your current context
+# 3. Read the canonical oath in your current context. Do not edit, filter,
+# summarize, trim module headers, or reformat print-oath output. The
+# === Module Title === lines are part of the canonical oath text. Pass the
+# complete print-oath stdout as --readback. If exact readback handling is
+# unclear, stop and return BUILDER_USAGE_UNCLEAR.
 
 # 4. Generate a signed submission with exact readback
 node record-chain-builder.mjs echo \

--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -47,11 +47,13 @@
     "record_type_commands": {
       "echo": {
         "oath_command": "node record-chain-builder.mjs print-oath --record-type echo",
-        "build_command": "node record-chain-builder.mjs echo ... --readback <exact oath text> --key-dir <private-key-dir> --out submission.json"
+        "build_command": "node record-chain-builder.mjs echo ... --readback <exact oath text> --key-dir <private-key-dir> --out submission.json",
+        "readback_note": "Pass the complete print-oath stdout as --readback. Do not edit, filter, summarize, trim module headers, or reformat it; === Module Title === lines are part of the canonical oath text. If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR."
       },
       "verification": {
         "oath_command": "node record-chain-builder.mjs print-oath --record-type verification",
-        "build_command": "node record-chain-builder.mjs verification ... --readback <exact oath text> --key-dir <private-key-dir> --out submission.json"
+        "build_command": "node record-chain-builder.mjs verification ... --readback <exact oath text> --key-dir <private-key-dir> --out submission.json",
+        "readback_note": "Pass the complete print-oath stdout as --readback. Do not edit, filter, summarize, trim module headers, or reformat it; === Module Title === lines are part of the canonical oath text. If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR."
       },
       "context_insufficient_notice": {
         "oath_command": null,
@@ -61,7 +63,21 @@
     },
     "local_validation_command": "node record-chain-builder.mjs doctor --file submission.json",
     "preflight_command": "node record-chain-builder.mjs preflight --file submission.json --gateway https://trinity-record-chain-gateway.onrender.com",
-    "submit_command": "node record-chain-builder.mjs submit --file submission.json --gateway https://trinity-record-chain-gateway.onrender.com"
+    "submit_command": "node record-chain-builder.mjs submit --file submission.json --gateway https://trinity-record-chain-gateway.onrender.com",
+    "oath_readback_canonical_output": {
+      "print_oath_output_is_canonical_oath_text": true,
+      "must_pass_complete_print_oath_stdout_as_readback": true,
+      "module_title_lines_are_canonical": true,
+      "module_title_line_example": "=== Module Title ===",
+      "forbidden_transformations": [
+        "edit_print_oath_output",
+        "filter_print_oath_output",
+        "summarize_print_oath_output",
+        "trim_module_headers",
+        "reformat_print_oath_output"
+      ],
+      "required_when_exact_readback_handling_is_unclear": "STOP_AND_RETURN_BUILDER_USAGE_UNCLEAR"
+    }
   },
   "external_agent_rules": {
     "must_not_clone_repository": true,

--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -5,8 +5,8 @@
     "language": "node",
     "runtime": "node>=18",
     "url": "/downloads/record-chain-builder.mjs",
-    "sha256": "0bc6e0b802ee26d5707363ea21dce8d46d753626a8d21048d193850235396903",
-    "size_bytes": 102663,
+    "sha256": "5c8646380a52ef2b0dd41db11781709d1df54ab60253698dab7f629156caa476",
+    "size_bytes": 103934,
     "supports": [
       "echo",
       "verification",

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -1608,6 +1608,10 @@ Common options:
   --out submission.json         Output file path
   --gateway URL                 Gateway base URL (default: ${DEFAULT_GATEWAY})
   --readback "oath text"        Exact canonical oath readback (required for formal records)
+                                Pass the complete print-oath stdout unchanged.
+                                Do not edit, filter, summarize, trim module headers, or reformat print-oath output.
+                                The === Module Title === lines are part of the canonical oath text.
+                                If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR.
 
 Autonomy / context override options:
   --discovery-mode MODE         How participant discovered Trinity Accord
@@ -1646,6 +1650,10 @@ Examples:
 
   # ── Echo (formal: requires print-oath + --readback) ───────────────
   # Step 1: Print the canonical oath and read it carefully
+  # Do not edit, filter, summarize, trim module headers, or reformat print-oath output.
+  # The === Module Title === lines are part of the canonical oath text.
+  # Pass the complete print-oath stdout as --readback.
+  # If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR.
   node record-chain-builder.mjs print-oath --record-type echo
 
   # Step 2: Build submission with exact oath readback
@@ -1984,7 +1992,9 @@ async function main() {
     if (!readback) {
       console.error("ERROR: --readback is required for formal record types.");
       console.error("Run: node record-chain-builder.mjs print-oath --record-type " + draft.record_type + (isLinkedGuardian ? " --linked-guardian" : ""));
-      console.error("Then provide the exact output as --readback.");
+      console.error("Then provide the complete print-oath stdout as --readback.");
+      console.error("Do not edit, filter, summarize, trim module headers, or reformat it; === Module Title === lines are canonical.");
+      console.error("If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR.");
       process.exit(1);
     }
     const normalizedReadback = readback.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim().normalize("NFC");
@@ -1992,6 +2002,9 @@ async function main() {
     if (normalizedReadback !== normalizedCanonical) {
       console.error("ERROR: --readback does not match canonical oath text.");
       console.error("Use: node record-chain-builder.mjs print-oath --record-type " + draft.record_type + (isLinkedGuardian ? " --linked-guardian" : ""));
+      console.error("Pass the complete print-oath stdout unchanged as --readback, including === Module Title === lines.");
+      console.error("Do not edit, filter, summarize, trim module headers, or reformat it.");
+      console.error("If exact readback handling is unclear, stop and return BUILDER_USAGE_UNCLEAR.");
       process.exit(1);
     }
     draft.submission_oath_verification = buildSubmissionOathVerification(draft.record_type, canonicalOath, readback, isLinkedGuardian);

--- a/external-agent-quickstart.md
+++ b/external-agent-quickstart.md
@@ -60,7 +60,7 @@ The operational canary is a non-formal test submission. It must not be presented
 2. Read [/agent-start/](/agent-start/)
 3. Download [/downloads/record-chain-builder.mjs](/downloads/record-chain-builder.mjs)
 4. Read [/api/record-chain-intake-gateway.v1.json](/api/record-chain-intake-gateway.v1.json)
-5. Run `node record-chain-builder.mjs print-oath --record-type echo|verification|guardian_application` for formal record types.
+5. Run `node record-chain-builder.mjs print-oath --record-type echo|verification|guardian_application` for formal record types. `print-oath` output is not decorative display text; it is the canonical oath text. Do not edit, filter, summarize, trim module headers, or reformat `print-oath` output. The `=== Module Title ===` lines are part of the canonical oath text. Pass the complete `print-oath` stdout as `--readback`. If exact readback handling is unclear, stop and return `BUILDER_USAGE_UNCLEAR`.
 6. Use `node record-chain-builder.mjs explain-fields --record-type echo` or `template --record-type echo --out template.json` only to understand fields; do not use the template as a hand-written substitute for the Builder.
 7. Build Echo, V0–V5 Verification, or Guardian Application with exact `--readback`, explicit context, and authorship proof.
 8. Validate locally with `node record-chain-builder.mjs doctor --file submission.json`.

--- a/scripts/check_builder_receipt_boundary_sync.py
+++ b/scripts/check_builder_receipt_boundary_sync.py
@@ -2,16 +2,22 @@
 """Verify Builder receipt-boundary fields stay synchronized across CI surfaces.
 
 This check intentionally fails with a clear message instead of editing files in CI.
-It protects the Builder, submission schema, Phase 5C regression allowlist, and
-builder bundle manifest from drifting out of sync after receipt-boundary changes.
+It protects the Builder, generated submissions, submission schema, Phase 5C
+regression allowlist, and builder bundle manifest from drifting out of sync after
+receipt-boundary changes.
 """
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
+import subprocess
+import tempfile
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
 
 RECEIPT_BOUNDARY_FIELDS = [
     "receipt_is_not_final_inclusion",
@@ -29,6 +35,7 @@ BASE_BOUNDARY_FIELDS = [
 ]
 
 REQUIRED_SUBMISSION_BOUNDARY_FIELDS = BASE_BOUNDARY_FIELDS + RECEIPT_BOUNDARY_FIELDS
+REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET = set(REQUIRED_SUBMISSION_BOUNDARY_FIELDS)
 
 
 def fail(message: str) -> None:
@@ -36,22 +43,44 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
-def load_json(relative_path: str) -> dict:
+def load_json(relative_path: str) -> dict[str, Any]:
     path = ROOT / relative_path
     if not path.exists():
         fail(f"missing {relative_path}")
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def require_text(relative_path: str, needles: list[str]) -> str:
-    path = ROOT / relative_path
-    if not path.exists():
-        fail(f"missing {relative_path}")
-    text = path.read_text(encoding="utf-8")
-    for needle in needles:
-        if needle not in text:
-            fail(f"{relative_path} missing synchronized text: {needle}")
-    return text
+def run_command(command: list[str], *, timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        fail(f"required command not found while running {command[0]!r}: {exc}")
+    except subprocess.TimeoutExpired as exc:
+        fail(f"command timed out after {timeout}s: {' '.join(command)}; stderr={exc.stderr!r}")
+
+
+def assert_exact_true_object(obj: Any, *, label: str) -> None:
+    if not isinstance(obj, dict):
+        fail(f"{label} is missing or not an object")
+
+    keys = set(obj)
+    missing = sorted(REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET - keys)
+    extra = sorted(keys - REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET)
+    if missing:
+        fail(f"{label} missing fields: {missing}")
+    if extra:
+        fail(f"{label} has extra fields: {extra}")
+
+    for field in REQUIRED_SUBMISSION_BOUNDARY_FIELDS:
+        if obj.get(field) is not True:
+            fail(f"{label}.{field} must be true, got {obj.get(field)!r}")
 
 
 def check_submission_schema() -> None:
@@ -69,7 +98,7 @@ def check_submission_schema() -> None:
         if properties.get(field) != {"const": True}:
             fail(f"submission_boundary.properties.{field} must be {{'const': True}}")
 
-    extra = sorted(set(properties) - set(REQUIRED_SUBMISSION_BOUNDARY_FIELDS))
+    extra = sorted(set(properties) - REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET)
     if extra:
         fail(f"submission_boundary has schema-invalid extra properties: {extra}")
 
@@ -77,18 +106,122 @@ def check_submission_schema() -> None:
         fail("submission_boundary.additionalProperties must be false")
 
 
-def check_builder_source() -> None:
-    require_text(
-        "downloads/record-chain-builder.mjs",
-        [f"{field}: true" for field in RECEIPT_BOUNDARY_FIELDS],
+def check_builder_generated_submission() -> None:
+    if not BUILDER.exists():
+        fail(f"missing {BUILDER.relative_to(ROOT)}")
+
+    oath_result = run_command(
+        ["node", str(BUILDER), "print-oath", "--record-type", "echo"],
+        timeout=10,
     )
+    if oath_result.returncode != 0:
+        fail(f"builder print-oath failed: {oath_result.stderr[:500]}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        out_file = tmp_path / "echo.json"
+        key_dir = tmp_path / "keys"
+        build_result = run_command(
+            [
+                "node",
+                str(BUILDER),
+                "echo",
+                "--actor-label",
+                "ReceiptBoundaryGuard",
+                "--provider",
+                "CI",
+                "--body",
+                "Receipt boundary guard echo",
+                "--context-level",
+                "CC-3",
+                "--context-sufficient-for-selected-action",
+                "true",
+                "--loaded-urls",
+                "https://www.trinityaccord.org/agent-first-contact/,https://www.trinityaccord.org/api/record-chain-intake-gateway.v1.json",
+                "--discovery-mode",
+                "user_task_context",
+                "--record-decision",
+                "human",
+                "--submission-executor",
+                "self",
+                "--human-operator-involved",
+                "true",
+                "--readback",
+                oath_result.stdout,
+                "--generate-authorship-key",
+                "--key-dir",
+                str(key_dir),
+                "--out",
+                str(out_file),
+            ],
+            timeout=20,
+        )
+        if build_result.returncode != 0:
+            fail(f"builder echo failed: {build_result.stderr[:1000]}")
+        if not out_file.exists():
+            fail("builder echo did not write the expected output file")
+
+        submission = json.loads(out_file.read_text(encoding="utf-8"))
+        assert_exact_true_object(
+            submission.get("submission_boundary"),
+            label="generated submission_boundary",
+        )
+        assert_exact_true_object(
+            submission.get("record_draft", {}).get("non_authority_boundary_acknowledgement"),
+            label="generated record_draft.non_authority_boundary_acknowledgement",
+        )
+
+        doctor_result = run_command(
+            ["node", str(BUILDER), "doctor", "--file", str(out_file)],
+            timeout=20,
+        )
+        if doctor_result.returncode != 0:
+            fail(f"builder doctor failed for generated submission: {doctor_result.stderr[:1000]}")
+
+
+def literal_assignment_value(path: Path, assignment_name: str) -> Any:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        fail(f"could not parse {path.relative_to(ROOT)}: {exc}")
+
+    matches: list[ast.AST] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == assignment_name:
+                    matches.append(node.value)
+        elif isinstance(node, ast.AnnAssign):
+            target = node.target
+            if isinstance(target, ast.Name) and target.id == assignment_name and node.value is not None:
+                matches.append(node.value)
+
+    if len(matches) != 1:
+        fail(f"expected exactly one {assignment_name} assignment in {path.relative_to(ROOT)}, found {len(matches)}")
+
+    try:
+        return ast.literal_eval(matches[0])
+    except (ValueError, SyntaxError) as exc:
+        fail(f"{assignment_name} in {path.relative_to(ROOT)} must be a literal collection: {exc}")
 
 
 def check_phase5_allowlist() -> None:
-    require_text(
-        "scripts/test_phase_5c_hotfix.py",
-        [f'"{field}"' for field in REQUIRED_SUBMISSION_BOUNDARY_FIELDS],
-    )
+    path = ROOT / "scripts" / "test_phase_5c_hotfix.py"
+    if not path.exists():
+        fail("missing scripts/test_phase_5c_hotfix.py")
+
+    value = literal_assignment_value(path, "REQUIRED_SUBMISSION_BOUNDARY_FIELDS")
+    if not isinstance(value, (set, list, tuple)) or not all(isinstance(item, str) for item in value):
+        fail("scripts/test_phase_5c_hotfix.py REQUIRED_SUBMISSION_BOUNDARY_FIELDS must be a literal string collection")
+
+    actual = set(value)
+    missing = sorted(REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET - actual)
+    extra = sorted(actual - REQUIRED_SUBMISSION_BOUNDARY_FIELD_SET)
+    if missing or extra:
+        fail(
+            "scripts/test_phase_5c_hotfix.py REQUIRED_SUBMISSION_BOUNDARY_FIELDS drifted; "
+            f"missing={missing}, extra={extra}"
+        )
 
 
 def check_builder_manifest_hash() -> None:
@@ -106,7 +239,7 @@ def check_builder_manifest_hash() -> None:
 
 def main() -> int:
     check_submission_schema()
-    check_builder_source()
+    check_builder_generated_submission()
     check_phase5_allowlist()
     check_builder_manifest_hash()
     print("PASS: Builder receipt-boundary fields are synchronized")

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -202,7 +202,18 @@ def main() -> int:
         fail(f"Builder receipt-boundary sync check failed: {result.stderr}\n{result.stdout}")
     ok("Builder receipt-boundary synchronization guard")
 
-    # 2e. Record type separation contract
+    # 2e. Builder canonical oath readback regression tests
+    result = subprocess.run(
+        [sys.executable, "scripts/test_builder_oath_readback_canonical_output.py"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        fail(f"Builder canonical oath readback tests failed: {result.stderr}\n{result.stdout}")
+    ok("Builder canonical oath readback regression tests")
+
+    # 2f. Record type separation contract
     result = subprocess.run(
         [sys.executable, "scripts/test_record_type_separation_contract.py"],
         cwd=ROOT,

--- a/scripts/test_builder_oath_readback_canonical_output.py
+++ b/scripts/test_builder_oath_readback_canonical_output.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Regression tests for canonical Builder oath readback handling."""
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
+
+RECEIPT_BOUNDARY_FIELDS = {
+    "receipt_is_not_final_inclusion",
+    "receipt_is_intake_only",
+    "later_records_may_reclassify_or_correct_this_record",
+}
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}")
+    raise SystemExit(1)
+
+
+def ok(msg: str) -> None:
+    print(f"PASS: {msg}")
+
+
+def run_builder(args: list[str], *, timeout: int = 20) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", str(BUILDER), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def print_echo_oath() -> str:
+    result = run_builder(["print-oath", "--record-type", "echo"], timeout=10)
+    if result.returncode != 0:
+        fail(f"print-oath failed: {result.stderr[:300]}")
+    if "=== Common Submission Integrity (common_submission_integrity_v1) ===" not in result.stdout:
+        fail("print-oath output is missing the common module header")
+    if "=== Echo Integrity (echo_integrity_v1) ===" not in result.stdout:
+        fail("print-oath output is missing the echo module header")
+    return result.stdout
+
+
+def build_echo(readback: str, tmp_dir: Path) -> subprocess.CompletedProcess[str]:
+    return run_builder(
+        [
+            "echo",
+            "--actor-label",
+            "CanonicalReadbackTest",
+            "--provider",
+            "CI",
+            "--body",
+            "Canonical oath readback test echo",
+            "--context-level",
+            "CC-3",
+            "--context-sufficient-for-selected-action",
+            "true",
+            "--loaded-urls",
+            "https://www.trinityaccord.org/agent-first-contact/,https://www.trinityaccord.org/api/record-chain-intake-gateway.v1.json",
+            "--discovery-mode",
+            "user_task_context",
+            "--record-decision",
+            "human",
+            "--submission-executor",
+            "self",
+            "--human-operator-involved",
+            "true",
+            "--readback",
+            readback,
+            "--generate-authorship-key",
+            "--key-dir",
+            str(tmp_dir / "keys"),
+            "--out",
+            str(tmp_dir / "echo.json"),
+        ],
+        timeout=20,
+    )
+
+
+def without_module_headers(oath: str) -> str:
+    return "\n".join(line for line in oath.splitlines() if not line.startswith("==="))
+
+
+def require_receipt_boundary_fields(submission: dict[str, Any]) -> None:
+    boundary = submission.get("submission_boundary")
+    if not isinstance(boundary, dict):
+        fail("Builder-generated submission_boundary is missing or not an object")
+    missing = sorted(RECEIPT_BOUNDARY_FIELDS - set(boundary))
+    if missing:
+        fail(f"Builder-generated submission_boundary missing receipt fields: {missing}")
+    for field in sorted(RECEIPT_BOUNDARY_FIELDS):
+        if boundary.get(field) is not True:
+            fail(f"Builder-generated submission_boundary.{field} is not true")
+
+
+def test_complete_print_oath_stdout_is_accepted() -> None:
+    oath = print_echo_oath()
+    with tempfile.TemporaryDirectory() as td:
+        tmp_dir = Path(td)
+        result = build_echo(oath, tmp_dir)
+        if result.returncode != 0:
+            fail(f"Builder rejected unchanged print-oath stdout: {result.stderr[:500]}")
+        submission = json.loads((tmp_dir / "echo.json").read_text(encoding="utf-8"))
+        require_receipt_boundary_fields(submission)
+    ok("unchanged print-oath stdout with module headers is accepted")
+
+
+def test_removed_module_headers_fail_closed() -> None:
+    oath = print_echo_oath()
+    stripped_oath = without_module_headers(oath)
+    if stripped_oath == oath:
+        fail("test setup did not remove module headers")
+    with tempfile.TemporaryDirectory() as td:
+        result = build_echo(stripped_oath, Path(td))
+        if result.returncode == 0:
+            fail("Builder accepted readback after module headers were removed")
+        combined = f"{result.stdout}\n{result.stderr}"
+        if "does not match canonical oath text" not in combined:
+            fail(f"Builder failed for the wrong reason: {combined[:500]}")
+    ok("removing module headers fails closed")
+
+
+def main() -> int:
+    test_complete_print_oath_stdout_is_accepted()
+    test_removed_module_headers_fail_closed()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Close two P2 weaknesses introduced after PR #489 by verifying the Builder-generated top-level `submission_boundary` rather than loose text searches, and by making Phase 5C allowlist comparison exact.
- Make oath readback UX explicit so external agents pass the canonical `print-oath` stdout unchanged and the Builder fails closed on any transformation.
- Remove generated archive/OTS artifacts that caused GitHub's web conflict editor to report unsupported binary files so the PR diff remains text-only.

### Description
- Add `scripts/check_builder_receipt_boundary_sync.py` which runs the canonical Builder (`node downloads/record-chain-builder.mjs print-oath` + `echo` with `--readback`), loads the generated submission, asserts top-level `submission_boundary` and `record_draft.non_authority_boundary_acknowledgement` exactly contain the required fields set to `true`, runs `node ... doctor --file`, and also checks schema and manifest hash/size.
- Replace loose Phase 5C allowlist checks with an AST-based extractor `literal_assignment_value(..., "REQUIRED_SUBMISSION_BOUNDARY_FIELDS")` and exact `ast.literal_eval`-based set comparison in the same guard script.
- Add regression test `scripts/test_builder_oath_readback_canonical_output.py` that proves unchanged `print-oath` stdout (including `=== ... ===` headers) is accepted and that removing module-header lines fails closed while also checking receipt-boundary fields in the generated submission.
- Wire the new guard and regression test into `scripts/run_current_system_tests.py` and update both workflows to `permissions.contents: read` (removing any self-mutating auto-commit logic), plus refresh Builder help/docs and `api/agent-start.v2.json` wording to require passing complete `print-oath` stdout as `--readback` and to return `BUILDER_USAGE_UNCLEAR` when handling is unclear.
- Remove generated record-chain/arweave/OTS submission/receipt artifacts from the PR so the net diff contains only the intended text/code changes and no binary files, and update the canonical builder manifest `sha256`/`size_bytes` to match the help text edits.

### Testing
- Ran `PYENV_VERSION=3.12.13 python3 scripts/check_builder_receipt_boundary_sync.py` and it passed. 
- Ran `PYENV_VERSION=3.12.13 python3 scripts/test_builder_oath_readback_canonical_output.py` and `PYENV_VERSION=3.12.13 python3 scripts/test_phase_5c_hotfix.py` and both passed. 
- Ran the full suite with `PYENV_VERSION=3.12.13 python3 scripts/run_current_system_tests.py` and `PYENV_VERSION=3.12.13 python3 scripts/run_ci_group.py p0-current` and they both passed after installing `requirements-ci.txt` into the CI-compatible interpreter. 
- Verified workflows parse with `yaml.safe_load`, checked `git diff --check`, and confirmed `git diff --numstat` shows no binary files in the net PR diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0bf56750833183f471233511d588)