### PR TITLE
fix(#507): close 3 production code gaps — builder opts, fail-closed receipt hash, summary-json guarantee

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -12,8 +12,8 @@
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "sha256": "e10e672d58904bdead3c84434870cd7c0ce686760cf4f6acabe5151eb463ebd3",
-    "size_bytes": 133152,
+    "sha256": "086a3ec32ce7032ef0cc928b3315d989ea680b03c7fecccff8196e02978bdafe",
+    "size_bytes": 133268,
     "supports": [
       "echo",
       "verification",

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -564,10 +564,12 @@ async def _submit_response_from_idempotency_index(
         raise RuntimeError(f"Idempotency receipt is not a JSON object: {receipt_path}")
 
     # Verify receipt hash integrity
-    if receipt_data.get("receipt_sha256"):
-        hash_ok, hash_err = verify_receipt_sha256(receipt_data)
-        if not hash_ok:
-            raise RuntimeError(f"IDEMPOTENCY_RECEIPT_HASH_INVALID: {hash_err} at {receipt_path}")
+    # Fail-closed: receipt MUST have receipt_sha256
+    if not receipt_data.get("receipt_sha256"):
+        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_MISSING_HASH: receipt has no receipt_sha256 at {receipt_path}")
+    hash_ok, hash_err = verify_receipt_sha256(receipt_data)
+    if not hash_ok:
+        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_HASH_INVALID: {hash_err} at {receipt_path}")
 
     receipt_id = (
         receipt_data.get("server_receipt_id")
@@ -1375,35 +1377,64 @@ async def get_receipt(receipt_id: str) -> dict[str, Any]:
         text = await get_file_text(receipt_path)
         if text is not None:
             receipt = json.loads(text)
-            # Verify receipt hash integrity before returning
-            if receipt.get("receipt_sha256"):
-                hash_ok, hash_err = verify_receipt_sha256(receipt)
-                if not hash_ok:
-                    logger.error("Durable receipt hash invalid for %s at %s: %s", receipt_id, receipt_path, hash_err)
-                    raise HTTPException(
-                        status_code=500,
-                        detail={
-                            "code": "RECEIPT_HASH_INVALID",
-                            "message": f"Receipt hash verification failed: {hash_err}",
-                            "receipt_id": receipt_id,
-                            "receipt_path": receipt_path,
-                        },
-                    )
-            else:
-                logger.warning("Receipt %s has no receipt_sha256; skipping hash verification", receipt_id)
+            # Fail-closed: receipt MUST have receipt_sha256
+            if not receipt.get("receipt_sha256"):
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "code": "RECEIPT_INTEGRITY_MISSING_HASH",
+                        "message": "Receipt is missing receipt_sha256; cannot verify integrity",
+                        "receipt_id": receipt_id,
+                        "receipt_path": receipt_path,
+                    },
+                )
+            # Verify receipt hash integrity
+            hash_ok, hash_err = verify_receipt_sha256(receipt)
+            if not hash_ok:
+                raise HTTPException(
+                    status_code=500,
+                    detail={
+                        "code": "RECEIPT_HASH_INVALID",
+                        "message": f"Receipt hash verification failed: {hash_err}",
+                        "receipt_id": receipt_id,
+                        "receipt_path": receipt_path,
+                    },
+                )
             _receipt_store[receipt_id] = receipt  # update cache
             return await _build_receipt_envelope(receipt, receipt_id, receipt_path)
+    except HTTPException:
+        # Re-raise HTTPExceptions (integrity errors) — do not swallow
+        raise
     except Exception as exc:
         backend_error = exc
         logger.warning("Durable receipt lookup failed for %s at %s: %s", receipt_id, receipt_path, exc)
 
-    # Fallback to memory cache
+    # Fallback to memory cache — also must verify hash
     cached = _receipt_store.get(receipt_id)
     if cached is not None:
+        if not cached.get("receipt_sha256"):
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "code": "RECEIPT_INTEGRITY_MISSING_HASH",
+                    "message": "Cached receipt is missing receipt_sha256; cannot verify integrity",
+                    "receipt_id": receipt_id,
+                },
+            )
+        hash_ok, hash_err = verify_receipt_sha256(cached)
+        if not hash_ok:
+            _receipt_store.pop(receipt_id, None)  # evict corrupt cache
+            raise HTTPException(
+                status_code=500,
+                detail={
+                    "code": "RECEIPT_HASH_INVALID",
+                    "message": f"Cached receipt hash verification failed: {hash_err}",
+                    "receipt_id": receipt_id,
+                },
+            )
         if backend_error is None:
-            # Durable returned None (not found) but cache exists — return cache
             return await _build_receipt_envelope(cached, receipt_id, receipt_path)
-        # Backend errored but we have cache — return cache with warning
+        # Backend errored but we have verified cache — return cache with warning
         out = dict(cached)
         warnings = out.setdefault("warnings", [])
         if isinstance(warnings, list):

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -566,10 +566,22 @@ async def _submit_response_from_idempotency_index(
     # Verify receipt hash integrity
     # Fail-closed: receipt MUST have receipt_sha256
     if not receipt_data.get("receipt_sha256"):
-        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_MISSING_HASH: receipt has no receipt_sha256 at {receipt_path}")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "IDEMPOTENCY_RECEIPT_MISSING_HASH",
+                "message": f"Receipt has no receipt_sha256 at {receipt_path}",
+            },
+        )
     hash_ok, hash_err = verify_receipt_sha256(receipt_data)
     if not hash_ok:
-        raise RuntimeError(f"IDEMPOTENCY_RECEIPT_HASH_INVALID: {hash_err} at {receipt_path}")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "code": "IDEMPOTENCY_RECEIPT_HASH_INVALID",
+                "message": f"Receipt hash invalid: {hash_err} at {receipt_path}",
+            },
+        )
 
     receipt_id = (
         receipt_data.get("server_receipt_id")
@@ -869,6 +881,10 @@ async def submit(request: Request) -> SubmitResponse | JSONResponse:
                 received_raw_body_sha256=received_raw_body_sha256,
                 body=body,
             )
+        except HTTPException:
+            # Fail-closed: receipt integrity errors (missing/invalid receipt_sha256)
+            # must not be swallowed by the broad except below.
+            raise
         except Exception as exc:
             logger.warning(
                 "Existing idempotency index could not be resolved for %s: %s",
@@ -1166,6 +1182,9 @@ async def submit(request: Request) -> SubmitResponse | JSONResponse:
                             received_raw_body_sha256=received_raw_body_sha256,
                             body=body,
                         )
+                    except HTTPException:
+                        # Fail-closed: receipt integrity errors must propagate.
+                        raise
                     except Exception as response_exc:
                         logger.error(
                             "Existing idempotency index could not be converted into response for %s: %s",

--- a/apps/record_chain_intake_gateway/tests/test_receipt.py
+++ b/apps/record_chain_intake_gateway/tests/test_receipt.py
@@ -55,8 +55,15 @@ class TestReceiptPathFromId:
 # ---------------------------------------------------------------------------
 
 class TestGetReceipt:
+    def _make_receipt(self, receipt_id: str = "rcg-20260613-abcdef123456") -> dict:
+        """Build a test receipt with valid receipt_sha256."""
+        from apps.record_chain_intake_gateway.gateway.receipts import compute_receipt_sha256
+        receipt = {"server_receipt_id": receipt_id, "accepted": True}
+        receipt["receipt_sha256"] = compute_receipt_sha256(receipt)
+        return receipt
+
     def test_durable_hit_returns_receipt(self, client: TestClient) -> None:
-        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        receipt = self._make_receipt()
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",
             new_callable=AsyncMock,
@@ -65,12 +72,11 @@ class TestGetReceipt:
             resp = client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
         assert resp.status_code == 200
         body = resp.json()
-        # Receipt is now wrapped in an envelope
         assert body["receipt"]["server_receipt_id"] == "rcg-20260613-abcdef123456"
         assert body["receipt_hash_verified"] is True
 
     def test_durable_hit_updates_cache(self, client: TestClient) -> None:
-        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        receipt = self._make_receipt()
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",
             new_callable=AsyncMock,
@@ -78,6 +84,17 @@ class TestGetReceipt:
         ):
             client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
         assert _receipt_store.get("rcg-20260613-abcdef123456") is not None
+
+    def test_durable_missing_hash_returns_500(self, client: TestClient) -> None:
+        receipt = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        with patch(
+            "apps.record_chain_intake_gateway.app.get_file_text",
+            new_callable=AsyncMock,
+            return_value=json.dumps(receipt),
+        ):
+            resp = client.get("/record-chain/receipt/rcg-20260613-abcdef123456")
+        assert resp.status_code == 500
+        assert resp.json()["detail"]["code"] == "RECEIPT_INTEGRITY_MISSING_HASH"
 
     def test_durable_backend_error_no_cache_returns_503(self, client: TestClient) -> None:
         with patch(
@@ -92,7 +109,7 @@ class TestGetReceipt:
         assert body["detail"]["retryable"] is True
 
     def test_durable_backend_error_with_cache_returns_cache_and_warning(self, client: TestClient) -> None:
-        cached = {"server_receipt_id": "rcg-20260613-abcdef123456", "accepted": True}
+        cached = self._make_receipt()
         _receipt_store["rcg-20260613-abcdef123456"] = cached
         with patch(
             "apps.record_chain_intake_gateway.app.get_file_text",

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -2489,6 +2489,8 @@ async function main() {
     newClassification: args.newClassification || "",
     classificationReason: args.classificationReason || "",
     evidenceOrReviewBasis: args.evidenceOrReviewBasis || "",
+    correctionReason: args.correctionReason || "",
+    correctedFieldsOrClaims: args.correctedFieldsOrClaims || "",
   };
 
   validateFormalInputs(cmd, opts);

--- a/scripts/trinity_record_chain.py
+++ b/scripts/trinity_record_chain.py
@@ -847,200 +847,200 @@ def append_records(all_records: bool = False, allow_rejections: bool = False, pe
         if summary_json:
             write_json(Path(summary_json), summary)
 
-    if pending_file:
-        # Single-file mode: append one specific pending file
-        p = Path(pending_file)
-        if not p.is_absolute():
-            p = ROOT / p
-        if not p.exists():
-            raise SystemExit(f"pending file not found: {p}")
-        pending = [p]
-    else:
-        pending = sorted(PENDING.glob("*.json"))
-    if not pending:
-        print("No pending records.")
-        _write_summary()
-        return
-    selected = pending if all_records else pending[:1]
-    summary["selected_count"] = len(selected)
-    rejected_count = 0
-    appended_count = 0
-    for path in selected:
-        try:
-            # Enforce CLI receipt-id binding: if --receipt-id is passed, it must match
-            # the pending file's receipt id
-            if receipt_id is not None:
-                pending_receipt_id = _gateway_pending_receipt_id(path)
-                if pending_receipt_id != receipt_id:
-                    raise ValueError(
-                        f"--receipt-id {receipt_id} does not match pending file receipt id {pending_receipt_id}: {path.relative_to(ROOT)}"
-                    )
+    try:
+        if pending_file:
+            # Single-file mode: append one specific pending file
+            p = Path(pending_file)
+            if not p.is_absolute():
+                p = ROOT / p
+            if not p.exists():
+                raise SystemExit(f"pending file not found: {p}")
+            pending = [p]
+        else:
+            pending = sorted(PENDING.glob("*.json"))
+        if not pending:
+            print("No pending records.")
+            return
+        selected = pending if all_records else pending[:1]
+        summary["selected_count"] = len(selected)
+        rejected_count = 0
+        appended_count = 0
+        for path in selected:
+            try:
+                # Enforce CLI receipt-id binding: if --receipt-id is passed, it must match
+                # the pending file's receipt id
+                if receipt_id is not None:
+                    pending_receipt_id = _gateway_pending_receipt_id(path)
+                    if pending_receipt_id != receipt_id:
+                        raise ValueError(
+                            f"--receipt-id {receipt_id} does not match pending file receipt id {pending_receipt_id}: {path.relative_to(ROOT)}"
+                        )
 
-            raw_draft = read_json(path)
+                raw_draft = read_json(path)
 
-            # Gateway-created pending files must not be appendable unless durable
-            # submission, receipt, and idempotency state already exist and bind to them.
-            # Non-canonical pending files are rejected unless explicitly allowed.
-            require_pending_file_is_appendable(path)
-            require_not_reserved_record_type(raw_draft)
+                # Gateway-created pending files must not be appendable unless durable
+                # submission, receipt, and idempotency state already exist and bind to them.
+                # Non-canonical pending files are rejected unless explicitly allowed.
+                require_pending_file_is_appendable(path)
+                require_not_reserved_record_type(raw_draft)
 
-            # Extract unsigned server append metadata before stripping unsigned projection fields.
-            server_append_metadata = extract_server_append_metadata(raw_draft)
+                # Extract unsigned server append metadata before stripping unsigned projection fields.
+                server_append_metadata = extract_server_append_metadata(raw_draft)
 
-            # Verify authorship proof on the signed-scope pending draft before normalization
-            # modifies it. Then append the same sanitized object that was verified.
-            signed_scope_draft = sanitize_pending_record_for_append(raw_draft)
-            require_not_reserved_record_type(signed_scope_draft)
-            verify_pending_record_authorship(signed_scope_draft)
-            draft = normalize_record_draft(signed_scope_draft)
+                # Verify authorship proof on the signed-scope pending draft before normalization
+                # modifies it. Then append the same sanitized object that was verified.
+                signed_scope_draft = sanitize_pending_record_for_append(raw_draft)
+                require_not_reserved_record_type(signed_scope_draft)
+                verify_pending_record_authorship(signed_scope_draft)
+                draft = normalize_record_draft(signed_scope_draft)
 
-            if server_append_metadata:
-                draft.setdefault("server_normalization", {})
-                draft["server_normalization"]["server_append_metadata"] = server_append_metadata
+                if server_append_metadata:
+                    draft.setdefault("server_normalization", {})
+                    draft["server_normalization"]["server_append_metadata"] = server_append_metadata
 
-            # --- Phase 6B: authorship_verification_status ---
-            # Record the scope of the authorship proof relative to the final
-            # appended record.  The builder signs the *draft* before gateway
-            # append-assigned fields exist; the final record hash is the
-            # server append hash, not the signed payload hash.
-            rtype = draft.get("record_type", "")
-            if rtype in FORMAL_RECORD_TYPES and rtype not in AUTHORSHIP_EXEMPT_TYPES:
-                existing_status = draft.get("authorship_verification_status")
-                if not isinstance(existing_status, dict):
-                    existing_status = {}
-                draft["authorship_verification_status"] = {
-                    "signed_payload_scope": "pre_append_record_draft",
-                    "verified_by_gateway_before_pending": existing_status.get("verified_by_gateway_before_pending") is True,
-                    "verified_by_append_before_record": True,
-                    "final_record_contains_append_assigned_fields_not_in_signed_payload": True,
+                # --- Phase 6B: authorship_verification_status ---
+                # Record the scope of the authorship proof relative to the final
+                # appended record.  The builder signs the *draft* before gateway
+                # append-assigned fields exist; the final record hash is the
+                # server append hash, not the signed payload hash.
+                rtype = draft.get("record_type", "")
+                if rtype in FORMAL_RECORD_TYPES and rtype not in AUTHORSHIP_EXEMPT_TYPES:
+                    existing_status = draft.get("authorship_verification_status")
+                    if not isinstance(existing_status, dict):
+                        existing_status = {}
+                    draft["authorship_verification_status"] = {
+                        "signed_payload_scope": "pre_append_record_draft",
+                        "verified_by_gateway_before_pending": existing_status.get("verified_by_gateway_before_pending") is True,
+                        "verified_by_append_before_record": True,
+                        "final_record_contains_append_assigned_fields_not_in_signed_payload": True,
+                    }
+
+                next_index = int(tip.get("latest_record_index") or 0) + 1
+                draft["record_index"] = next_index
+                draft["record_id"] = record_id(next_index)
+                draft["assigned_at"] = utc_now()
+                draft["previous_record_sha256"] = tip.get("latest_record_sha256")
+
+                # --- Phase 6B: append_assigned_metadata ---
+                # Mark fields that are assigned by the server during append and
+                # are NOT part of the original signed payload.
+                # Hash fields (content_sha256, record_sha256) are intentionally
+                # excluded — they are record-integrity fields, not append assignments.
+                draft["append_assigned_metadata"] = {
+                    "record_index": next_index,
+                    "record_id": record_id(next_index),
+                    "assigned_at": draft["assigned_at"],
+                    "previous_record_sha256": draft["previous_record_sha256"],
                 }
 
-            next_index = int(tip.get("latest_record_index") or 0) + 1
-            draft["record_index"] = next_index
-            draft["record_id"] = record_id(next_index)
-            draft["assigned_at"] = utc_now()
-            draft["previous_record_sha256"] = tip.get("latest_record_sha256")
-
-            # --- Phase 6B: append_assigned_metadata ---
-            # Mark fields that are assigned by the server during append and
-            # are NOT part of the original signed payload.
-            # Hash fields (content_sha256, record_sha256) are intentionally
-            # excluded — they are record-integrity fields, not append assignments.
-            draft["append_assigned_metadata"] = {
-                "record_index": next_index,
-                "record_id": record_id(next_index),
-                "assigned_at": draft["assigned_at"],
-                "previous_record_sha256": draft["previous_record_sha256"],
-            }
-
-            # --- Phase 6B: server_normalization projection ---
-            # Legacy compatibility defaults that used to be scattered into the
-            # draft are now isolated in a server_normalization block so they
-            # don't pollute the canonical content hash signed by the author.
-            draft.setdefault("server_normalization", {})
-            sn = draft["server_normalization"]
-            sn.setdefault("legacy_compatibility_projection", {
-                "human_context": None,
-                "discovery_autonomy": None,
-                "decision_autonomy": None,
-                "execution_authorization": None,
-                "guardian_proof": None,
-                "oath": None,
-            })
-
-            draft["content_sha256"] = content_hash(draft)
-            draft["content_sha256_v2"] = content_hash_v2(draft)
-            draft["record_sha256"] = record_hash(draft)
-
-            out = RECORDS / f"{draft['record_id']}.json"
-            if out.exists():
-                raise ValueError(f"record output already exists: {out}")
-            write_json(out, draft)
-            shutil.move(str(path), str(PROCESSED / path.name))
-            tip.update({
-                "native_record_count": int(tip.get("native_record_count") or 0) + 1,
-                "latest_record_index": next_index,
-                "latest_record_id": draft["record_id"],
-                "latest_record_sha256": draft["record_sha256"],
-                "updated_at": utc_now(),
-            })
-            write_json(CHAIN_TIP, tip)
-            appended_count += 1
-
-            # C.1: Write durable receipt-status for appended record
-            _rcid = _gateway_pending_receipt_id(path)
-            if _rcid:
-                rs_path = RECEIPT_STATUS / f"{_rcid}.json"
-                write_json(rs_path, {
-                    "schema": "trinityaccord.record-chain-receipt-final-status.v1",
-                    "receipt_id": _rcid,
-                    "pending_file_path": str(path.relative_to(ROOT)),
-                    "append_status": "appended",
-                    "final_record_id": draft["record_id"],
-                    "final_record_path": str(out.relative_to(ROOT)),
-                    "final_record_sha256": draft["record_sha256"],
-                    "rejection_path": None,
-                    "rejection_code": None,
-                    "updated_at": utc_now(),
-                })
-        except Exception as exc:
-            # Phase 6B: --all continues after rejection; writes rejection JSON
-            REJECTED.mkdir(parents=True, exist_ok=True)
-            rejection_path = REJECTED / f"{path.stem}.rejection.json"
-            rejection = {
-                "schema": "trinityaccord.record-chain-rejection.v1",
-                "rejected_at": utc_now(),
-                "source_pending": path.name,
-                "reason": str(exc),
-            }
-            write_json(rejection_path, rejection)
-            if path.exists():
-                shutil.move(str(path), str(REJECTED / path.name))
-            rejected_count += 1
-
-            # C.1: Write durable receipt-status for rejected record
-            _rcid = _gateway_pending_receipt_id(path)
-            if _rcid:
-                rs_path = RECEIPT_STATUS / f"{_rcid}.json"
-                write_json(rs_path, {
-                    "schema": "trinityaccord.record-chain-receipt-final-status.v1",
-                    "receipt_id": _rcid,
-                    "pending_file_path": str(path.relative_to(ROOT)),
-                    "append_status": "rejected",
-                    "final_record_id": None,
-                    "final_record_path": None,
-                    "final_record_sha256": None,
-                    "rejection_path": str(rejection_path.relative_to(ROOT)),
-                    "rejection_code": str(exc),
-                    "updated_at": utc_now(),
+                # --- Phase 6B: server_normalization projection ---
+                # Legacy compatibility defaults that used to be scattered into the
+                # draft are now isolated in a server_normalization block so they
+                # don't pollute the canonical content hash signed by the author.
+                draft.setdefault("server_normalization", {})
+                sn = draft["server_normalization"]
+                sn.setdefault("legacy_compatibility_projection", {
+                    "human_context": None,
+                    "discovery_autonomy": None,
+                    "decision_autonomy": None,
+                    "execution_authorization": None,
+                    "guardian_proof": None,
+                    "oath": None,
                 })
 
-            if not all_records:
-                raise SystemExit(f"Rejected pending record {path.name}: {exc}") from exc
-            print(f"REJECTED {path.name}: {exc}", file=sys.stderr)
-    if rejected_count:
-        print(f"Append summary: {appended_count} appended, {rejected_count} rejected.")
+                draft["content_sha256"] = content_hash(draft)
+                draft["content_sha256_v2"] = content_hash_v2(draft)
+                draft["record_sha256"] = record_hash(draft)
+
+                out = RECORDS / f"{draft['record_id']}.json"
+                if out.exists():
+                    raise ValueError(f"record output already exists: {out}")
+                write_json(out, draft)
+                shutil.move(str(path), str(PROCESSED / path.name))
+                tip.update({
+                    "native_record_count": int(tip.get("native_record_count") or 0) + 1,
+                    "latest_record_index": next_index,
+                    "latest_record_id": draft["record_id"],
+                    "latest_record_sha256": draft["record_sha256"],
+                    "updated_at": utc_now(),
+                })
+                write_json(CHAIN_TIP, tip)
+                appended_count += 1
+
+                # C.1: Write durable receipt-status for appended record
+                _rcid = _gateway_pending_receipt_id(path)
+                if _rcid:
+                    rs_path = RECEIPT_STATUS / f"{_rcid}.json"
+                    write_json(rs_path, {
+                        "schema": "trinityaccord.record-chain-receipt-final-status.v1",
+                        "receipt_id": _rcid,
+                        "pending_file_path": str(path.relative_to(ROOT)),
+                        "append_status": "appended",
+                        "final_record_id": draft["record_id"],
+                        "final_record_path": str(out.relative_to(ROOT)),
+                        "final_record_sha256": draft["record_sha256"],
+                        "rejection_path": None,
+                        "rejection_code": None,
+                        "updated_at": utc_now(),
+                    })
+            except Exception as exc:
+                # Phase 6B: --all continues after rejection; writes rejection JSON
+                REJECTED.mkdir(parents=True, exist_ok=True)
+                rejection_path = REJECTED / f"{path.stem}.rejection.json"
+                rejection = {
+                    "schema": "trinityaccord.record-chain-rejection.v1",
+                    "rejected_at": utc_now(),
+                    "source_pending": path.name,
+                    "reason": str(exc),
+                }
+                write_json(rejection_path, rejection)
+                if path.exists():
+                    shutil.move(str(path), str(REJECTED / path.name))
+                rejected_count += 1
+
+                # C.1: Write durable receipt-status for rejected record
+                _rcid = _gateway_pending_receipt_id(path)
+                if _rcid:
+                    rs_path = RECEIPT_STATUS / f"{_rcid}.json"
+                    write_json(rs_path, {
+                        "schema": "trinityaccord.record-chain-receipt-final-status.v1",
+                        "receipt_id": _rcid,
+                        "pending_file_path": str(path.relative_to(ROOT)),
+                        "append_status": "rejected",
+                        "final_record_id": None,
+                        "final_record_path": None,
+                        "final_record_sha256": None,
+                        "rejection_path": str(rejection_path.relative_to(ROOT)),
+                        "rejection_code": str(exc),
+                        "updated_at": utc_now(),
+                    })
+
+                if not all_records:
+                    raise SystemExit(f"Rejected pending record {path.name}: {exc}") from exc
+                print(f"REJECTED {path.name}: {exc}", file=sys.stderr)
+        if rejected_count:
+            print(f"Append summary: {appended_count} appended, {rejected_count} rejected.")
+            summary["appended_count"] = appended_count
+            summary["rejected_count"] = rejected_count
+            if not allow_rejections:
+                raise SystemExit(2)
+
+        # Phase 6B: immediately verify after append — newly appended records
+        # must pass verify_native_records() before building indexes.
+        if appended_count > 0:
+            verrors = verify_native_records()
+            if verrors:
+                print("Post-append verification FAILED:", file=sys.stderr)
+                for e in verrors:
+                    print(f"  - {e}", file=sys.stderr)
+                raise SystemExit("Post-append verify_native_records() failed; indexes not rebuilt.")
+
+        build_indexes()
+
         summary["appended_count"] = appended_count
         summary["rejected_count"] = rejected_count
+    finally:
         _write_summary()
-        if not allow_rejections:
-            raise SystemExit(2)
-
-    # Phase 6B: immediately verify after append — newly appended records
-    # must pass verify_native_records() before building indexes.
-    if appended_count > 0:
-        verrors = verify_native_records()
-        if verrors:
-            print("Post-append verification FAILED:", file=sys.stderr)
-            for e in verrors:
-                print(f"  - {e}", file=sys.stderr)
-            raise SystemExit("Post-append verify_native_records() failed; indexes not rebuilt.")
-
-    build_indexes()
-
-    summary["appended_count"] = appended_count
-    summary["rejected_count"] = rejected_count
-    _write_summary()
 
 
 def existing_batch_manifests() -> list[Path]:


### PR DESCRIPTION
## Production code fixes from #507

### 3 fixes, 4 files changed

1. **`downloads/record-chain-builder.mjs`** — `correctionReason` and `correctedFieldsOrClaims` were missing from the CLI→opts map. `--correction-reason` and `--corrected-fields-or-claims` were validated by `requireExplicit()` but never actually passed to `buildCorrectionDraft()`, so the correction draft always had empty values.

2. **`apps/record_chain_intake_gateway/app.py`** — `_submit_response_from_idempotency_index()` raised `RuntimeError` when `receipt_sha256` was missing or hash-invalid, but the broad `except Exception` in both call sites swallowed it and returned `accepted=False` with a warning. Now raises `HTTPException(500)` and callers re-raise `HTTPException` before the broad catch — fail-closed as intended.

3. **`scripts/trinity_record_chain.py`** — `--summary-json` was not written when `SystemExit` was raised (single-file rejection, post-append verification failure, or `allow_rejections=false`). Wrapped the main body in `try/finally` so `_write_summary()` runs on every exit path.

### Validation results (all green)

| Command | Result |
|---------|--------|
| `python3 -m py_compile` (app.py, trinity_record_chain.py) | ✅ OK |
| `pytest apps/record_chain_intake_gateway/tests/ -q` | ✅ 287 passed, 1 skipped |
| `python3 scripts/trinity_record_chain.py verify` | ✅ Passed |
| `python3 scripts/run_current_system_tests.py` | ✅ All 87 tests passed |

### Files changed
- `downloads/record-chain-builder.mjs` (+2 lines)
- `apps/record_chain_intake_gateway/app.py` (fail-closed receipt integrity)
- `apps/record_chain_intake_gateway/tests/test_receipt.py` (receipt test fixtures)
- `scripts/trinity_record_chain.py` (restructured try/finally)
- `api/record-chain-builder-bundles.v1.json` (updated builder sha256)