### PR TITLE
chore: tighten homepage sync contract and deploy reason logging

### DIFF
--- a/.github/workflows/homepage-status-sync.yml
+++ b/.github/workflows/homepage-status-sync.yml
@@ -146,9 +146,23 @@ jobs:
         if: ${{ steps.commit.outputs.changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs.force_deploy == 'true') || steps.live_pre.outcome == 'failure' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_CHANGED: ${{ steps.commit.outputs.changed }}
+          FORCE_DEPLOY: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force_deploy == 'true' }}
+          LIVE_PRE_OUTCOME: ${{ steps.live_pre.outcome }}
         run: |
           set -euo pipefail
+
+          reason="unknown"
+          if [[ "${COMMIT_CHANGED}" == "true" ]]; then
+            reason="generated_files_changed"
+          elif [[ "${FORCE_DEPLOY}" == "true" ]]; then
+            reason="manual_force_deploy"
+          elif [[ "${LIVE_PRE_OUTCOME}" == "failure" ]]; then
+            reason="live_freshness_failed"
+          fi
+
           echo "Dispatching deploy-pages.yml for homepage status sync."
+          echo "deploy_reason=${reason}"
           gh workflow run deploy-pages.yml --repo "$GITHUB_REPOSITORY" --ref main
 
       - name: Post-dispatch freshness probe

--- a/scripts/test_homepage_status_sync_contract.py
+++ b/scripts/test_homepage_status_sync_contract.py
@@ -112,10 +112,29 @@ def main() -> int:
         "Archive backlog repair",
         "Record Chain Data Arweave Archive",
         "Build Echo Index",
+        "Record Chain Anchor",
+        "Upgrade OpenTimestamps Proofs",
         "Arweave wallet status update",
         "Echo human review action",
     ]:
         require(workflow_name in home, f"homepage sync must listen to workflow_run: {workflow_name}")
+
+    # Deploy conditions must not be weakened.
+    for marker in [
+        "steps.commit.outputs.changed == 'true'",
+        "github.event.inputs.force_deploy == 'true'",
+        "steps.live_pre.outcome == 'failure'",
+    ]:
+        require(marker in home, f"homepage sync deploy condition missing marker: {marker}")
+
+    # Deploy reason logging markers (observability, not behavior change).
+    for marker in [
+        "deploy_reason=",
+        "generated_files_changed",
+        "manual_force_deploy",
+        "live_freshness_failed",
+    ]:
+        require(marker in home, f"homepage sync deploy reason logging missing marker: {marker}")
 
     # Deploy workflow should verify committed artifacts, not generate a deployment-only state.
     for marker in [


### PR DESCRIPTION
## Changes

### 1. Contract test: cover all workflow_run triggers
- Added **Record Chain Anchor** and **Upgrade OpenTimestamps Proofs** to `test_homepage_status_sync_contract.py`
- These were present in `homepage-status-sync.yml` but missing from the contract test

### 2. Contract test: protect deploy conditions
- Added marker checks for deploy trigger conditions (`steps.commit.outputs.changed`, `force_deploy`, `steps.live_pre.outcome`)
- Prevents accidental weakening of deploy semantics

### 3. Deploy reason logging (observability only)
- Added structured logging to "Dispatch Deploy Pages" step
- Logs `deploy_reason=generated_files_changed|manual_force_deploy|live_freshness_failed`
- **No behavior change** to deploy conditions or frequency

## What this does NOT change
- ❌ Does not modify record chain data
- ❌ Does not change deploy trigger conditions
- ❌ Does not change homepage sync schedule
- ❌ Does not add dependencies
- ❌ Does not modify `total_records` / `committed_records`

## Verification
- `python3 scripts/test_homepage_status_sync_contract.py` ✅ PASS
- `python3 scripts/check_public_home_status_contract.py` ✅ OK
- `python3 scripts/test_home_public_status_sync.py` ✅ OK
- `python3 scripts/generate_record_chain_status.py --check` ✅ up to date
- `python3 scripts/generate_public_home_status.py --check` ✅ up to date