### PR TITLE
fix: receipt endpoint fail-closed integrity

### DIFF
--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -564,10 +564,12 @@ async def _submit_response_from_idempotency_index(
         raise RuntimeError(f"Idempotency receipt is not a JSON object: {receipt_path}")
 
     # Verify receipt hash integrity
-    if receipt_data.get("receipt_sha256"):
-        hash_ok, hash_err = verify_receipt_sha256(receipt_data)
-        if not hash_ok:
-            raise RuntimeError(f"IDEMPOTENCY_RECEIPT_HASH_INVALID: {hash_err} at {receipt_path}")
+    # Fail-closed: receipt MUST have receipt_sha256
+    if not receipt_data.get("receipt_sha256"):
+        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_MISSING_HASH: receipt has no receipt_sha256 at {receipt_path}")
+    hash_ok, hash_err = verify_receipt_sha256(receipt_data)
+    if not hash_ok:
+        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_HASH_INVALID: {hash_err} at {receipt_path}")
 
     receipt_id = (
         receipt_data.get("server_receipt_id")
@@ -1375,35 +1377,64 @@ async def get_receipt(receipt_id: str) -> dict[str, Any]:
         text = await get_file_text(receipt_path)
         if text is not None:
             receipt = json.loads(text)
-            # Verify receipt hash integrity before returning
-            if receipt.get("receipt_sha256"):
-                hash_ok, hash_err = verify_receipt_sha256(receipt)
-                if not hash_ok:
-                    logger.error("Durable receipt hash invalid for %s at %s: %s", receipt_id, receipt_path, hash_err)
-                    raise HTTPException(
-                        status_code=500,
-                        detail={
-                            "code": "RECEIPT_HASH_INVALID",
-                            "message": f"Receipt hash verification failed: {hash_err}",
-                            "receipt_id": receipt_id,
-                            "receipt_path": receipt_path,
-                        },
-                    )
-            else:
-                logger.warning("Receipt %s has no receipt_sha256; skipping hash verification", receipt_id)
+            # Fail-closed: receipt MUST have receipt_sha256
+            if not receipt.get("receipt_sha256"):
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "code": "RECEIPT_INTEGRITY_MISSING_HASH",
+                        "message": "Receipt is missing receipt_sha256; cannot verify integrity",
+                        "receipt_id": receipt_id,
+                        "receipt_path": receipt_path,
+                    },
+                )
+            # Verify receipt hash integrity
+            hash_ok, hash_err = verify_receipt_sha256(receipt)
+            if not hash_ok:
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "code": "RECEIPT_HASH_INVALID",
+                        "message": f"Receipt hash verification failed: {hash_err}",
+                        "receipt_id": receipt_id,
+                        "receipt_path": receipt_path,
+                    },
+                )
             _receipt_store[receipt_id] = receipt  # update cache
             return await _build_receipt_envelope(receipt, receipt_id, receipt_path)
+    except HTTPException:
+        # Re-raise HTTPExceptions (integrity errors) — do not swallow
+        raise
     except Exception as exc:
         backend_error = exc
         logger.warning("Durable receipt lookup failed for %s at %s: %s", receipt_id, receipt_path, exc)
 
-    # Fallback to memory cache
+    # Fallback to memory cache — also must verify hash
     cached = _receipt_store.get(receipt_id)
     if cached is not None:
+        if not cached.get("receipt_sha256"):
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "code": "RECEIPT_INTEGRITY_MISSING_HASH",
+                    "message": "Cached receipt is missing receipt_sha256; cannot verify integrity",
+                    "receipt_id": receipt_id,
+                },
+            )
+        hash_ok, hash_err = verify_receipt_sha256(cached)
+        if not hash_ok:
+            _receipt_store.pop(receipt_id, None)  # evict corrupt cache
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "code": "RECEIPT_HASH_INVALID",
+                    "message": f"Cached receipt hash verification failed: {hash_err}",
+                    "receipt_id": receipt_id,
+                },
+            )
         if backend_error is None:
-            # Durable returned None (not found) but cache exists — return cache
             return await _build_receipt_envelope(cached, receipt_id, receipt_path)
-        # Backend errored but we have cache — return cache with warning
+        # Backend errored but we have verified cache — return cache with warning
         out = dict(cached)
         warnings = out.setdefault("warnings", [])
         if isinstance(warnings, list):

--- a/apps/record_chain_intake_gateway/tests/test_receipt.py
+++ b/apps/record_chain_intake_gateway/tests/test_receipt.py
@@ -55,8 +55,15 @@ class TestReceiptPathFromId:
 # ---------------------------------------------------------------------------
 
 class TestGetReceipt:
+    def _make_receipt(self, receipt_id: str = "rcg-20260613-abcdef123456") -> dict:
+        """Build a test receipt with valid receipt_sha256."""
+        from apps.record_chain_intake_gateway.gateway.receipts import compute_receipt_sha256
+        receipt = {"server_receipt_id": receipt_id, "accepted": True}
+        receipt["receipt_sha256"] = compute_receipt_sha256(receipt)
+        return receipt
+
     def test_durable_hit_returns_receipt(self, client: TestClient) -> None:
-        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        receipt = self._make_receipt()
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",
             new_callable=AsyncMock,
@@ -65,12 +72,11 @@ class TestGetReceipt:
             resp = client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
         assert resp.status_code == 200
         body = resp.json()
-        # Receipt is now wrapped in an envelope
         assert body["receipt"]["server_receipt_id"] == "rcg-20260613-abcdef123456"
         assert body["receipt_hash_verified"] is True
 
     def test_durable_hit_updates_cache(self, client: TestClient) -> None:
-        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        receipt = self._make_receipt()
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",
             new_callable=AsyncMock,
@@ -78,6 +84,17 @@ class TestGetReceipt:
         ):
             client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
         assert _receipt_store.get("rcg-20260613-abcdef123456") is not None
+
+    def test_durable_missing_hash_returns_500(self, client: TestClient) -> None:
+        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        with patch(
+            "apps.record_chain_intake_gateway.app.get_file_text",
+            new_callable=AsyncMock,
+            return_value=json.dumps(receipt),
+        ):
+            resp = client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
+        assert resp.status_code == 500
+        assert resp.json()["detail"]["code"] == "RECEIPT_INTEGRITY_MISSING_HASH"
 
     def test_durable_backend_error_no_cache_returns_503(self, client: TestClient) -> None:
         with patch(
@@ -92,7 +109,7 @@ class TestGetReceipt:
         assert body["detail"]["retryable"] is True
 
     def test_durable_backend_error_with_cache_returns_cache_and_warning(self, client: TestClient) -> None:
-        cached = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        cached = self._make_receipt()
         _receipt_store["rcg-20260613-abcdef123456"] = cached
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",


### PR DESCRIPTION
## fix: receipt endpoint fail-closed integrity

### Changes (app.py)

**Receipt endpoint (`GET /record-chain/receipt/{receipt_id}`):**
- Missing `receipt_sha256` now returns 500 `RECEIPT_INTEGRITY_MISSING_HASH` (was: warning + skip)
- Hash mismatch returns 500 `RECEIPT_HASH_INVALID`; `HTTPException` re-raised, not caught by broad `except Exception`
- Cache fallback also verifies hash before returning; corrupt cache entries evicted

**Idempotency index receipt check:**
- Missing `receipt_sha256` now raises `RuntimeError` (fail-closed, was: skip)

### Changes (test_receipt.py)

- Added `_make_receipt()` helper that builds test receipts with valid `receipt_sha256`
- Added `test_durable_missing_hash_returns_500` test
- Updated cache test to use receipts with valid hash

### Validation

```
Gateway tests: 287 passed, 0 failed
System tests: ALL PASSED
```
