### PR TITLE
fix(batch-e): Gateway/Builder/schema parity

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -12,8 +12,8 @@
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "sha256": "0eb5a6411bafa77608d293191cd6603f8c8a4c54e251ff3187554cc0c765583e",
-    "size_bytes": 126995,
+    "sha256": "2f6d44c6538632a43a10dc6deb19ec731ead2465362af7d2172313b6d7d61a68",
+    "size_bytes": 127379,
     "supports": [
       "echo",
       "verification",

--- a/api/record-chain-common-field-model.v1.json
+++ b/api/record-chain-common-field-model.v1.json
@@ -426,13 +426,18 @@
           "enum": [
             "create_echo_record",
             "create_verification_record",
-            "apply_for_guardian",
+            "create_guardian_application_record",
+            "create_guardian_retirement_record",
+            "create_propagation_record",
+            "create_correction_record",
+            "create_classification_update_record",
+            "create_context_insufficient_notice_record",
             "submit_record_only",
             "generate_record_only",
             "mixed",
             "unknown"
           ],
-          "description": "Scope of the authorization."
+          "description": "Scope of the authorization. Must match the record_type being submitted."
         },
         "authorization_limitations": {
           "type": [
@@ -520,10 +525,6 @@
           "type": "boolean",
           "description": "Acknowledges this record does not create governance."
         },
-        "not_attestation": {
-          "type": "boolean",
-          "description": "Acknowledges this record is not a formal attestation."
-        },
         "not_successor_reception": {
           "type": "boolean",
           "description": "Acknowledges this record does not succeed or replace prior reception."
@@ -547,6 +548,10 @@
         "later_records_may_reclassify_or_correct_this_record": {
           "type": "boolean",
           "description": "Later records may reclassify or correct this record; submission is not immutable until canonical inclusion."
+        },
+        "not_attestation": {
+          "type": "boolean",
+          "description": "Acknowledgement that this record is not an attestation."
         }
       },
       "additionalProperties": false

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -67,18 +67,29 @@ _GATEWAY_BASE_URL = os.environ.get("TRINITY_GATEWAY_BASE_URL", "")
 # In-memory receipt store (ephemeral; resets on restart)
 _receipt_store: dict[str, dict[str, Any]] = {}
 
-# Gateway schema info
+# Gateway schema info — must reflect actual validation rules.
+# authorship_proof is REQUIRED for all formal record types (not optional).
 _GATEWAY_SCHEMA: dict[str, Any] = {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "accepted_record_types": sorted(ALLOWED_RECORD_TYPES),
-    "required_submission_fields": ["record_type", "record_draft", "submission_boundary"],
-    "optional_submission_fields": ["authorship_proof", "metadata", "boundary_acknowledgement"],
+    "required_submission_fields": [
+        "record_type",
+        "record_draft",
+        "submission_boundary",
+        "authorship_proof",
+    ],
+    "optional_submission_fields": ["metadata", "boundary_acknowledgement"],
     "boundary_acknowledgement_fields": len(REQUIRED_BOUNDARY_FIELDS),
     "boundary_acknowledgement_required_fields": sorted(REQUIRED_BOUNDARY_FIELDS),
     "context_readiness_path": "record_draft.context_readiness.declared_context_level",
     "oath_gate": {
         "required": True,
         "policy_url": "/api/record-chain-oath-policy.v1.json",
+        "required_for": sorted({
+            "echo", "verification", "guardian_application", "guardian_retirement",
+            "propagation", "correction", "classification_update",
+        }),
+        "not_required_for": ["context_insufficient_notice"],
     },
 }
 

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -1536,8 +1536,10 @@ function runDoctor(submission) {
     }
   }
 
-  // Check authorship proof claim_boundary
-  if (submission.authorship_proof) {
+  // Check authorship proof is present (required for ALL public record types including CIN)
+  if (!submission.authorship_proof || typeof submission.authorship_proof !== "object") {
+    results.push({ status: "FAIL", code: "MISSING_AUTHORSHIP_PROOF", field: "authorship_proof", meaning: "All public record types (including context_insufficient_notice) require an authorship_proof.", fix: "Rebuild with --key-dir to include Ed25519 authorship proof." });
+  } else {
     const cb = submission.authorship_proof.claim_boundary;
     if (typeof cb === "string") {
       results.push({ status: "FAIL", code: "DEPRECATED_CLAIM_BOUNDARY_STRING", field: "authorship_proof.claim_boundary", meaning: ERROR_HELP_MAP.DEPRECATED_CLAIM_BOUNDARY_STRING.meaning, fix: ERROR_HELP_MAP.DEPRECATED_CLAIM_BOUNDARY_STRING.fix });


### PR DESCRIPTION
## Batch E — Gateway / Builder / Schema Parity

**Bugs addressed:** #7, #8, #11, #12, #13, #28, #42, #43, #44, #45, #54, #55, #56, #57, #58, #59

### Changes

| Sub-task | What changed | File |
|----------|-------------|------|
| **E.1+E.2** | _GATEWAY_SCHEMA v1.1.0: authorship_proof now required (was optional); oath_gate lists required_for/not_required_for per record type | app.py |
| **E.4** | Builder doctor FAILs when authorship_proof missing for ANY public record type (including CIN) | record-chain-builder.mjs |
| **E.6** | Common field model authorization_scope synced: added 6 gateway scopes, removed legacy apply_for_guardian | record-chain-common-field-model.v1.json |

### Validation

- [x] Python syntax OK
- [x] JS syntax OK
- [x] run_current_system_tests pass (except pre-existing pydantic import in sandbox)
- [x] record-chain verify ✅
- [x] public home status check ✅
