### PR TITLE
fix(tests): add receipt_sha256 to idempotency index test fixtures

### DIFF
--- a/apps/record_chain_intake_gateway/tests/test_idempotency_index.py
+++ b/apps/record_chain_intake_gateway/tests/test_idempotency_index.py
@@ -245,6 +245,7 @@ class TestValidDuplicateReturnsReceipt:
     def test_valid_duplicate_returns_receipt(self, signed_echo_submission, monkeypatch):
         """When valid idempotency index and receipt exist, return duplicate with receipt."""
         from gateway.canonical import sha256_canonical_json
+        from gateway.receipts import compute_receipt_sha256
 
         actual_sha = sha256_canonical_json(signed_echo_submission)
         existing_receipt_id = "rcg-20260101-existing123"
@@ -268,6 +269,7 @@ class TestValidDuplicateReturnsReceipt:
             "pending_file_path": existing_index["pending_file_path"],
             "intake_submission_path": existing_index["intake_submission_path"],
         }
+        existing_receipt["receipt_sha256"] = compute_receipt_sha256(existing_receipt)
 
         async def mock_get_file_text(path):
             if "by-submission-sha256" in path:
@@ -381,6 +383,7 @@ class TestIndexWriteRaceReturnsExistingReceipt:
         """When idempotency index write fails but existing index found,
         return the existing receipt and rollback new files."""
         from gateway.canonical import sha256_canonical_json
+        from gateway.receipts import compute_receipt_sha256
 
         actual_sha = sha256_canonical_json(signed_echo_submission)
         existing_receipt_id = "rcg-20260101-existing123"
@@ -404,6 +407,7 @@ class TestIndexWriteRaceReturnsExistingReceipt:
             "pending_file_path": existing_index["pending_file_path"],
             "intake_submission_path": existing_index["intake_submission_path"],
         }
+        existing_receipt["receipt_sha256"] = compute_receipt_sha256(existing_receipt)
 
         put_call_count = 0
         get_text_call_count = 0


### PR DESCRIPTION
## fix(tests): add receipt_sha256 to idempotency index test fixtures

### Problem
Two tests in `test_idempotency_index.py` created mock receipts without `receipt_sha256`.
Since receipt endpoint is now fail-closed (missing hash = 500 error), these tests broke.

### Fix
- `test_valid_duplicate_returns_receipt`: added `from gateway.receipts import compute_receipt_sha256` in function body, computed hash after dict creation
- `test_index_write_race_returns_existing_receipt`: same change

### Changed files
- `apps/record_chain_intake_gateway/tests/test_idempotency_index.py` (+4 lines)

### Validation
```
python -m py_compile apps/record_chain_intake_gateway/tests/test_idempotency_index.py  # SYNTAX OK
pytest apps/record_chain_intake_gateway/tests/test_idempotency_index.py -q            # 14 passed
pytest apps/record_chain_intake_gateway/tests/ -q                                      # 24 failed (same as main), 262 passed
```

No production code changed. No builder/schema/gateway changes.
