### PR TITLE
feat(builder): add agent submit field guidance

### DIFF
--- a/api/record-chain-agent-field-guidance.v1.json
+++ b/api/record-chain-agent-field-guidance.v1.json
@@ -1,0 +1,160 @@
+{
+  "schema": "trinityaccord.record-chain-agent-field-guidance.v1",
+  "status": "active",
+  "version": "1.0.0",
+  "generated_for": "record-chain-builder semantic field guidance",
+  "purpose": "Machine-readable guidance for agents before building Record-Chain submissions. This file explains how to fill target-binding and evidence fields that cannot be safely inferred from format validation alone.",
+  "global_rules": [
+    "Do not guess target record identifiers or hashes.",
+    "For any target_record_sha256-style field, use the target final record's record_sha256 unless this guidance explicitly says otherwise.",
+    "Never use content_sha256, content_sha256_v2, receipt_sha256, archive hash, or the new record's hash as a target record hash.",
+    "If the target final record cannot be identified, stop and return BUILDER_USAGE_UNCLEAR.",
+    "Corrections, classification updates, and guardian retirements are append-only records; they do not mutate or delete prior records."
+  ],
+  "record_types": {
+    "correction": {
+      "purpose": "Append-only correction of a prior final record. It links to the original record and explains a concrete error, omission, or bounded claim that needs correction.",
+      "before_build": [
+        "Read the target final record first.",
+        "Copy target_record_id from the target final record's record_id.",
+        "Copy target_record_sha256 from the target final record's record_sha256.",
+        "Write a specific correction_reason; do not use vague text such as 'fix' or 'update'.",
+        "List the corrected fields or claims explicitly.",
+        "State the evidence or review basis, such as source paths, tests, PRs, CI results, command output, or manual audit findings.",
+        "If any target binding value is uncertain, stop and return BUILDER_USAGE_UNCLEAR."
+      ],
+      "builder_command": "correction",
+      "required_cli_options": [
+        "--body",
+        "--target-record-id",
+        "--target-record-sha256",
+        "--correction-reason",
+        "--corrected-fields-or-claims",
+        "--evidence-or-review-basis"
+      ],
+      "example_cli_fragment": "--target-record-id R-000000123 --target-record-sha256 <target.record_sha256> --correction-reason \"Receipt endpoint missing-hash behavior was previously described incorrectly\" --corrected-fields-or-claims \"receipt hash verification,fail-closed behavior\" --evidence-or-review-basis \"Reviewed apps/record_chain_intake_gateway/app.py and gateway receipt tests\""
+    },
+    "classification_update": {
+      "purpose": "Append-only classification or reclassification of a prior final record based on new information or analysis.",
+      "before_build": [
+        "Read the target final record first.",
+        "Copy target_record_id from the target final record's record_id.",
+        "Copy target_record_sha256 from the target final record's record_sha256.",
+        "Use previous_classification for the classification/status before this update.",
+        "Use new_classification for the classification/status this update asserts now.",
+        "State the classification_reason and evidence_or_review_basis explicitly.",
+        "If the target or prior classification is unclear, stop and return BUILDER_USAGE_UNCLEAR."
+      ],
+      "builder_command": "classification-update",
+      "required_cli_options": [
+        "--target-record-id",
+        "--target-record-sha256",
+        "--previous-classification",
+        "--new-classification",
+        "--classification-reason",
+        "--evidence-or-review-basis"
+      ]
+    },
+    "guardian_retirement": {
+      "purpose": "Append-only retirement of an existing guardian. Retirement preserves history and must bind to the original guardian_application record.",
+      "before_build": [
+        "Find the matching guardian_application final record for the guardian being retired.",
+        "Copy target_guardian_application_record_id from that guardian_application record's record_id.",
+        "Copy target_guardian_application_record_sha256 from that guardian_application record's record_sha256.",
+        "Do not use the guardian retirement record's future hash, content hash, receipt hash, or a copied public key hash as the target record hash.",
+        "If the matching guardian_application record cannot be identified, stop and return BUILDER_USAGE_UNCLEAR."
+      ],
+      "builder_command": "guardian-retirement",
+      "required_cli_options": [
+        "--guardian-id",
+        "--guardian-key-sha",
+        "--body",
+        "--target-guardian-application-record-id",
+        "--target-guardian-application-record-sha256"
+      ]
+    }
+  },
+  "fields": {
+    "correction_content": {
+      "meaning": "Structured correction payload linking this correction to the prior final record it corrects.",
+      "how_to_fill": "Use this block for append-only correction details. It must identify the target final record and explain the correction basis.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.target_record_id": {
+      "meaning": "The record_id of the final record being corrected.",
+      "how_to_fill": "Read the target final record and copy its record_id exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_id",
+      "never_use": ["the new correction record id", "receipt id", "batch id", "archive id"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.target_record_sha256": {
+      "meaning": "The record_sha256 of the final record being corrected.",
+      "how_to_fill": "Read the target final record and copy its record_sha256 exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256",
+      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "archive_manifest_sha256", "the new correction record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.correction_reason": {
+      "meaning": "Specific reason the prior record needs correction.",
+      "how_to_fill": "State the concrete error, omission, or bounded claim being corrected. Avoid vague values such as 'fix' or 'update'.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.corrected_fields_or_claims": {
+      "meaning": "Non-empty list of fields or claims being corrected.",
+      "how_to_fill": "Use specific field names or claim labels. In the CLI, pass comma-separated values.",
+      "example": ["receipt hash verification", "arweave current status"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.evidence_or_review_basis": {
+      "meaning": "Evidence, review basis, or reasoning supporting the correction.",
+      "how_to_fill": "Cite source file paths, tests, PR numbers, CI results, command output, or manual audit findings.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.target_record_id": {
+      "meaning": "The record_id of the final record being classified or reclassified.",
+      "how_to_fill": "Read the target final record and copy its record_id exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_id",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.target_record_sha256": {
+      "meaning": "The record_sha256 of the final record being classified or reclassified.",
+      "how_to_fill": "Read the target final record and copy its record_sha256 exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256",
+      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "the new classification_update record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.previous_classification": {
+      "meaning": "The classification/status before this update.",
+      "how_to_fill": "Use the best known prior classification from prior records, overlay index, or explicit review context.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.new_classification": {
+      "meaning": "The classification/status asserted by this update.",
+      "how_to_fill": "Use the new bounded classification supported by the stated evidence or review basis.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.classification_reason": {
+      "meaning": "Reason for changing or setting the classification.",
+      "how_to_fill": "Explain the new information or analysis that supports the update.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.evidence_or_review_basis": {
+      "meaning": "Evidence, review basis, or reasoning supporting this classification update.",
+      "how_to_fill": "Cite source file paths, tests, PRs, CI results, command output, or manual audit findings.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "target_guardian_application_record_id": {
+      "meaning": "The record_id of the original guardian_application final record for the guardian being retired.",
+      "how_to_fill": "Find the matching guardian_application record and copy its record_id exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_id where record_type is guardian_application",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "target_guardian_application_record_sha256": {
+      "meaning": "The record_sha256 of the original guardian_application final record for the guardian being retired.",
+      "how_to_fill": "Find the matching guardian_application record and copy its record_sha256 exactly.",
+      "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256 where record_type is guardian_application",
+      "never_use": ["guardian_public_key_sha256", "content_sha256", "content_sha256_v2", "receipt_sha256", "the new guardian_retirement record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    }
+  }
+}

--- a/downloads/record-chain-agent-field-guidance.v1.json
+++ b/downloads/record-chain-agent-field-guidance.v1.json
@@ -1,0 +1,88 @@
+{
+  "schema": "trinityaccord.record-chain-agent-field-guidance.v1",
+  "status": "active",
+  "version": "1.0.0",
+  "purpose": "Machine-readable guidance for agents before building correction, classification_update, and guardian_retirement submissions.",
+  "global_rules": [
+    "Do not guess target record identifiers or hashes.",
+    "Use the target final record's record_sha256 for target hash fields.",
+    "Never use content_sha256, content_sha256_v2, receipt_sha256, archive hash, or the new record hash as a target record hash.",
+    "If the target final record cannot be identified, stop and return BUILDER_USAGE_UNCLEAR."
+  ],
+  "record_types": {
+    "correction": {
+      "purpose": "Append-only correction of a prior final record.",
+      "required_cli_options": ["--body", "--target-record-id", "--target-record-sha256", "--correction-reason", "--corrected-fields-or-claims", "--evidence-or-review-basis"],
+      "before_build": [
+        "Read the target final record first.",
+        "Copy target_record_id from target.record_id.",
+        "Copy target_record_sha256 from target.record_sha256.",
+        "Write a specific correction_reason.",
+        "List corrected fields or claims explicitly.",
+        "State evidence_or_review_basis. If uncertain, return BUILDER_USAGE_UNCLEAR."
+      ]
+    },
+    "classification_update": {
+      "purpose": "Append-only classification or reclassification of a prior final record.",
+      "required_cli_options": ["--target-record-id", "--target-record-sha256", "--previous-classification", "--new-classification", "--classification-reason", "--evidence-or-review-basis"],
+      "before_build": [
+        "Read the target final record first.",
+        "Copy target_record_id from target.record_id.",
+        "Copy target_record_sha256 from target.record_sha256.",
+        "State previous and new classification. If uncertain, return BUILDER_USAGE_UNCLEAR."
+      ]
+    },
+    "guardian_retirement": {
+      "purpose": "Append-only retirement of an existing guardian; it must bind to the original guardian_application record.",
+      "required_cli_options": ["--guardian-id", "--guardian-key-sha", "--body", "--target-guardian-application-record-id", "--target-guardian-application-record-sha256"],
+      "before_build": [
+        "Find the matching guardian_application final record.",
+        "Copy target_guardian_application_record_id from that record_id.",
+        "Copy target_guardian_application_record_sha256 from that record_sha256.",
+        "If no matching guardian_application record is clear, return BUILDER_USAGE_UNCLEAR."
+      ]
+    }
+  },
+  "fields": {
+    "correction_content.target_record_sha256": {
+      "meaning": "record_sha256 of the final record being corrected.",
+      "source_of_truth": "target final record record_sha256",
+      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "new correction record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "classification_update_content.target_record_sha256": {
+      "meaning": "record_sha256 of the final record being classified or reclassified.",
+      "source_of_truth": "target final record record_sha256",
+      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "new classification_update record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "target_guardian_application_record_sha256": {
+      "meaning": "record_sha256 of the original guardian_application final record for the guardian being retired.",
+      "source_of_truth": "matching guardian_application final record record_sha256",
+      "never_use": ["guardian_public_key_sha256", "content_sha256", "content_sha256_v2", "receipt_sha256", "new guardian_retirement record hash"],
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.target_record_id": {
+      "meaning": "record_id of the final record being corrected.",
+      "source_of_truth": "target final record record_id",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.correction_reason": {
+      "meaning": "Specific reason the prior record needs correction; avoid vague text like fix or update.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.corrected_fields_or_claims": {
+      "meaning": "Non-empty list of fields or claims being corrected; CLI value is comma-separated.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "correction_content.evidence_or_review_basis": {
+      "meaning": "Evidence or review basis such as source paths, tests, PR, CI, command output, or audit finding.",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    },
+    "target_guardian_application_record_id": {
+      "meaning": "record_id of the original guardian_application final record for the guardian being retired.",
+      "source_of_truth": "matching guardian_application final record record_id",
+      "unclear_action": "BUILDER_USAGE_UNCLEAR"
+    }
+  }
+}

--- a/downloads/record-chain-agent-submit-guide.mjs
+++ b/downloads/record-chain-agent-submit-guide.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const data = JSON.parse(readFileSync(resolve(here, "../api/record-chain-agent-field-guidance.v1.json"), "utf-8"));
+
+function usage() {
+  console.log("Usage:");
+  console.log("  node downloads/record-chain-agent-submit-guide.mjs list");
+  console.log("  node downloads/record-chain-agent-submit-guide.mjs record-type correction");
+  console.log("  node downloads/record-chain-agent-submit-guide.mjs field correction_content.target_record_sha256");
+  console.log("");
+  console.log("If a target id or target record_sha256 is unclear, stop with BUILDER_USAGE_UNCLEAR.");
+}
+
+function knownRecordTypes() {
+  return Object.keys(data.record_types || {}).sort();
+}
+
+function knownFields() {
+  return Object.keys(data.fields || {}).sort();
+}
+
+function showList() {
+  console.log("Record types:");
+  for (const key of knownRecordTypes()) {
+    console.log("  " + key + " — " + data.record_types[key].purpose);
+  }
+  console.log("\nFields:");
+  for (const key of knownFields()) console.log("  " + key);
+}
+
+function showRecordType(name) {
+  const key = String(name || "").replace(/-/g, "_");
+  const item = data.record_types?.[key];
+  if (!item) {
+    console.error("Unknown record type: " + name);
+    console.error("Known record types: " + knownRecordTypes().join(", "));
+    process.exitCode = 1;
+    return;
+  }
+  console.log(key);
+  console.log("Purpose: " + item.purpose);
+  if (item.builder_command) console.log("Builder command: " + item.builder_command);
+  if (Array.isArray(item.required_cli_options)) {
+    console.log("\nRequired CLI options:");
+    for (const opt of item.required_cli_options) console.log("  " + opt);
+  }
+  if (Array.isArray(item.before_build)) {
+    console.log("\nBefore build:");
+    for (const step of item.before_build) console.log("  - " + step);
+  }
+  if (item.example_cli_fragment) {
+    console.log("\nExample CLI fragment:");
+    console.log("  " + item.example_cli_fragment);
+  }
+}
+
+function showField(name) {
+  const item = data.fields?.[name];
+  if (!item) {
+    console.error("Unknown field: " + name);
+    console.error("Run list to see known fields.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log(name);
+  console.log("Meaning: " + item.meaning);
+  if (item.how_to_fill) console.log("How to fill: " + item.how_to_fill);
+  if (item.source_of_truth) console.log("Source of truth: " + item.source_of_truth);
+  if (Array.isArray(item.never_use)) console.log("Never use: " + item.never_use.join(", ") + ".");
+  if (item.example) console.log("Example: " + JSON.stringify(item.example));
+  if (item.unclear_action) console.log("If unclear: stop with " + item.unclear_action + ".");
+}
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+const value = args[1];
+
+if (!cmd || cmd === "help" || cmd === "--help" || cmd === "-h") usage();
+else if (cmd === "list") showList();
+else if (cmd === "record-type") showRecordType(value);
+else if (cmd === "field") showField(value);
+else {
+  console.error("Unknown command: " + cmd);
+  usage();
+  process.exitCode = 1;
+}

--- a/scripts/test_agent_submit_guidance.py
+++ b/scripts/test_agent_submit_guidance.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Smoke tests for agent submit field guidance."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDANCE = ROOT / "api" / "record-chain-agent-field-guidance.v1.json"
+CLI = ROOT / "downloads" / "record-chain-agent-submit-guide.mjs"
+
+
+def run_cli(*args: str) -> str:
+    return subprocess.check_output(
+        ["node", str(CLI), *args],
+        cwd=ROOT,
+        text=True,
+    )
+
+
+def main() -> None:
+    data = json.loads(GUIDANCE.read_text(encoding="utf-8"))
+
+    assert data["schema"] == "trinityaccord.record-chain-agent-field-guidance.v1"
+    assert "correction" in data["record_types"]
+    assert "guardian_retirement" in data["record_types"]
+    assert "correction_content.target_record_sha256" in data["fields"]
+    assert "target_guardian_application_record_sha256" in data["fields"]
+
+    target_sha = data["fields"]["correction_content.target_record_sha256"]
+    assert target_sha["source_of_truth"].endswith("record_sha256")
+    assert "content_sha256" in target_sha["never_use"]
+    assert "content_sha256_v2" in target_sha["never_use"]
+    assert target_sha["unclear_action"] == "BUILDER_USAGE_UNCLEAR"
+
+    correction_output = run_cli("record-type", "correction")
+    assert "--target-record-id" in correction_output
+    assert "--target-record-sha256" in correction_output
+    assert "BUILDER_USAGE_UNCLEAR" in correction_output
+
+    field_output = run_cli("field", "correction_content.target_record_sha256")
+    assert "record_sha256" in field_output
+    assert "Never use" in field_output
+    assert "content_sha256" in field_output
+    assert "BUILDER_USAGE_UNCLEAR" in field_output
+
+    guardian_output = run_cli("record-type", "guardian-retirement")
+    assert "--target-guardian-application-record-id" in guardian_output
+    assert "--target-guardian-application-record-sha256" in guardian_output
+
+    print("agent submit guidance contract OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -356,4 +356,9 @@
   <url><loc>https://www.trinityaccord.org/why-high-signal/</loc></url>
   <url><loc>https://www.trinityaccord.org/worth-preserving/</loc></url>
   <url><loc>https://www.trinityaccord.org/zero-clone-builders/</loc></url>
+  <url>
+    <loc>https://www.trinityaccord.org/api/record-chain-agent-field-guidance.v1.json</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Adds a safe, source-controlled agent submit guidance surface without rewriting the large Builder file.

This PR adds:

- `api/record-chain-agent-field-guidance.v1.json` — machine-readable guidance for target-binding and evidence fields.
- `downloads/record-chain-agent-submit-guide.mjs` — small CLI to query record-type and field guidance before building submissions.
- `scripts/test_agent_submit_guidance.py` — smoke test for the guidance contract and CLI output.

## Why

Builder and Gateway already enforce required fields and hash formats, but agents still need explicit source-level guidance for how to choose values such as:

- `correction_content.target_record_sha256`
- `classification_update_content.target_record_sha256`
- `target_guardian_application_record_sha256`
- `correction_reason`
- `corrected_fields_or_claims`
- `evidence_or_review_basis`

The guidance makes the key invariant explicit: target hashes must come from the target final record's `record_sha256`; agents must not use `content_sha256`, `content_sha256_v2`, `receipt_sha256`, archive hashes, or the new record's hash.

## Safety

- Does not modify `downloads/record-chain-builder.mjs`.
- Does not modify Gateway validation semantics.
- Does not weaken final-chain verification.
- Does not alter existing records or generated indexes.
- Provides a low-risk bridge that can later be wired into Builder's existing `explain-fields`, `template`, `doctor`, and `error-help` surfaces.

## Validation to run

```bash
python3 scripts/test_agent_submit_guidance.py
node downloads/record-chain-agent-submit-guide.mjs list
node downloads/record-chain-agent-submit-guide.mjs record-type correction
node downloads/record-chain-agent-submit-guide.mjs field correction_content.target_record_sha256
python3 scripts/trinity_record_chain.py verify
python3 scripts/run_current_system_tests.py
```

## Note

This branch was created before the latest main commits and may need an update/rebase before merge.