### PR TITLE
fix(batch-b): Guardian lifecycle safety — retirement target binding

### DIFF
--- a/apps/record_chain_intake_gateway/gateway/validation.py
+++ b/apps/record_chain_intake_gateway/gateway/validation.py
@@ -906,6 +906,11 @@ def validate_record_type_specific_content(record_type: str, draft: dict[str, Any
         for field in ("guardian_id", "guardian_public_key_sha256", "reason"):
             if not (draft.get(field) or payload.get(field)):
                 missing("MISSING_GUARDIAN_RETIREMENT_FIELD", f"draft.{field}", f"Guardian retirement requires {field}")
+        # B.4: Require target_guardian_application_record_id and sha for retirement binding
+        if not (draft.get("target_guardian_application_record_id") or payload.get("target_guardian_application_record_id")):
+            missing("MISSING_GUARDIAN_RETIREMENT_TARGET", "draft.target_guardian_application_record_id", "Guardian retirement requires target_guardian_application_record_id to bind to the specific application record being retired")
+        if not (draft.get("target_guardian_application_record_sha256") or payload.get("target_guardian_application_record_sha256")):
+            missing("MISSING_GUARDIAN_RETIREMENT_TARGET_SHA", "draft.target_guardian_application_record_sha256", "Guardian retirement requires target_guardian_application_record_sha256 to verify the target application record integrity")
     elif record_type in {"propagation", "correction"}:
         for field in ("title", "body"):
             if not draft.get(field):

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -1418,6 +1418,8 @@ function runDoctor(submission) {
     if (!draft.guardian_id) missing.push("guardian_id");
     if (!draft.guardian_public_key_sha256) missing.push("guardian_public_key_sha256");
     if (!draft.reason) missing.push("reason");
+    if (!draft.target_guardian_application_record_id) missing.push("target_guardian_application_record_id");
+    if (!draft.target_guardian_application_record_sha256) missing.push("target_guardian_application_record_sha256");
 
     if (missing.length) {
       results.push({
@@ -1425,7 +1427,7 @@ function runDoctor(submission) {
         code: "MISSING_GUARDIAN_RETIREMENT_FIELD",
         field: "record_draft",
         meaning: `Guardian retirement is missing required field(s): ${missing.join(", ")}`,
-        fix: "Rebuild with guardian-retirement and provide --guardian-id, --guardian-key-sha, and --body.",
+        fix: "Rebuild with guardian-retirement and provide --guardian-id, --guardian-key-sha, --body, --target-application-record-id, and --target-application-record-sha.",
       });
     }
 


### PR DESCRIPTION
## Batch B — Guardian lifecycle safety

### Changes
- **B.4**: Gateway and Builder now enforce `target_guardian_application_record_id` and `target_guardian_application_record_sha256` for `guardian_retirement` records
- Gateway validation: added `MISSING_GUARDIAN_RETIREMENT_TARGET` and `MISSING_GUARDIAN_RETIREMENT_TARGET_SHA`
- Builder doctor: require target fields in guardian retirement preflight

### Already verified (no changes needed)
- **B.1**: Guardian application does not become active (derived status = `application_recorded_pending_activation`)
- **B.2**: Founding status not inferred from `-founding` suffix (hardcoded `False`)
- **B.3**: Guardian uniqueness verified via `verify_guardian_uniqueness()`
- **B.5**: Legacy Guardian retirement rejected (target must exist as native record)

### Bugs addressed
- #15, #18, #24, #71, #72, #73, #74

### Validation
- [x] `python3 -m pytest tests/test_record_chain_guardian_retirement_flow.py` — PASSED
- [x] `python3 -m pytest tests/test_redteam_api_consistency.py` — PASSED
- [x] `python3 -m pytest tests/test_redteam_issue_vs_archive.py` — PASSED