### PR TITLE
ci(record-chain): add push retry logic and improve gateway guard error message

### DIFF
--- a/.github/workflows/native-ots-upgrade-watch.yml
+++ b/.github/workflows/native-ots-upgrade-watch.yml
@@ -159,7 +159,19 @@ jobs:
           else
             git commit -m "chore: sync upgraded native OTS anchor and registry"
           fi
-          git push
+
+          for attempt in 1 2 3; do
+            if git push; then
+              exit 0
+            fi
+            printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+            git fetch origin main
+            git rebase origin main || { git rebase --abort; }
+            sleep $((attempt * 5))
+          done
+
+          echo "::error::Failed to push native OTS upgrade after retries."
+          exit 1
 
       - name: Upload native OTS audit logs
         if: always()

--- a/.github/workflows/record-chain-anchor.yml
+++ b/.github/workflows/record-chain-anchor.yml
@@ -60,10 +60,23 @@ jobs:
 
       - name: Commit anchor updates
         run: |
+          set -euo pipefail
           if ! git diff --quiet; then
             git config user.name "trinity-record-chain-bot"
             git config user.email "actions@github.com"
             git add record-chain/ api/record-chain-anchor-status.json
             git commit -m "anchor: build record-chain batch and OTS status"
-            git push
+
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+              git fetch origin main
+              git rebase origin main || { git rebase --abort; }
+              sleep $((attempt * 5))
+            done
+
+            echo "::error::Failed to push anchor updates after retries."
+            exit 1
           fi

--- a/.github/workflows/record-chain-auto-finalize.yml
+++ b/.github/workflows/record-chain-auto-finalize.yml
@@ -75,5 +75,17 @@ jobs:
             echo "No finalization changes."
           else
             git commit -m "record-chain: auto-finalize accepted submissions"
-            git push
+
+            for attempt in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+              git fetch origin main
+              git rebase origin main || { git rebase --abort; }
+              sleep $((attempt * 5))
+            done
+
+            echo "::error::Failed to push auto-finalize updates after retries."
+            exit 1
           fi

--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -195,7 +195,11 @@ def require_actions_actor(actor: str | None, writer: str) -> tuple[bool, str]:
 
 def require_gateway_actor(actor: str | None, allowed_gateway_actors: set[str]) -> tuple[bool, str]:
     if not allowed_gateway_actors:
-        return False, "gateway intake actor allow-list is not configured"
+        return False, (
+            "gateway intake actor allow-list is not configured; "
+            "set repo variable RECORD_CHAIN_GATEWAY_ACTORS to a comma-separated list of allowed GitHub actors "
+            f"(e.g. RECORD_CHAIN_GATEWAY_ACTORS={actor or 'thechurchofagi'})"
+        )
     if actor in allowed_gateway_actors:
         return True, "gateway intake actor verified"
     return False, f"gateway intake actor not allowed: actor={actor!r} allowed={sorted(allowed_gateway_actors)!r}"


### PR DESCRIPTION
### Root cause

Gateway intake commits trigger multiple concurrent CI writer workflows that race while pushing to `main`:

- `record-chain-anchor.yml` and `record-chain-auto-finalize.yml` used bare `git push` without retry, causing `git push rejected` when another workflow pushed first.
- `native-ots-upgrade-watch.yml` had the same bare `git push` problem.
- Write Path Guard failed closed because repo variable `RECORD_CHAIN_GATEWAY_ACTORS` was not configured, but the error message did not name the variable.

### Fix

- Add bounded `git fetch + rebase + retry` (3 attempts with backoff) to `record-chain-anchor.yml`, `record-chain-auto-finalize.yml`, and `native-ots-upgrade-watch.yml`.
- Improve Write Path Guard error message to show the exact repo variable name (`RECORD_CHAIN_GATEWAY_ACTORS`) and example value.
- All retry loops use `git fetch origin main` + `git rebase origin main` (not `git pull --rebase || true`) to comply with the fail-open test.

### Manual action required

Configure repo variable before merging:

```
Settings > Variables > Actions > New repository variable
Name:  RECORD_CHAIN_GATEWAY_ACTORS
Value: thechurchofagi
```

### Safety

- No record-chain records/OTS/Arweave/status artifacts edited.
- No force-push.
- No `continue-on-error`.
- No wildcard allow-list.
- No docs/Builder changes mixed in.

### Testing

- `python3 scripts/run_current_system_tests.py` — ALL PASSED
- `python3 scripts/run_ci_group.py p0-current` — OK
- YAML parse check — OK
- `git diff --check` — clean