### PR TITLE
fix: align test conftest oath hash with gateway core-hash

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -12,8 +12,8 @@
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "sha256": "6411c4d129f5c6d626cebebc583dcf92bc79442497faab4d3772ef993855eb3e",
-    "size_bytes": 112810,
+    "sha256": "93eb1941b3a45b42ac2d2757c2a4ec982c76b699aa5a30747dd5fc72a62123ef",
+    "size_bytes": 112816,
     "supports": [
       "echo",
       "verification",

--- a/apps/record_chain_intake_gateway/tests/conftest.py
+++ b/apps/record_chain_intake_gateway/tests/conftest.py
@@ -177,7 +177,15 @@ def _build_oath_for_record_type(record_type: str, draft: dict[str, Any]) -> tupl
     policy = json.loads(policy_path.read_text(encoding="utf-8"))
 
     policy_json = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    policy_sha256 = hashlib.sha256(policy_json.encode("utf-8")).hexdigest()
+    # Compute policy-core hash (excluding self-describing metadata keys)
+    _METADATA_KEYS = {
+        "oath_policy_sha256",
+        "oath_policy_sha256_semantics",
+        "canonical_oath_text_hash_is_record_type_specific",
+    }
+    core_policy = {k: v for k, v in policy.items() if k not in _METADATA_KEYS}
+    core_json = json.dumps(core_policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+    policy_sha256 = hashlib.sha256(core_json.encode("utf-8")).hexdigest()
 
     modules = list(policy.get("record_type_modules", {}).get(record_type, []))
     linked = draft.get("optional_linked_guardian_application_request")

--- a/scripts/test_record_chain_builder_bundle_contract.py
+++ b/scripts/test_record_chain_builder_bundle_contract.py
@@ -138,8 +138,14 @@ def main() -> None:
             if m:
                 embedded_sha = m.group(1)
                 policy = json.loads(oath_policy_path.read_text(encoding="utf-8"))
-                # Hash the full policy JSON (same as gateway validation.py)
-                canonical = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+                # Compute policy-core hash (excluding self-describing metadata keys)
+                _METADATA_KEYS = {
+                    "oath_policy_sha256",
+                    "oath_policy_sha256_semantics",
+                    "canonical_oath_text_hash_is_record_type_specific",
+                }
+                core_policy = {k: v for k, v in policy.items() if k not in _METADATA_KEYS}
+                canonical = json.dumps(core_policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
                 actual_sha = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
                 if embedded_sha != actual_sha:
                     errors.append(

--- a/scripts/test_record_chain_oath_gate_contract.py
+++ b/scripts/test_record_chain_oath_gate_contract.py
@@ -116,13 +116,20 @@ def main() -> None:
             errors.append("builder missing print-oath command")
         if "OATH_POLICY_SHA256" not in builder_text:
             errors.append("builder missing OATH_POLICY_SHA256")
-        # Verify embedded hash matches actual policy hash
+        # Verify embedded hash matches actual policy-core hash
+        # (excluding self-describing metadata keys, matching gateway compute_oath_policy_sha256)
         import re
         m = re.search(r'OATH_POLICY_SHA256\s*=\s*"([a-f0-9]{64})"', builder_text)
         if m:
             embedded_sha = m.group(1)
-            # Hash full policy JSON (same as gateway validation.py)
-            canonical = json.dumps(policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+            # Compute policy-core hash (same domain as gateway compute_oath_policy_sha256)
+            _METADATA_KEYS = {
+                "oath_policy_sha256",
+                "oath_policy_sha256_semantics",
+                "canonical_oath_text_hash_is_record_type_specific",
+            }
+            core_policy = {k: v for k, v in policy.items() if k not in _METADATA_KEYS}
+            canonical = json.dumps(core_policy, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
             actual_sha = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
             if embedded_sha != actual_sha:
                 errors.append(f"builder OATH_POLICY_SHA256 mismatch: embedded={embedded_sha[:16]}... actual={actual_sha[:16]}...")
@@ -370,6 +377,10 @@ def main() -> None:
     # Test 22-24: Gateway rejects missing hash fields (OATH_REQUIRED_HASH_MISSING)
     if VALIDATION.exists():
         import importlib
+        import sys as _sys
+
+        if str(ROOT) not in _sys.path:
+            _sys.path.insert(0, str(ROOT))
 
         try:
             mod = importlib.import_module("apps.record_chain_intake_gateway.gateway.validation")


### PR DESCRIPTION
Follow-up to #496/#497. Aligns conftest oath hash computation with the new core-hash domain.