### PR TITLE
fix: PR-08 OTS/Arweave pipeline semantics

### DIFF
--- a/scripts/build_record_chain_arweave_archive.py
+++ b/scripts/build_record_chain_arweave_archive.py
@@ -416,6 +416,8 @@ def build_archive_manifest(mode: str) -> None:
                 "canonicalization": "json.sort_keys.no_whitespace.utf8.allow_nan_false.v1",
             }
             # Recompute archive_manifest_sha256 after payload binding
+            # Must clear before computing to match verifier's None-reset approach
+            manifest["archive_manifest_sha256"] = None
             manifest["archive_manifest_sha256"] = sha256_canonical_json(manifest)
             try:
                 upload_result = upload_to_arweave(payload_path, archive_dir)
@@ -468,6 +470,7 @@ def build_archive_manifest(mode: str) -> None:
                 upload_failed = status != "archived"
         manifest["mode"] = "live"
 
+    manifest["archive_manifest_sha256"] = None
     manifest["archive_manifest_sha256"] = sha256_canonical_json(manifest)
     write_json(archive_dir / "manifest.json", manifest)
     update_arweave_index()

--- a/scripts/detect_record_chain_pipeline_backlog.py
+++ b/scripts/detect_record_chain_pipeline_backlog.py
@@ -72,6 +72,8 @@ def main() -> int:
         and ots_sha == chain_sha
         and ots_count == chain_count
         and ots.get("legacy_main_chain_jsonl_is_not_source") is True
+        and ots.get("ots_status") in ("upgraded", "verified")
+        and ots.get("bitcoin_verified") is True
     )
 
     arweave_matches_ots = (


### PR DESCRIPTION
## Summary

Fixes PR-08: OTS/Arweave live pipeline semantics.

## Bugs covered

- A-073: Arweave manifest hash includes stale hash value
- A-076: OTS backlog detector ignores ots_status/bitcoin_verified

## Changes

- Fix backlog detector: require ots_status=upgraded AND bitcoin_verified=true for ots_matches_chain
- Fix Arweave manifest hash: reset archive_manifest_sha256 to None before computing

## Tests

All PASS.

## Safety

No Bitcoin originals modified. No record-chain history rewritten. No live deploy.