### PR TITLE
fix: PR-09 legacy isolation / prelaunch taxonomy cleanup

### DIFF
--- a/api/gateway-rate-limit-policy.v1.json
+++ b/api/gateway-rate-limit-policy.v1.json
@@ -1,7 +1,10 @@
 {
   "schema": "trinityaccord.gateway-rate-limit-policy.v1",
-  "status": "prelaunch_policy",
-  "purpose": "Simple trust-first rate limit for early external agent submissions.",
+  "status": "production_live_policy",
+  "purpose": "Trust-first rate limit for public Record-Chain Intake Gateway. Single-process in-memory; not durable across restarts; not multi-instance safe.",
+  "limiter_class": "single_process_in_memory",
+  "durable_across_restart": false,
+  "multi_instance_safe": false,
   "policy": {
     "global_submit_limit_per_hour": 100,
     "participant_submit_limit_per_hour": 10,

--- a/scripts/run_current_system_tests.py
+++ b/scripts/run_current_system_tests.py
@@ -271,7 +271,7 @@ def main() -> int:
     ok("gateway v1 historical status API")
 
     # 4. Homepage points to record-chain
-    require_text("index.md", ["record-chain", "trinity_record_builder.py", "trinity_record_chain.py"])
+    require_text("index.md", ["record-chain", "downloads/record-chain-builder.mjs", "trinity_record_chain.py"])
 
     # 5. Agent entry pages point to record-chain
     for candidate in ["agent-first-contact.md", "agent-first-contact/index.md"]:


### PR DESCRIPTION
## Summary

Fixes PR-09: Legacy isolation / prelaunch taxonomy cleanup.

## Bugs covered

- A-020: Rate-limit policy still says prelaunch_policy
- A-049: Test taxonomy preserves outdated mental models
- A-060: Test requires old trinity_record_builder.py name

## Changes

- Update rate-limit policy: prelaunch_policy -> production_live_policy
- Add limiter_class, durable_across_restart, multi_instance_safe
- Replace old trinity_record_builder.py test reference

## Tests

All PASS.

## Safety

No Bitcoin originals modified. No live deploy.