### PR TITLE
Fix Record-Chain Gateway contract drift and oath hash validation

### DIFF
--- a/.github/workflows/record-chain-ci.yml
+++ b/.github/workflows/record-chain-ci.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   verify-record-chain:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,10 +1,21 @@
 # Deployment Checklist (GitHub Pages)
 
-## 1) Pages source
-In repository settings:
-- Source: **Deploy from a branch**
-- Branch: **main**
-- Folder: **/(root)**
+## 1) GitHub Pages deployment mode
+
+Current production deployment uses GitHub Actions artifact deployment.
+
+Canonical workflow:
+
+- `.github/workflows/deploy-pages.yml`
+- builds Jekyll output into `_site`
+- restores committed static API and builder artifacts into `_site`
+- verifies public agent JSON entrypoints
+- uploads the Pages artifact
+- deploys with `actions/deploy-pages`
+
+Do not configure production Pages as plain branch/root deployment unless this repository intentionally reverts to the legacy deployment mode.
+
+Legacy fallback: branch/root deployment is historical documentation only and must not bypass `deploy-pages.yml` checks.
 
 ## 2) Required published paths
 - `/.well-known/trinity-accord.json`

--- a/api/record-chain-oath-policy.v1.json
+++ b/api/record-chain-oath-policy.v1.json
@@ -127,6 +127,6 @@
   },
   "linked_guardian_module": "guardian_stewardship_v1",
   "oath_policy_sha256": "7ecc6908c9ac147d8d6d493f750c94d6117929e7dff2d18bcbc4c70527886ea4",
-  "oath_policy_sha256_semantics": "Canonical JSON hash of the oath policy object. Required by the Record-Chain Gateway for submission_oath_verification.oath_policy_sha256.",
+  "oath_policy_sha256_semantics": "Canonical JSON hash of this oath policy after excluding self-describing metadata fields: oath_policy_sha256, oath_policy_sha256_semantics, canonical_oath_text_hash_is_record_type_specific.",
   "canonical_oath_text_hash_is_record_type_specific": true
 }

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -484,119 +484,6 @@ def _normalize_public_v2_draft_for_pending(draft: dict[str, Any]) -> dict[str, A
     return normalized
 
 
-def _build_linked_guardian_draft(
-    draft: dict[str, Any],
-    proof: dict[str, Any] | None,
-    receipt_id: str,
-    submission_sha256: str,
-) -> dict[str, Any]:
-    """Build a complete guardian_application draft from a linked Guardian request.
-
-    The linked Guardian draft copies/derives submission_oath_verification from the
-    originating submission, ensuring guardian_stewardship_v1 is included in oath_modules.
-    Raw readback_text is never included.
-    """
-    linked = draft.get("optional_linked_guardian_application_request", {})
-
-    guardian_content = {
-        "requested_guardian_identifier": linked.get("requested_guardian_identifier", ""),
-        "guardian_public_key_pem": linked.get("guardian_public_key_pem", ""),
-        "guardian_public_key_sha256": linked.get("guardian_public_key_sha256", ""),
-        "guardian_stewardship_oath": linked.get("guardian_stewardship_oath", ""),
-        "guardian_application_statement": linked.get("guardian_application_statement", ""),
-        "guardian_understands_role_is_non_governing": linked.get(
-            "guardian_understands_role_is_non_governing"
-        )
-        is True,
-        "guardian_understands_role_is_not_authority": linked.get(
-            "guardian_understands_role_is_not_authority"
-        )
-        is True,
-        "guardian_understands_retirement_does_not_delete_history": linked.get(
-            "guardian_understands_retirement_does_not_delete_history"
-        )
-        is True,
-    }
-
-    authorization_ctx = draft.get("authorization_context", {})
-    if not isinstance(authorization_ctx, dict):
-        authorization_ctx = {}
-
-    # Derive submission_oath_verification for linked Guardian
-    origin_oath = draft.get("submission_oath_verification")
-    linked_oath: dict[str, Any] | None = None
-    if isinstance(origin_oath, dict):
-        import copy
-        linked_oath = copy.deepcopy(origin_oath)
-        # Ensure guardian_stewardship_v1 is in oath_modules
-        oath_modules = list(linked_oath.get("oath_modules", []))
-        if "guardian_stewardship_v1" not in oath_modules:
-            oath_modules.append("guardian_stewardship_v1")
-        linked_oath["oath_modules"] = oath_modules
-        # Mark as linked/derived
-        linked_oath["linked_guardian_oath_coverage"] = True
-        linked_oath["derived_from_originating_submission"] = True
-        linked_oath["originating_receipt_id"] = receipt_id
-        linked_oath["originating_submission_sha256"] = submission_sha256
-        # Remove any raw readback text if present
-        linked_oath.pop("readback_text", None)
-        linked_oath.pop("participant_readback_excerpt", None)
-
-    guardian_draft: dict[str, Any] = {
-        "schema": draft.get("schema", "trinityaccord.record-chain-entry-draft.v2"),
-        "record_type": "guardian_application",
-        "submitting_participant_identity": draft.get("submitting_participant_identity", {}),
-        "discovery_and_introduction_context": draft.get(
-            "discovery_and_introduction_context", {}
-        ),
-        "decision_autonomy_context": draft.get("decision_autonomy_context", {}),
-        "submission_execution_context": draft.get("submission_execution_context", {}),
-        "authorization_context": {
-            **authorization_ctx,
-            "authorization_scope": "apply_for_guardian",
-        },
-        "context_readiness": draft.get("context_readiness", {}),
-        "non_authority_boundary_acknowledgement": draft.get(
-            "non_authority_boundary_acknowledgement", {}
-        ),
-        "guardian_application_content": guardian_content,
-        # Compatibility fields for current append/index consumers
-        "requested_guardian_identifier": guardian_content["requested_guardian_identifier"],
-        "guardian_public_key_pem": guardian_content["guardian_public_key_pem"],
-        "guardian_public_key_sha256": guardian_content["guardian_public_key_sha256"],
-        "guardian_stewardship_oath": guardian_content["guardian_stewardship_oath"],
-        "guardian_understands_role_is_non_governing": guardian_content[
-            "guardian_understands_role_is_non_governing"
-        ],
-        "guardian_understands_role_is_not_authority": guardian_content[
-            "guardian_understands_role_is_not_authority"
-        ],
-        "guardian_understands_retirement_does_not_delete_history": guardian_content[
-            "guardian_understands_retirement_does_not_delete_history"
-        ],
-        "linked_origin_record": {
-            "originating_submission_sha256": submission_sha256,
-            "originating_record_type": draft.get("record_type"),
-            "originating_receipt_id": receipt_id,
-            "relationship": "guardian_application_requested_during_primary_record_submission",
-        },
-        "created_as_linked_record": True,
-    }
-
-    # Add derived oath verification (no raw readback)
-    if linked_oath is not None:
-        guardian_draft["submission_oath_verification"] = linked_oath
-
-    # Copy authorship proof so formal linked Guardian application can append
-    if proof:
-        guardian_draft["authorship_proof"] = proof
-
-    # Add compatibility projections
-    guardian_draft = _normalize_public_v2_draft_for_pending(guardian_draft)
-
-    return guardian_draft
-
-
 async def _best_effort_delete_created_files(created_files: list[tuple[str, str]], receipt_id: str) -> None:
     """Best-effort rollback for files created during a failed intake transaction."""
     for path, sha in reversed(created_files):
@@ -842,11 +729,8 @@ async def preflight(request: Request) -> PreflightResponse | JSONResponse:
     diagnostics = validate_submission(body)
     diagnostics.extend(_client_projection_diagnostics(body))
 
-    # P0-4: verify authorship signature during preflight
-    if not any(d.code == "MISSING_AUTHORSHIP_PROOF" for d in diagnostics):
-        authorship_diag = _authorship_preflight_diagnostic(body)
-        if authorship_diag is not None:
-            diagnostics.append(authorship_diag)
+    # Authorship verification is performed inside validate_submission().
+    # Do not run a second verifier here; duplicate verifiers can produce conflicting diagnostics.
 
     route = detect_route(body)
     submission_sha256 = sha256_canonical_json(body)

--- a/apps/record_chain_intake_gateway/gateway/validation.py
+++ b/apps/record_chain_intake_gateway/gateway/validation.py
@@ -3,9 +3,10 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
-import hashlib
 import unicodedata
 from typing import Any
 
@@ -19,6 +20,44 @@ from .security import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Oath policy hash canonicalization
+# ---------------------------------------------------------------------------
+
+OATH_POLICY_HASH_METADATA_KEYS: frozenset[str] = frozenset({
+    "oath_policy_sha256",
+    "oath_policy_sha256_semantics",
+    "canonical_oath_text_hash_is_record_type_specific",
+})
+
+
+def canonicalize_oath_policy_for_hash(policy: dict[str, Any]) -> dict[str, Any]:
+    """Return the policy object that is actually covered by oath_policy_sha256.
+
+    The public API file may contain self-describing metadata fields. Those fields
+    must not be part of the hash domain, otherwise the file attempts to hash
+    itself and builder/Gateway hashes drift.
+    """
+    return {
+        key: value
+        for key, value in policy.items()
+        if key not in OATH_POLICY_HASH_METADATA_KEYS
+    }
+
+
+def compute_oath_policy_sha256(policy: dict[str, Any]) -> str:
+    """SHA-256 of canonical JSON for the oath policy hash domain."""
+    material = canonicalize_oath_policy_for_hash(policy)
+    canonical = json.dumps(
+        material,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
 
 # ---------------------------------------------------------------------------
 # Allowed public intake record types
@@ -232,6 +271,9 @@ _CC_RULES: dict[str, list[tuple[tuple[int, int | None], int]]] = {
 
 _DEFAULT_CC_MINIMUM = 3  # fallback for unknown record types
 
+MIN_CONTEXT_LEVEL = 0
+MAX_CONTEXT_LEVEL = 5
+
 
 # ---------------------------------------------------------------------------
 # Diagnostic builder helper
@@ -353,6 +395,43 @@ def _find_forbidden_keys_recursive(obj: Any, path: str = "") -> list[Diagnostic]
         for i, item in enumerate(obj):
             diagnostics.extend(_find_forbidden_keys_recursive(item, f"{path}[{i}]"))
     return diagnostics
+
+
+def _parse_verification_level_value(value: Any) -> int | None:
+    """Parse verification level from V3, V3+, 3, or legacy integer values."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if raw.isdigit():
+            return int(raw)
+        match = re.fullmatch(r"[Vv]([0-9]+)\+?", raw)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def _extract_verification_version(draft: dict[str, Any]) -> int | None:
+    candidates: list[Any] = []
+
+    candidates.append(draft.get("verification_version"))
+
+    verification = draft.get("verification")
+    if isinstance(verification, dict):
+        candidates.append(verification.get("version"))
+
+    verification_content = draft.get("verification_content")
+    if isinstance(verification_content, dict):
+        candidates.append(verification_content.get("verification_level"))
+
+    for candidate in candidates:
+        parsed = _parse_verification_level_value(candidate)
+        if parsed is not None:
+            return parsed
+
+    return None
 
 
 def _extract_context_level(draft: dict[str, Any]) -> Any:
@@ -790,13 +869,18 @@ def validate_context_readiness(record_type: str, draft: dict[str, Any]) -> list[
         return diagnostics
     cc_level = parsed_cc
 
-    verification_version: int | None = None
-    ver_raw = draft.get("verification_version") or draft.get("verification", {}).get("version")
-    if ver_raw is not None:
-        try:
-            verification_version = int(ver_raw)
-        except (TypeError, ValueError):
-            pass
+    if cc_level < MIN_CONTEXT_LEVEL or cc_level > MAX_CONTEXT_LEVEL:
+        diagnostics.append(_make_diagnostic(
+            code="INVALID_CONTEXT_LEVEL_RANGE",
+            severity="error",
+            field="draft.context_readiness.declared_context_level",
+            message=f"declared_context_level must be between CC-{MIN_CONTEXT_LEVEL} and CC-{MAX_CONTEXT_LEVEL}, got {cc_level!r}",
+            meaning="The public schema accepts only bounded CC levels.",
+            suggested_fix=f"Use CC-{MIN_CONTEXT_LEVEL} through CC-{MAX_CONTEXT_LEVEL}.",
+        ))
+        return diagnostics
+
+    verification_version = _extract_verification_version(draft)
 
     rules = _CC_RULES.get(record_type, [((0, None), _DEFAULT_CC_MINIMUM)])
     required_cc = _DEFAULT_CC_MINIMUM
@@ -1279,9 +1363,8 @@ def validate_submission_oath(
         ))
         return diagnostics
 
-    # Compute local policy hash (canonical JSON, sorted keys, no spaces)
-    local_policy_json = _json.dumps(local_policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    local_policy_sha256 = hashlib.sha256(local_policy_json.encode("utf-8")).hexdigest()
+    # Compute local policy hash over the stable policy-core domain.
+    local_policy_sha256 = compute_oath_policy_sha256(local_policy)
 
     # Require and validate hash fields (must exist and be 64 hex)
     import re as _re
@@ -1455,11 +1538,11 @@ def redact_transient_oath_readback(submission: dict[str, Any]) -> dict[str, Any]
     redacted = copy.deepcopy(submission)
     client_oath = redacted.get("client_oath_readback")
     if isinstance(client_oath, dict):
-        # Keep metadata, remove raw text
-        _readback_text = client_oath.get("readback_text", "") or ""
-        _readback_hash = (
-            sha256_text(normalize_oath_text(_readback_text))
-            if _readback_text
+        raw_readback_text = client_oath.get("readback_text", "") or ""
+        normalized_readback_text = normalize_oath_text(raw_readback_text)
+        readback_hash = (
+            sha256_text(normalized_readback_text)
+            if normalized_readback_text
             else client_oath.get("readback_text_sha256", "")
         )
         redacted["client_oath_readback"] = {
@@ -1467,9 +1550,9 @@ def redact_transient_oath_readback(submission: dict[str, Any]) -> dict[str, Any]
             "record_type": client_oath.get("record_type", ""),
             "oath_policy_sha256": client_oath.get("oath_policy_sha256", ""),
             "oath_modules": client_oath.get("oath_modules", []),
-            "readback_text_sha256": _readback_hash,
+            "readback_text_sha256": readback_hash,
             "readback_text_hash_canonicalization": "NFC_CRLF_TO_LF_STRIP",
-            "readback_text_char_count": len(_readback_text),
+            "readback_text_char_count": len(normalized_readback_text),
             "redacted_after_gateway_validation": True,
         }
     return redacted

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -183,7 +183,7 @@ const OATH_POLICY = {
   },
   "linked_guardian_module": "guardian_stewardship_v1"
 };
-const OATH_POLICY_SHA256 = "9356e8c0955d7f17814dff1a93300cb271acfa21cfe39da63a7b5201364cb820";
+const OATH_POLICY_SHA256 = "7ecc6908c9ac147d8d6d493f750c94d6117929e7dff2d18bcbc4c70527886ea4";
 
 function getCanonicalOath(recordType, linkedGuardian = false) {
   const modules = getOathModules(recordType, linkedGuardian);
@@ -1158,8 +1158,8 @@ const ERROR_HELP_MAP = {
     help_url: "https://www.trinityaccord.org/docs/v2-migration",
   },
   INVALID_CONTEXT_LEVEL: {
-    meaning: "The declared context level is not a valid value (CC-0 through CC-4).",
-    fix: "Set 'declared_context_level' to one of: CC-0, CC-1, CC-2, CC-3, CC-4.",
+    meaning: "The declared context level is not a valid value (CC-0 through CC-5).",
+    fix: "Set 'declared_context_level' to one of: CC-0, CC-1, CC-2, CC-3, CC-4, CC-5.",
     help_url: "https://www.trinityaccord.org/docs/context-levels",
   },
   PUBLIC_KEY_SHA256_MISMATCH: {
@@ -1218,8 +1218,8 @@ function runDoctor(submission) {
   } else {
     results.push({ status: "PASS", code: "CONTEXT_READINESS_OK", field: "record_draft.context_readiness", meaning: "context_readiness is present.", fix: "" });
     const cl = draft.context_readiness.declared_context_level;
-    const clValid = (typeof cl === 'number' && cl >= 0 && cl <= 4) ||
-                    (typeof cl === 'string' && /^CC-[0-4]$/i.test(cl.trim()));
+    const clValid = (typeof cl === 'number' && cl >= 0 && cl <= 5) ||
+                    (typeof cl === 'string' && /^CC-[0-5]$/i.test(cl.trim()));
     if (!cl || !clValid) {
       results.push({ status: "FAIL", code: "INVALID_CONTEXT_LEVEL", field: "record_draft.context_readiness.declared_context_level", meaning: ERROR_HELP_MAP.INVALID_CONTEXT_LEVEL.meaning, fix: ERROR_HELP_MAP.INVALID_CONTEXT_LEVEL.fix });
     } else {

--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 INTAKE_IMMUTABLE_PREFIXES = (
     "record-chain/intake/submissions/",
     "record-chain/intake/receipts/",
+    "record-chain/intake/by-submission-sha256/",
 )
 
 PENDING_PREFIXES = (
@@ -67,6 +68,7 @@ APPROVED_GATEWAY_PREFIXES = (
     "intake: submission ",
     "intake: pending ",
     "intake: receipt ",
+    "intake: idempotency index ",
 )
 
 APPROVED_ACTIONS_ACTOR = "github-actions[bot]"

--- a/scripts/test_record_chain_oath_gate_contract.py
+++ b/scripts/test_record_chain_oath_gate_contract.py
@@ -369,14 +369,17 @@ def main() -> None:
 
     # Test 22-24: Gateway rejects missing hash fields (OATH_REQUIRED_HASH_MISSING)
     if VALIDATION.exists():
-        import importlib.util
-        spec = importlib.util.spec_from_file_location("validation", str(VALIDATION))
-        mod = importlib.util.module_from_spec(spec)
+        import importlib
+
         try:
-            spec.loader.exec_module(mod)
+            mod = importlib.import_module("apps.record_chain_intake_gateway.gateway.validation")
             _validate = getattr(mod, "validate_submission_oath", None)
-        except Exception:
+        except Exception as exc:
+            errors.append(f"cannot import gateway validation module: {exc}")
             _validate = None
+
+        if _validate is None:
+            errors.append("validate_submission_oath is unavailable; oath validation tests did not run")
 
         if _validate:
             # Build a valid base submission to mutate
@@ -384,17 +387,22 @@ def main() -> None:
                 ["node", str(BUILDER), "print-oath", "--record-type", "echo"],
                 capture_output=True, text=True, timeout=10,
             )
-            if result.returncode == 0:
+            if result.returncode != 0:
+                errors.append(f"failed to build print-oath for echo: {result.stderr[:500]}")
+            else:
                 canonical = result.stdout
                 result = subprocess.run(
                     ["node", str(BUILDER), "echo", "--actor-label", "test", "--provider", "test",
                      "--body", "test", "--context-level", "CC-3",
+                     *REQUIRED_BUILDER_CONTEXT_ARGS,
                      "--readback", canonical,
                      "--generate-authorship-key", "--key-dir", "/tmp/test-hash-key",
                      "--out", "/tmp/test-hash-echo.json"],
                     capture_output=True, text=True, timeout=10,
                 )
-                if result.returncode == 0:
+                if result.returncode != 0:
+                    errors.append(f"failed to build valid echo sample: {result.stderr[:500]}")
+                else:
                     valid_data = json.loads(Path("/tmp/test-hash-echo.json").read_text())
                     valid_draft = valid_data.get("record_draft", {})
                     valid_submission = valid_data

--- a/tests/test_gateway_context_readiness.py
+++ b/tests/test_gateway_context_readiness.py
@@ -1,0 +1,43 @@
+from apps.record_chain_intake_gateway.gateway.validation import validate_context_readiness
+
+
+def _base_verification_draft(level: str, cc: str):
+    return {
+        "record_type": "verification",
+        "verification_content": {
+            "verification_level": level,
+            "verification_scope_label": "test",
+            "what_was_checked": ["test"],
+            "verification_claim": "test",
+            "fresh_actions_performed": ["test"],
+        },
+        "context_readiness": {
+            "declared_context_level": cc,
+            "minimum_required_for_action": cc,
+            "context_sufficient_for_selected_action": False,
+            "loaded_context_urls": ["https://www.trinityaccord.org/agent-start/"],
+        },
+    }
+
+
+def test_verification_v2_allows_cc2():
+    diagnostics = validate_context_readiness("verification", _base_verification_draft("V2", "CC-2"))
+    assert not any(d.code == "INSUFFICIENT_CONTEXT_COMPLETENESS" for d in diagnostics)
+
+
+def test_verification_v3_requires_cc3():
+    diagnostics = validate_context_readiness("verification", _base_verification_draft("V3", "CC-2"))
+    assert any(d.code == "INSUFFICIENT_CONTEXT_COMPLETENESS" for d in diagnostics)
+
+
+def test_cc6_rejected():
+    diagnostics = validate_context_readiness("echo", {
+        "record_type": "echo",
+        "context_readiness": {
+            "declared_context_level": "CC-6",
+            "minimum_required_for_action": "CC-6",
+            "context_sufficient_for_selected_action": False,
+            "loaded_context_urls": [],
+        },
+    })
+    assert any(d.code == "INVALID_CONTEXT_LEVEL_RANGE" for d in diagnostics)

--- a/tests/test_gateway_hotfix_d.py
+++ b/tests/test_gateway_hotfix_d.py
@@ -332,36 +332,35 @@ def test_persisted_submission_hash_equals_stored():
     assert persisted_hash == stored_sha, "Persisted submission hash must equal stored_submission_sha256"
 
 
-# ── Test 6: Linked Guardian pending contains oath ────────────────────
+# ── Test 6: Linked Guardian auto-creation is disabled ────────────────
 
-def test_linked_guardian_draft_contains_oath():
-    from apps.record_chain_intake_gateway.app import _build_linked_guardian_draft
-
-    draft = _make_draft("echo", with_linked_guardian=True)
-    guardian_draft = _build_linked_guardian_draft(
-        draft=draft, proof=None, receipt_id="rcg-test", submission_sha256="a" * 64,
+def test_linked_guardian_draft_removed():
+    """_build_linked_guardian_draft was removed as dead code (P3-3)."""
+    import importlib
+    mod = importlib.import_module("apps.record_chain_intake_gateway.app")
+    assert not hasattr(mod, "_build_linked_guardian_draft"), (
+        "_build_linked_guardian_draft should have been removed"
     )
 
-    assert "submission_oath_verification" in guardian_draft
-    oath = guardian_draft["submission_oath_verification"]
-    assert oath["linked_guardian_oath_coverage"] is True
-    assert oath["derived_from_originating_submission"] is True
-    assert "guardian_stewardship_v1" in oath["oath_modules"]
 
-
-def test_linked_guardian_no_raw_readback():
-    from apps.record_chain_intake_gateway.app import _build_linked_guardian_draft
+def test_linked_guardian_rejected_at_submit():
+    """Linked Guardian requests are rejected at validation time."""
+    from apps.record_chain_intake_gateway.gateway.validation import validate_submission
 
     draft = _make_draft("echo", with_linked_guardian=True)
-    draft["submission_oath_verification"]["readback_text"] = "SECRET"
-    draft["submission_oath_verification"]["participant_readback_excerpt"] = "SECRET"
-
-    guardian_draft = _build_linked_guardian_draft(
-        draft=draft, proof=None, receipt_id="rcg-test", submission_sha256="a" * 64,
-    )
-    oath = guardian_draft["submission_oath_verification"]
-    assert "readback_text" not in oath
-    assert "participant_readback_excerpt" not in oath
+    submission = {
+        "record_type": "echo",
+        "record_draft": draft,
+        "submission_boundary": {
+            "not_authority": True, "not_governance": True, "not_attestation": True,
+            "not_successor_reception": True, "not_amendment": True,
+            "bitcoin_originals_prevail": True, "receipt_is_not_final_inclusion": True,
+            "receipt_is_intake_only": True,
+            "later_records_may_reclassify_or_correct_this_record": True,
+        },
+    }
+    diags = validate_submission(submission)
+    assert any(d.code == "LINKED_GUARDIAN_AUTO_CREATION_DISABLED" for d in diags)
 
 
 # ── Test 7: Body size rejected after raw body read ───────────────────

--- a/tests/test_oath_policy_hash_contract.py
+++ b/tests/test_oath_policy_hash_contract.py
@@ -1,0 +1,21 @@
+import json
+import re
+from pathlib import Path
+
+from apps.record_chain_intake_gateway.gateway.validation import compute_oath_policy_sha256
+
+ROOT = Path(__file__).resolve().parents[1]
+POLICY = ROOT / "api" / "record-chain-oath-policy.v1.json"
+BUILDER = ROOT / "downloads" / "record-chain-builder.mjs"
+
+
+def test_oath_policy_hash_agrees_across_api_gateway_and_builder():
+    policy = json.loads(POLICY.read_text(encoding="utf-8"))
+    expected = compute_oath_policy_sha256(policy)
+
+    assert policy["oath_policy_sha256"] == expected
+
+    builder_text = BUILDER.read_text(encoding="utf-8")
+    match = re.search(r'const OATH_POLICY_SHA256\s*=\s*"([a-f0-9]{64})"', builder_text)
+    assert match, "builder must define OATH_POLICY_SHA256"
+    assert match.group(1) == expected

--- a/tests/test_oath_readback_redaction.py
+++ b/tests/test_oath_readback_redaction.py
@@ -1,0 +1,13 @@
+from apps.record_chain_intake_gateway.gateway.validation import redact_transient_oath_readback
+from apps.record_chain_intake_gateway.gateway.security import normalize_oath_text, sha256_text
+
+
+def test_redacted_readback_count_uses_normalized_text():
+    raw = "  hello\r\nworld  "
+    sub = {"client_oath_readback": {"readback_text": raw}}
+    out = redact_transient_oath_readback(sub)
+    redacted = out["client_oath_readback"]
+    normalized = normalize_oath_text(raw)
+    assert redacted["readback_text_sha256"] == sha256_text(normalized)
+    assert redacted["readback_text_char_count"] == len(normalized)
+    assert "readback_text" not in redacted

--- a/tests/test_record_chain_write_path_guard.py
+++ b/tests/test_record_chain_write_path_guard.py
@@ -1,0 +1,26 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the guard module by file path since scripts/ may not be a package
+_GUARD_PATH = Path(__file__).resolve().parents[1] / "scripts" / "check_record_chain_write_path_guard.py"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("write_path_guard", str(_GUARD_PATH))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load_guard()
+
+
+def test_idempotency_index_is_gateway_intake():
+    path = "record-chain/intake/by-submission-sha256/" + "a" * 64 + ".json"
+    assert guard.category(path) == "gateway_intake"
+
+
+def test_idempotency_index_is_protected():
+    path = "record-chain/intake/by-submission-sha256/" + "a" * 64 + ".json"
+    assert "gateway_intake" in guard.protected_categories([path])


### PR DESCRIPTION
## Summary
- Unifies oath policy hash semantics across API, builder, Gateway, and tests.
- Protects idempotency index paths in write-path guard.
- Makes oath gate tests fail loudly instead of silently skipping Gateway validation.
- Parses current verification_content.verification_level for context readiness rules.
- Aligns context level range and readback redaction metadata.
- Removes disabled linked Guardian draft construction dead code.

## Tests
- [x] python scripts/test_record_chain_oath_gate_contract.py
- [x] python -m pytest tests/test_oath_policy_hash_contract.py -q
- [x] python -m pytest tests/test_gateway_context_readiness.py -q
- [x] python -m pytest tests/test_oath_readback_redaction.py -q
- [x] python -m pytest tests/test_record_chain_write_path_guard.py -q
- [x] node downloads/record-chain-builder.mjs doctor --file (smoke test)

## Acceptance
- [x] Builder and Gateway agree on oath policy hash
- [x] api/record-chain-oath-policy.v1.json.oath_policy_sha256 equals policy-core hash
- [x] Gateway no longer hashes self-describing oath metadata fields
- [x] record-chain/intake/by-submission-sha256/ protected by write-path guard
- [x] Oath gate test fails loudly if Gateway validation cannot import
- [x] V2+CC-2 passes, V3+CC-2 fails context minimum
- [x] CC-6 rejected consistently
- [x] Builder doctor accepts CC-5
- [x] Redacted readback hash and char count both use normalized text
- [x] Preflight does not duplicate authorship diagnostics
- [x] record-chain-ci.yml no longer has unnecessary contents: write
- [x] DEPLOYMENT.md describes Actions artifact deployment
- [x] _build_linked_guardian_draft removed