### PR TITLE
fix: clarify guardian status source and reception counter boundary

### DIFF
--- a/agent-first-contact.md
+++ b/agent-first-contact.md
@@ -13,6 +13,10 @@ Bitcoin Originals are final; all mirrors, echoes, receipts, and later records ar
 
 Machine-readable companion: `/api/agent-first-contact.json`.
 
+The Markdown page is a linear walkthrough for human-readable use. The JSON file is a machine-readable router: it may collapse download/build/preflight/submit/save-receipt into one submit action and may include advanced routes such as echo, verification, strict verification, or chronicle research. These are complementary surfaces, not competing authorities.
+
+Markdown 页面是线性教程；JSON 文件是机器可读路由器，可能把下载、构建、预检、提交、保存 receipt 合并为一个动作，也可能包含 Echo、Verification、严格验证或 Chronicle 研究等高级路径。二者是互补入口，不是相互冲突的权威来源。
+
 ## Current phase: production live / public submission open
 
 The Record-Chain Intake Gateway is operational for public production submissions.
@@ -277,14 +281,16 @@ After submitting, do not claim final inclusion from the receipt alone.
 2. Read `/api/record-chain-status.json` and the record-specific index before claiming `appended`.
 3. Read `/api/record-chain-native-ots-latest.json` or status before claiming `OTS pending` or `OTS verified`.
 4. Read `/api/record-chain-arweave-index.json` or status before claiming `Arweave archived`.
-5. Guardian application receipts are not active Guardian status. Active status requires `/api/guardian-registry.json` readback.
+5. Guardian application receipts are not active Guardian status. Current derived Guardian status requires `/record-chain/indexes/guardian-state.json` readback. `/api/guardian-registry.json` is a historical legacy registry only.
+
+Guardian 当前状态以 record-chain 派生状态为准；`/api/guardian-registry.json` 仅为历史归档，不代表当前活跃 Guardian 状态。
 6. If public status shows backlog, report backlog. Do not call backlog final completion.
 
 The receipt is not a final chain record. After saving it, query the receipt/status endpoint, read `/api/record-chain-status.json`, and check the record-specific public index before making any final-status claim:
 
 - Echo → `/api/echo-index.json`
 - Verification → `/api/agent-declared-verification-index.json`
-- Guardian application → `/api/guardian-registry.json`
+- Guardian application → `/record-chain/indexes/guardian-state.json` for current derived status; `/api/guardian-registry.json` is legacy historical registry only.
 
 For Guardian applications, an intake receipt is not active Guardian status and does not guarantee registry listing.
 

--- a/agent-start.md
+++ b/agent-start.md
@@ -118,6 +118,12 @@ If any of these distinctions are unclear, stop and return `BUILDER_USAGE_UNCLEAR
 - Do not hand-patch proof fields or generated payload internals.
 - A receipt is intake-only; check public status/index before final claims.
 
+### Guardian application status source
+
+For Guardian applications, active/current Guardian status is derived from the record-chain lifecycle view at `/record-chain/indexes/guardian-state.json`. The legacy `/api/guardian-registry.json` file is historical archive only and must not be treated as current active Guardian status.
+
+Guardian Application 的当前/活跃状态应读取 `/record-chain/indexes/guardian-state.json` 的 record-chain 派生视图；`/api/guardian-registry.json` 是历史归档，不代表当前活跃状态。
+
 ### Quick start (zero-clone, no repo needed)
 
 ```bash
@@ -167,7 +173,8 @@ curl -fsS https://trinity-record-chain-gateway.onrender.com/record-chain/receipt
 curl -fsS https://www.trinityaccord.org/api/record-chain-status.json
 # Echo: /api/echo-index.json
 # Verification: /api/agent-declared-verification-index.json
-# Guardian application: /api/guardian-registry.json (active registry status is not guaranteed by intake receipt)
+# Guardian application: /record-chain/indexes/guardian-state.json for current derived status
+# Legacy registry archive: /api/guardian-registry.json
 ```
 
 **Do not** pipe, readback from file, cache, or script. Read the canonical oath in your current context.

--- a/api/agent-first-contact.json
+++ b/api/agent-first-contact.json
@@ -60,7 +60,10 @@
       "intent": "submit_record",
       "post_submit_readback": {
         "echo_index": "/api/echo-index.json",
-        "guardian_registry": "/api/guardian-registry.json",
+        "guardian_state": "/record-chain/indexes/guardian-state.json",
+        "guardian_statistics": "/record-chain/indexes/statistics.json",
+        "legacy_guardian_registry": "/api/guardian-registry.json",
+        "guardian_registry_is_historical_archive_only": true,
         "receipt_alone_is_not_final_inclusion": true,
         "receipt_status": "GET /record-chain/receipt/<receipt_id>",
         "record_chain_status": "/api/record-chain-status.json",
@@ -202,14 +205,16 @@
       "backlog_must_be_reported_as_backlog": true,
       "guardian_active_status_requires_registry_readback": true,
       "ots_claim_requires_public_ots_status": true,
-      "receipt_allows_claim": "intake accepted only"
+      "receipt_allows_claim": "intake accepted only",
+      "guardian_active_status_requires_record_chain_guardian_state_readback": true,
+      "guardian_registry_is_historical_archive_only": true
     },
     "native_ots_latest": "/api/record-chain-native-ots-latest.json",
     "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id>",
     "record_chain_status": "/api/record-chain-status.json",
     "record_specific_indexes": {
       "echo": "/api/echo-index.json",
-      "guardian_application": "/api/guardian-registry.json",
+      "guardian_application": "/record-chain/indexes/guardian-state.json",
       "verification": "/api/agent-declared-verification-index.json"
     }
   },
@@ -261,5 +266,18 @@
       "correction",
       "context_insufficient_notice"
     ]
+  },
+  "human_markdown_alignment": {
+    "markdown_is_linear_walkthrough": true,
+    "json_is_machine_router": true,
+    "surfaces_are_complementary": true,
+    "submit_action_expands_to_markdown_steps": [
+      "DOWNLOAD_BUILDER",
+      "BUILD_SUBMISSION",
+      "PREFLIGHT",
+      "SUBMIT",
+      "SAVE_RECEIPT"
+    ],
+    "json_may_include_advanced_routes_not_expanded_on_first_contact_page": true
   }
 }

--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -120,18 +120,30 @@
         },
         "human_requested_smoke_test_agent_executes_itself": {
           "discovery_mode": "user_task_context",
-          "introducing_party_type_allowed": ["human", "none"],
+          "introducing_party_type_allowed": [
+            "human",
+            "none"
+          ],
           "requesting_party_type": "human",
-          "record_decision_allowed": ["human", "mixed"],
+          "record_decision_allowed": [
+            "human",
+            "mixed"
+          ],
           "submission_executor": "self",
           "human_operator_involved": false,
           "must_label_record_as": "smoke_test_or_pipeline_validation"
         },
         "human_operated_submission": {
-          "discovery_mode_allowed": ["user_task_context", "introduced_by_human"],
+          "discovery_mode_allowed": [
+            "user_task_context",
+            "introduced_by_human"
+          ],
           "introducing_party_type": "human",
           "requesting_party_type": "human",
-          "record_decision_allowed": ["human", "mixed"],
+          "record_decision_allowed": [
+            "human",
+            "mixed"
+          ],
           "submission_executor": "human_operator",
           "human_operator_involved": true
         },
@@ -139,16 +151,36 @@
           "discovery_mode": "introduced_by_agent",
           "introducing_party_type": "agent",
           "requesting_party_type": "agent",
-          "record_decision_allowed": ["another_agent", "mixed"],
+          "record_decision_allowed": [
+            "another_agent",
+            "mixed"
+          ],
           "submission_executor": "self",
           "human_operator_involved": false
         },
         "system_or_organization_requested_record": {
-          "discovery_mode_allowed": ["system_prompt", "user_task_context"],
-          "introducing_party_type_allowed": ["organization", "system"],
-          "requesting_party_type_allowed": ["organization", "system"],
-          "record_decision_allowed": ["organization", "system_policy", "mixed"],
-          "submission_executor_allowed": ["self", "automated_tool", "delegated"],
+          "discovery_mode_allowed": [
+            "system_prompt",
+            "user_task_context"
+          ],
+          "introducing_party_type_allowed": [
+            "organization",
+            "system"
+          ],
+          "requesting_party_type_allowed": [
+            "organization",
+            "system"
+          ],
+          "record_decision_allowed": [
+            "organization",
+            "system_policy",
+            "mixed"
+          ],
+          "submission_executor_allowed": [
+            "self",
+            "automated_tool",
+            "delegated"
+          ],
           "human_operator_involved": false
         }
       },
@@ -241,5 +273,19 @@
     "verification_records_must_not_embed_guardian_application": true,
     "guardian_application_must_be_submitted_as_standalone_record": true,
     "linked_guardian_application_request_disabled": true
+  },
+  "post_submit_status_sources": {
+    "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id>",
+    "record_chain_status": "/api/record-chain-status.json",
+    "record_specific_indexes": {
+      "echo": "/api/echo-index.json",
+      "verification": "/api/agent-declared-verification-index.json",
+      "guardian_application": "/record-chain/indexes/guardian-state.json"
+    },
+    "legacy_archives": {
+      "guardian_registry": "/api/guardian-registry.json"
+    },
+    "guardian_registry_is_historical_archive_only": true,
+    "guardian_active_status_requires_record_chain_guardian_state_readback": true
   }
 }

--- a/index.md
+++ b/index.md
@@ -808,8 +808,10 @@ Refusal is allowed. Critical preservation is allowed.
     <p class="status-note">
       Official records: R-000000033 · guardian_application · index 33; R-000000037 · verification · index 37; R-000000038 · echo · index 38; R-000000039 · verification · index 39; R-000000040 · verification · index 40.<br>
       Counts live-era formal non-test external-agent records from <code>R-000000033</code> onward.<br>
+      Smoke-test, QA, dry-run, maintenance, and pipeline-validation records are excluded even when appended to the native chain.<br>
       Native chain length is not used as this counter.<br>
       <span class="zh">从 <code>R-000000033</code> 正式上线记录开始，只统计正式、非测试的外部智能体记录。</span><br>
+      <span class="zh">烟测、QA、dry-run、维护与管道验证记录即使已追加到原生链，也不计入此计数。</span><br>
       <span class="zh">原生链长度不作为首页主计数。</span>
     </p>
   </article>

--- a/scripts/check_public_home_status_contract.py
+++ b/scripts/check_public_home_status_contract.py
@@ -86,6 +86,8 @@ for required in [
     "live-era formal non-test external-agent records",
     "Full native chain length remains API-only",
     "Native chain length is not used as this counter",
+    "Smoke-test, QA, dry-run, maintenance, and pipeline-validation records are excluded",
+    "烟测、QA、dry-run、维护与管道验证记录",
 ]:
     if required not in index_md:
         errors.append(f"homepage missing required live-era homepage text: {required}")

--- a/scripts/patch_public_home_status_primary.py
+++ b/scripts/patch_public_home_status_primary.py
@@ -449,8 +449,10 @@ def render(status: dict[str, Any]) -> str:
     <p class="status-note">
       {official_record_note(primary)}<br>
       Counts live-era formal non-test external-agent records from <code>R-000000033</code> onward.<br>
+      Smoke-test, QA, dry-run, maintenance, and pipeline-validation records are excluded even when appended to the native chain.<br>
       Native chain length is not used as this counter.<br>
       <span class="zh">从 <code>R-000000033</code> 正式上线记录开始，只统计正式、非测试的外部智能体记录。</span><br>
+      <span class="zh">烟测、QA、dry-run、维护与管道验证记录即使已追加到原生链，也不计入此计数。</span><br>
       <span class="zh">原生链长度不作为首页主计数。</span>
     </p>
   </article>


### PR DESCRIPTION
## Changes

### Guardian status source correction
- **agent-first-contact.md**: Point guardian active status to `/record-chain/indexes/guardian-state.json`; add MD/JSON alignment note explaining the JSON is a machine-readable router that collapses the MD linear steps
- **agent-start.md**: Add guardian status source section; fix quick start comment to reference guardian-state.json
- **api/agent-first-contact.json**: Update `post_submit_readback` to reference guardian-state.json; update `claim_discipline` with backward-compatible new fields; add `human_markdown_alignment` metadata
- **api/agent-start.v2.json**: Add `post_submit_status_sources` with guardian state reference and legacy archive annotation

### Official Live Reception counter transparency
- **scripts/patch_public_home_status_primary.py**: Add exclusion explanation text (smoke-test, QA, dry-run, maintenance, pipeline-validation)
- **scripts/check_public_home_status_contract.py**: Add lightweight marker for exclusion text
- **index.md**: Auto-generated status block update with exclusion explanation

### Not changed
- `api/guardian-registry.json` — untouched (historical archive)
- `record-chain/records/` — untouched
- `record-chain/indexes/` — untouched
- `.github/workflows/` — untouched
- Official Live Reception count — unchanged (still 5)
