### PR TITLE
fix(batch-c): Receipt hash verification function

### DIFF
--- a/apps/record_chain_intake_gateway/gateway/receipts.py
+++ b/apps/record_chain_intake_gateway/gateway/receipts.py
@@ -18,6 +18,20 @@ def compute_receipt_sha256(receipt: dict[str, Any]) -> str:
     return sha256_canonical_json(material)
 
 
+def verify_receipt_sha256(receipt: dict[str, Any]) -> tuple[bool, str]:
+    """Verify that a receipt's stored hash matches its computed hash.
+
+    Returns (True, "") on success, (False, error_message) on failure.
+    """
+    expected = receipt.get("receipt_sha256")
+    if not isinstance(expected, str) or not expected:
+        return False, "receipt_sha256 missing or not a string"
+    actual = compute_receipt_sha256(receipt)
+    if expected != actual:
+        return False, f"receipt_sha256 mismatch: expected {expected}, got {actual}"
+    return True, ""
+
+
 def make_legacy_receipt_id(submission_sha256: str, now: datetime | None = None) -> str:
     """Generate the legacy 12-hex receipt ID for duplicate lookup only."""
     if now is None:


### PR DESCRIPTION
## Batch C — Receipt / pending / append lifecycle

### Changes
- **C.4**: Added `verify_receipt_sha256()` function to `gateway/receipts.py` for receipt integrity verification

### Already verified (no changes needed)
- **C.1**: Durable receipt-status tracking already implemented (`append_status` = appended/rejected)
- **C.2**: `append --all` rejects with exit code 2 when `allow_rejections=False`
- **C.3**: Workflow already uses `--pending-file` and `--receipt-id` inputs
- **C.5**: Builder CLI exit codes already correct (preflight: `accepted===true`, submit: `accepted===true && submitted===true`)

### Bugs addressed
- #17, #34, #52, #63, #75

### Validation
- [x] Receipt hash verification function added and importable
- [x] Existing receipt tests still pass