### PR TITLE
feat(builder): advertise agent field guidance in builder manifest

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -29,6 +29,19 @@
     ],
     "url": "/downloads/record-chain-builder.mjs"
   },
+  "agent_field_guidance": {
+    "schema": "trinityaccord.record-chain-agent-field-guidance.v1",
+    "status": "active",
+    "url": "/downloads/record-chain-agent-field-guidance.v1.json",
+    "github_raw_url": "https://raw.githubusercontent.com/thechurchofagi/trinity-accord/main/downloads/record-chain-agent-field-guidance.v1.json",
+    "read_before_record_types": [
+      "correction",
+      "classification_update",
+      "guardian_retirement"
+    ],
+    "purpose": "Machine-readable field semantics for target-binding records. Agents should read this file before building correction, classification_update, or guardian_retirement submissions.",
+    "critical_rule": "For target_record_sha256-style fields, use the target final record's record_sha256. Do not use content_sha256, content_sha256_v2, receipt_sha256, archive hashes, public-key hashes, or the new record hash. If the target final record is unclear, stop and return BUILDER_USAGE_UNCLEAR."
+  },
   "download_methods": [
     {
       "name": "canonical_public_site_manifest_verified",


### PR DESCRIPTION
## Summary

Advertises the newly merged agent field guidance file from the canonical Builder bundle manifest.

This makes the guidance discoverable during the normal Builder acquisition flow:

- Builder manifest: `/api/record-chain-builder-bundles.v1.json`
- Guidance file: `/downloads/record-chain-agent-field-guidance.v1.json`

## Why

#514 added the guidance file, but agents that only fetch the Builder through the canonical manifest would not necessarily know the guidance file exists. This PR closes that discovery gap by adding an `agent_field_guidance` block to the Builder manifest.

## Behavior

The manifest now tells agents to read the guidance before building:

- `correction`
- `classification_update`
- `guardian_retirement`

It also states the critical target hash rule: target hash fields must come from the target final record's `record_sha256`, not `content_sha256`, `content_sha256_v2`, `receipt_sha256`, archive hashes, public-key hashes, or the new record hash.

## Safety

- Does not modify `downloads/record-chain-builder.mjs`.
- Does not change Builder hash or size.
- Does not change Gateway validation.
- Modifies an existing API manifest only, so sitemap URL set should not drift.

## Validation to run

```bash
python3 scripts/trinity_record_chain.py verify
python3 scripts/run_current_system_tests.py
```
