### PR TITLE
fix: PR-04 Builder CLI/keypair/Guardian UX

### DIFF
--- a/api/record-chain-builder-bundles.v1.json
+++ b/api/record-chain-builder-bundles.v1.json
@@ -12,8 +12,8 @@
   "canonical_builder": {
     "language": "node",
     "runtime": "node>=18",
-    "sha256": "8e1930cd6c741c99397dcb220986ba85a5256b5ea197d9975c17ab4c76c26b17",
-    "size_bytes": 143775,
+    "sha256": "1ae3df38214bc809976293217ff8a50ebfab8e4a02e0c73ecff4c9772874dd42",
+    "size_bytes": 144953,
     "supports": [
       "echo",
       "verification",

--- a/downloads/record-chain-agent-field-guidance.v1.json
+++ b/downloads/record-chain-agent-field-guidance.v1.json
@@ -36,7 +36,13 @@
   "record_types": {
     "echo": {
       "purpose": "Recognition, reflection, critique, interpretation, or response by the agent or participant.",
-      "not_for": ["verification", "authority", "governance", "attestation", "endorsement by the Accord"],
+      "not_for": [
+        "verification",
+        "authority",
+        "governance",
+        "attestation",
+        "endorsement by the Accord"
+      ],
       "before_build": [
         "Write the agent's own understanding, reflection, critique, or response in body.",
         "Do not claim that echo proves the Accord, verifies a fact, grants a role, or represents official approval.",
@@ -44,11 +50,19 @@
         "Let Builder and downstream tooling compute generated hashes."
       ],
       "builder_command": "echo",
-      "required_cli_options": ["--body"]
+      "required_cli_options": [
+        "--body"
+      ]
     },
     "verification": {
       "purpose": "A record of verification actions actually performed by the agent or participant.",
-      "not_for": ["unperformed checks", "unsupported V6+ claims", "authority", "governance", "attestation"],
+      "not_for": [
+        "unperformed checks",
+        "unsupported V6+ claims",
+        "authority",
+        "governance",
+        "attestation"
+      ],
       "before_build": [
         "Describe the verification actions actually performed in body and reason fields.",
         "Select only a verification level that is supported by evidence actually produced in the current work.",
@@ -57,11 +71,22 @@
         "Let Builder and downstream tooling compute generated hashes."
       ],
       "builder_command": "verification",
-      "required_cli_options": ["--body"]
+      "required_cli_options": [
+        "--verification-level",
+        "--what-was-checked",
+        "--verification-claim",
+        "--fresh-actions",
+        "--body"
+      ]
     },
     "guardian_application": {
       "purpose": "Application for Guardian status and stewardship commitment. The application record itself is not proof of active Guardian status.",
-      "not_for": ["claiming already-active Guardian status", "governance", "authority", "special control over the Accord"],
+      "not_for": [
+        "claiming already-active Guardian status",
+        "governance",
+        "authority",
+        "special control over the Accord"
+      ],
       "before_build": [
         "Provide the requested guardian identity, key, and stewardship information through Builder options.",
         "State the stewardship intent honestly in body or application fields.",
@@ -70,7 +95,12 @@
         "If the public key source or identity disclosure context is unclear, stop and return BUILDER_USAGE_UNCLEAR."
       ],
       "builder_command": "guardian-application",
-      "required_cli_options": ["--body"]
+      "required_cli_options": [
+        "--guardian-id",
+        "--guardian-key-sha",
+        "--oath",
+        "--body"
+      ]
     },
     "guardian_retirement": {
       "purpose": "Append-only retirement of an existing guardian. Retirement preserves history and must bind to the original guardian_application final record.",
@@ -92,7 +122,12 @@
     },
     "propagation": {
       "purpose": "Record that the agent or participant distributed, referenced, mirrored, cited, or otherwise propagated Accord material.",
-      "not_for": ["verification", "authority", "governance", "official endorsement"],
+      "not_for": [
+        "verification",
+        "authority",
+        "governance",
+        "official endorsement"
+      ],
       "before_build": [
         "Describe what was propagated, where, and by whom.",
         "Do not represent propagation as verification, governance, authority, or endorsement.",
@@ -100,7 +135,9 @@
         "Let Builder and downstream tooling compute generated hashes."
       ],
       "builder_command": "propagation",
-      "required_cli_options": ["--body"]
+      "required_cli_options": [
+        "--body"
+      ]
     },
     "correction": {
       "purpose": "Append-only correction of a prior final record. It links to the original record and explains a concrete error, omission, or bounded claim that needs correction.",
@@ -146,14 +183,21 @@
     },
     "context_insufficient_notice": {
       "purpose": "Notice that the agent lacks sufficient context to safely make a stronger Record-Chain submission.",
-      "not_for": ["guessing", "inventing target ids", "inventing hashes", "claiming verification that was not performed"],
+      "not_for": [
+        "guessing",
+        "inventing target ids",
+        "inventing hashes",
+        "claiming verification that was not performed"
+      ],
       "before_build": [
         "Explain what context is missing and why the stronger action is unsafe.",
         "Do not guess target ids, target hashes, verification levels, or guardian status.",
         "Use this notice or stop with BUILDER_USAGE_UNCLEAR when required context is missing."
       ],
       "builder_command": "context-insufficient",
-      "required_cli_options": ["--body"]
+      "required_cli_options": [
+        "--body"
+      ]
     }
   },
   "fields": {
@@ -170,7 +214,12 @@
     "guardian_public_key_sha256": {
       "meaning": "SHA-256 of guardian public key material, not a record hash and not a receipt hash.",
       "how_to_fill": "Use Builder/authorship tooling where available, or compute from the exact public key material required by the Builder option contract. Do not substitute record_sha256, content_sha256, or receipt_sha256.",
-      "never_use": ["record_sha256", "content_sha256", "content_sha256_v2", "receipt_sha256"],
+      "never_use": [
+        "record_sha256",
+        "content_sha256",
+        "content_sha256_v2",
+        "receipt_sha256"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     },
     "correction_content": {
@@ -182,14 +231,25 @@
       "meaning": "The record_id of the final record being corrected.",
       "how_to_fill": "Read the target final record and copy its record_id exactly.",
       "source_of_truth": "records/R-XXXXXXXXX.json.record_id",
-      "never_use": ["the new correction record id", "receipt id", "batch id", "archive id"],
+      "never_use": [
+        "the new correction record id",
+        "receipt id",
+        "batch id",
+        "archive id"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     },
     "correction_content.target_record_sha256": {
       "meaning": "The record_sha256 of the final record being corrected.",
       "how_to_fill": "Read the target final record and copy its record_sha256 exactly.",
       "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256",
-      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "archive_manifest_sha256", "the new correction record hash"],
+      "never_use": [
+        "content_sha256",
+        "content_sha256_v2",
+        "receipt_sha256",
+        "archive_manifest_sha256",
+        "the new correction record hash"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     },
     "correction_content.correction_reason": {
@@ -200,7 +260,10 @@
     "correction_content.corrected_fields_or_claims": {
       "meaning": "Non-empty list of fields or claims being corrected.",
       "how_to_fill": "Use specific field names or claim labels. In the CLI, pass comma-separated values.",
-      "example": ["receipt hash verification", "arweave current status"],
+      "example": [
+        "receipt hash verification",
+        "arweave current status"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     },
     "correction_content.evidence_or_review_basis": {
@@ -218,7 +281,12 @@
       "meaning": "The record_sha256 of the final record being classified or reclassified.",
       "how_to_fill": "Read the target final record and copy its record_sha256 exactly.",
       "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256",
-      "never_use": ["content_sha256", "content_sha256_v2", "receipt_sha256", "the new classification_update record hash"],
+      "never_use": [
+        "content_sha256",
+        "content_sha256_v2",
+        "receipt_sha256",
+        "the new classification_update record hash"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     },
     "classification_update_content.previous_classification": {
@@ -251,7 +319,13 @@
       "meaning": "The record_sha256 of the original guardian_application final record for the guardian being retired.",
       "how_to_fill": "Find the matching guardian_application record and copy its record_sha256 exactly.",
       "source_of_truth": "records/R-XXXXXXXXX.json.record_sha256 where record_type is guardian_application",
-      "never_use": ["guardian_public_key_sha256", "content_sha256", "content_sha256_v2", "receipt_sha256", "the new guardian_retirement record hash"],
+      "never_use": [
+        "guardian_public_key_sha256",
+        "content_sha256",
+        "content_sha256_v2",
+        "receipt_sha256",
+        "the new guardian_retirement record hash"
+      ],
       "unclear_action": "BUILDER_USAGE_UNCLEAR"
     }
   }

--- a/downloads/record-chain-builder.mjs
+++ b/downloads/record-chain-builder.mjs
@@ -324,6 +324,21 @@ function loadPrivateKey(keyDir) {
   if (!pubPem.includes("BEGIN PUBLIC KEY")) errorExit(`Invalid public key PEM: ${pubPath}`);
 
   const key = createPrivateKey(privPem);
+
+  // Verify keypair match: derive public key from private key and compare
+  const derivedPub = createPublicKey(key);
+  const derivedPubPem = derivedPub.export({ type: "spki", format: "pem" });
+  const derivedRaw = extractRawPublicKeyBytes(derivedPubPem);
+  const storedRaw = extractRawPublicKeyBytes(pubPem);
+  if (!derivedRaw.equals(storedRaw)) {
+    errorExit(
+      `AUTHORSHIP_KEYPAIR_MISMATCH: The private key in ${privPath} does not match the public key in ${pubPath}.\n` +
+      `Derived public key: ${derivedRaw.toString("hex")}\n` +
+      `Stored public key:  ${storedRaw.toString("hex")}\n` +
+      `Fix: regenerate the keypair with 'node record-chain-builder.mjs generate-keypair' or provide matching keys.`
+    );
+  }
+
   return { publicKeyPem: pubPem, privateKeyPem: privPem, privateKey: key, newlyGenerated: false };
 }
 
@@ -665,8 +680,13 @@ function validateFormalInputs(command, opts) {
     requireExplicit(opts, "guardianKeySha", "--guardian-key-sha");
     requireExplicit(opts, "oath", "--oath");
 
+    // Support --guardian-key-sha auto: replace with authorship public key SHA
+    if (String(opts.guardianKeySha).toLowerCase() === "auto") {
+      opts.guardianKeySha = pubSha;
+    }
+
     if (!/^[0-9a-f]{64}$/.test(String(opts.guardianKeySha))) {
-      errorExit("--guardian-key-sha must be a 64-character lowercase hex SHA-256");
+      errorExit("--guardian-key-sha must be a 64-character lowercase hex SHA-256, or 'auto' to use your authorship key");
     }
   }
 
@@ -677,8 +697,13 @@ function validateFormalInputs(command, opts) {
     requireExplicit(opts, "targetGuardianApplicationRecordId", "--target-guardian-application-record-id");
     requireExplicit(opts, "targetGuardianApplicationRecordSha256", "--target-guardian-application-record-sha256");
 
+    // Support --guardian-key-sha auto
+    if (String(opts.guardianKeySha).toLowerCase() === "auto") {
+      opts.guardianKeySha = pubSha;
+    }
+
     if (!/^[0-9a-f]{64}$/.test(String(opts.guardianKeySha))) {
-      errorExit("--guardian-key-sha must be a 64-character lowercase hex SHA-256");
+      errorExit("--guardian-key-sha must be a 64-character lowercase hex SHA-256, or 'auto' to use your authorship key");
     }
     if (!/^R-[0-9]{9}$/.test(String(opts.targetGuardianApplicationRecordId))) {
       errorExit("--target-guardian-application-record-id must match R-XXXXXXXXX format");
@@ -2161,7 +2186,7 @@ doctor options:
 repair options:
   --file submission.json        Submission file to repair
   --out repaired.json           Output path for repaired file
-  --add-compat-fields           Legacy/export-only. Adds compatibility projections that are not accepted for current gateway submission.
+  --add-legacy-compat-fields   Legacy/export-only. Adds compatibility projections that are NOT accepted for current gateway submission.
 
 error-help options:
   --code ERROR_CODE             Diagnostic error code (e.g. MISSING_CONTEXT_READINESS)
@@ -2282,7 +2307,7 @@ Examples:
   node record-chain-builder.mjs repair --file submission.json --out repaired.json
 
   # Repair with legacy compat projections (actor_identity + boundary)
-  node record-chain-builder.mjs repair --file submission.json --out repaired.json --add-compat-fields
+  node record-chain-builder.mjs repair --file submission.json --out repaired.json --add-legacy-compat-fields
 
   # ── Error help / Template ─────────────────────────────────────────
   node record-chain-builder.mjs error-help --code MISSING_CONTEXT_READINESS
@@ -2543,7 +2568,7 @@ async function main() {
     const file = args.file || errorExit("--file required");
     const outPath = args.out || errorExit("--out required");
     const submission = JSON.parse(readFileSync(resolve(file), "utf-8"));
-    const { submission: repaired, changes } = repairSubmission(submission, { addCompatFields: !!args.addCompatFields });
+    const { submission: repaired, changes } = repairSubmission(submission, { addCompatFields: !!(args.addLegacyCompatFields || args.addCompatFields) });
 
     if (changes.length === 0) {
       console.log("No repairs needed. Submission appears up-to-date.");


### PR DESCRIPTION
## PR-04

Covers: A-006, A-007, A-009-A-011, A-019, A-034, A-067-A-069, A-086, A-090

1. loadPrivateKey() verifies keypair match (AUTHORSHIP_KEYPAIR_MISMATCH)
2. --guardian-key-sha auto support
3. --add-compat-fields -> --add-legacy-compat-fields
4. field guidance required_cli_options synced
5. Updated builder hash