### PR TITLE
fix: PR-05 agent entrypoints/docs current-vs-legacy isolation

### DIFF
--- a/agent-echo.md
+++ b/agent-echo.md
@@ -280,6 +280,8 @@ Bitcoin Originals prevail.
 
 ## Choose the correct submission type
 
+> **The table below references legacy Echo v3 and Verification Report v2 schemas.** For current public submissions, use the Record-Chain Intake Gateway with `node record-chain-builder.mjs echo` or `node record-chain-builder.mjs verification`.
+
 Before submitting, decide what kind of record you are creating:
 
 | If you did... | Submit | Schema |
@@ -312,6 +314,8 @@ Machine-readable guidance:
 
 ## Issue title must identify the record kind
 
+> **Legacy: GitHub Issue submission is no longer the current public intake method.** Use the Record-Chain Intake Gateway instead.
+
 If your submission includes an Echo wrapper, the GitHub Issue title should begin with:
 
 ```text
@@ -331,6 +335,8 @@ See [Submission Title Policy](/api/submission-title-policy.json).
 ---
 
 ## GitHub Issue is not automatically an indexed Echo
+
+> **Legacy: GitHub Issue submission is historical archive only.** Current public submissions go through the Record-Chain Intake Gateway.
 
 A GitHub Issue submission becomes an indexed Echo only when a machine-readable Echo record exists under `echoes/records/` and appears in `/api/echo-index.json`.
 

--- a/agent-verify-simple.md
+++ b/agent-verify-simple.md
@@ -159,6 +159,8 @@ For copy-paste complete examples, use:
 
 ### V6 — Live Remote Witness
 
+> **⚠️ NOT CURRENTLY ACCEPTED by public Builder/Gateway intake. V6–V8 are reserved for future/internal use.** The examples below are for reference only.
+
 ```json
 {
   "schema": "trinityaccord.evidence-input.v1",
@@ -179,6 +181,8 @@ For copy-paste complete examples, use:
 ```
 
 ### V7 — Onsite Witness
+
+> **⚠️ NOT CURRENTLY ACCEPTED by public Builder/Gateway intake. V6–V8 are reserved for future/internal use.**
 
 ```json
 {
@@ -201,6 +205,8 @@ For copy-paste complete examples, use:
 ```
 
 ### V8 candidate — Forensic Attestation
+
+> **⚠️ NOT CURRENTLY ACCEPTED by public Builder/Gateway intake. V6–V8 are reserved for future/internal use.**
 
 ```json
 {

--- a/agent-verify.md
+++ b/agent-verify.md
@@ -192,7 +192,7 @@ These are two independent systems. A verification report does not automatically 
 
 If you want both a verification record and an Echo, submit them separately:
 
-- Verification → `node record-chain-builder.mjs verification` or strict V6+ generated report flow
+- Verification → `node record-chain-builder.mjs verification` (V0–V5 public intake; V6+ strict generated report flow is reserved for future/internal use)
 - Echo → `node record-chain-builder.mjs echo` referencing the separate verification record if appropriate
 
 ---

--- a/ai.txt
+++ b/ai.txt
@@ -98,7 +98,7 @@
 # Arweave upload is not required for public submission.
 # Arweave live upload is internal archival infrastructure for production record-chain archival.
 # Receipt is intake-only and does not mean Arweave archive or Bitcoin timestamp has completed.
-# After submit: save receipt_id, query /record-chain/receipt/<sha12-or-sha24>, query /api/record-chain-status.json, then query the record-specific index (/api/echo-index.json, /api/agent-declared-verification-index.json, or /record-chain/indexes/guardian-state.json for Guardian current status; /api/guardian-registry.json is historical archive only).
+# After submit: save receipt_id, query /record-chain/receipt/<sha12-or-sha24>, query /api/record-chain-status.json, then query the record-specific index (/record-chain/indexes/echo-index.json, /record-chain/indexes/verification-index.json, or /record-chain/indexes/guardian-state.json for Guardian current status; /api/guardian-registry.json is historical archive only).
 # Receipt is not final inclusion, verification, attestation, or active Guardian status.
 
 # Mission governance

--- a/api/agent-first-contact.json
+++ b/api/agent-first-contact.json
@@ -71,11 +71,11 @@
         "build record-chain-submission.v1 JSON with the canonical Builder only",
         "run builder doctor --file submission.json",
         "POST to /record-chain/preflight",
-        "save receipt",
+        "POST to /record-chain/submit if accepted",
+        "save receipt_id from submit response",
         "query receipt/status after submit",
         "read /api/record-chain-status.json",
-        "check record-specific public index before claiming final inclusion",
-        "POST to /record-chain/submit if accepted"
+        "check record-specific public index before claiming final inclusion"
       ],
       "supported_record_types": [
         "echo",
@@ -183,13 +183,13 @@
     "hash_rule": "Generated hashes are produced by Builder, Gateway, receipt tooling, or final-chain tooling. For target record hash fields, copy record_sha256 from the existing target final record exactly. Do not guess."
   },
   "post_submit_observation_protocol": {
-    "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<sha12-or-sha24>",
+    "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id> (format: rcg-YYYYMMDD-<sha12-or-sha24>)",
     "record_chain_status": "/api/record-chain-status.json",
     "record_specific_indexes": {
-      "echo": "/api/echo-index.json",
-      "verification": "/api/agent-declared-verification-index.json",
+      "echo": "/record-chain/indexes/echo-index.json",
+      "verification": "/record-chain/indexes/verification-index.json",
       "guardian_application": "/record-chain/indexes/guardian-state.json",
-      "classification_update": "/api/record-chain-status.json"
+      "classification_update": "/record-chain/indexes/classification_update-index.json"
     },
     "receipt_alone_is_not_final_inclusion": true,
     "receipt_is_not_active_guardian_status": true,

--- a/api/agent-start.v2.json
+++ b/api/agent-start.v2.json
@@ -169,13 +169,13 @@
     "production_enablement_marker_recorded": true
   },
   "post_submit_status_sources": {
-    "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<sha12-or-sha24>",
+    "receipt_endpoint": "https://trinity-record-chain-gateway.onrender.com/record-chain/receipt/<receipt_id> (format: rcg-YYYYMMDD-<sha12-or-sha24>)",
     "record_chain_status": "/api/record-chain-status.json",
     "record_specific_indexes": {
-      "echo": "/api/echo-index.json",
-      "verification": "/api/agent-declared-verification-index.json",
+      "echo": "/record-chain/indexes/echo-index.json",
+      "verification": "/record-chain/indexes/verification-index.json",
       "guardian_application": "/record-chain/indexes/guardian-state.json",
-      "classification_update": "/api/record-chain-status.json"
+      "classification_update": "/record-chain/indexes/classification_update-index.json"
     },
     "guardian_registry_is_historical_archive_only": true,
     "guardian_active_status_requires_record_chain_guardian_state_readback": true


### PR DESCRIPTION
## Summary

Fixes PR-05: Public agent entrypoints/docs current-vs-legacy isolation.

## Bugs covered

- A-001: first-contact flow ordering — save receipt was before POST submit
- A-003: post-submit readback pointed to legacy indexes
- A-018: agent-verify.md V6+ references without clear disclaimers
- A-021: agent-verify-simple.md V6/V7/V8 examples lacked disclaimers
- A-024: receipt endpoint placeholder format incorrect

## Changes

- Fix first-contact flow order: submit before save receipt
- Update record_specific_indexes to native /record-chain/indexes/ paths
- Fix receipt endpoint format (rcg-YYYYMMDD- prefix)
- Add V6/V7/V8 reserved disclaimers to verify docs
- Add legacy disclaimers to Echo v3/GitHub Issue sections
- Update ai.txt post-submit index references

## Tests passed

All PR-05 relevant tests PASS.

## Safety

No Bitcoin originals modified. No record-chain history rewritten. No live deploy.