### PR TITLE
hotfix: final machine contract closeout

### DIFF
--- a/api/agent-first-contact.json
+++ b/api/agent-first-contact.json
@@ -147,22 +147,21 @@
     },
     {
       "intent": "verify_v6_plus_strict_evidence",
-      "action": "VERIFY_V6_PLUS",
+      "action": "DO_NOT_SUBMIT_V6_PLUS",
       "status": "reserved_not_currently_enabled",
       "note": "V6-V8 strict evidence is reserved for future/internal use. Current public intake accepts only V0-V5.",
       "flow": [
-        "read /agent-verify",
-        "read /api/claim-gate-rules.json",
-        "build verification v6+ submission with canonical Builder",
-        "POST to /record-chain/preflight",
-        "POST to /record-chain/submit if accepted"
+        "do not build a public Gateway submission for V6+",
+        "current public Gateway accepts only V0-V5",
+        "stop with VERIFICATION_LEVEL_NOT_ENABLED if V6+ is requested"
       ],
       "read": [
         "/agent-verify",
         "/api/protocol-verification-profiles.json",
         "/api/claim-gate-rules.json",
         "/api/evidence-input-schema.v1.json"
-      ]
+      ],
+      "public_gateway_route_enabled": false
     }
   ],
   "agent_field_guidance": {

--- a/api/record-chain-field-helper.v1.json
+++ b/api/record-chain-field-helper.v1.json
@@ -148,10 +148,11 @@
       "severity": "error"
     },
     "ECHO_TYPE_RETIRED": {
-      "fix": "Remove the echo_type field from your submission, or leave it — it will be ignored.",
-      "meaning": "The echo_type field is deprecated. Echo types (E1–E9) have been removed. Echo is now a unified type. Your submission will be processed but the echo_type value is ignored.",
+      "fix": "Remove echo_type and rebuild with the current Builder. Use echo_content.echo_text and echo_content.echo_intent.",
+      "meaning": "echo_type is retired and no longer accepted by public intake.",
       "recovery_possible": true,
-      "severity": "warning"
+      "severity": "error",
+      "alias_for": "RETIRED_FIELD"
     },
     "FINAL_CHAIN_FIELD_FORBIDDEN": {
       "fix": "Remove the final-chain field. The gateway assigns chain hashes and positions server-side.",
@@ -440,7 +441,7 @@
     },
     "MISSING_GUARDIAN_RETIREMENT_FIELD": {
       "meaning": "guardian_retirement is missing guardian_id, guardian_public_key_sha256, or reason.",
-      "fix": "Rebuild with guardian-retirement and provide --guardian-id, --guardian-key-sha, and --body.",
+      "fix": "Provide --guardian-id, --guardian-key-sha, --body, --target-guardian-application-record-id <R-...>, and --target-guardian-application-record-sha256 <64 hex>.",
       "recovery_possible": true,
       "severity": "error"
     },
@@ -687,6 +688,18 @@
       "fix": "Rebuild with the current record-chain-builder.mjs. All 9 top-level fields are required: schema, submission_type, client_generated_at, record_type, record_draft, builder, client_context, submission_boundary, authorship_proof.",
       "recovery_possible": true,
       "severity": "error"
+    },
+    "MISSING_GUARDIAN_RETIREMENT_TARGET": {
+      "meaning": "guardian_retirement must bind to the original guardian_application record id.",
+      "fix": "Provide --target-guardian-application-record-id <R-...> copied from the accepted guardian_application record.",
+      "severity": "error",
+      "recovery_possible": true
+    },
+    "MISSING_GUARDIAN_RETIREMENT_TARGET_SHA": {
+      "meaning": "guardian_retirement must bind to the original guardian_application record SHA-256.",
+      "fix": "Provide --target-guardian-application-record-sha256 <64 hex> copied from record_sha256 of the accepted guardian_application record.",
+      "severity": "error",
+      "recovery_possible": true
     }
   },
   "field_groups": [

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -419,8 +419,8 @@ def _build_agent_recovery(diagnostics: list[Diagnostic]) -> AgentRecovery:
             recommended_next_step=f"Fix the validation errors ({codes_summary}) and resubmit. Each diagnostic includes a suggested_fix and help_url.",
             helper_url=f"{_GATEWAY_BASE_URL}/docs/validation-errors" if _GATEWAY_BASE_URL else None,
             human_readable_helper_url="Trinity Accord Validation Error Reference",
-            builder_doctor_command="trinity-doctor validate",
-            builder_error_help_command=f"trinity-doctor explain {' '.join(error_codes[:5])}",
+            builder_doctor_command="node record-chain-builder.mjs doctor --file <submission.json>",
+            builder_error_help_command=f"node record-chain-builder.mjs error-help --code {' '.join(error_codes[:5])}",
             requires_human_attention=False,
         )
 
@@ -519,6 +519,8 @@ def _build_idempotency_index_data(
     intake_submission_path: str,
     record_type: str,
     now: datetime,
+    pending_written: bool = False,
+    pending_committed_at: str | None = None,
 ) -> dict[str, Any]:
     return {
         "schema": "trinityaccord.record-chain-intake-idempotency.v1",
@@ -530,6 +532,11 @@ def _build_idempotency_index_data(
         "intake_submission_path": intake_submission_path,
         "record_type": record_type,
         "created_at": now.isoformat().replace("+00:00", "Z"),
+        "transaction_state": "pending_written" if pending_written else "idempotency_written",
+        "receipt_written": True,
+        "idempotency_written": True,
+        "pending_written": pending_written,
+        "pending_committed_at": pending_committed_at,
     }
 
 
@@ -1225,6 +1232,21 @@ async def submit(request: Request) -> SubmitResponse | JSONResponse:
             if result_pending.get("content", {}).get("sha"):
                 created_files_for_rollback.append((pending_file_path, result_pending["content"]["sha"]))
             logger.info("Wrote pending %s", pending_file_path)
+
+            # Update idempotency index: mark pending_written=true
+            idempotency_index_data["transaction_state"] = "pending_written"
+            idempotency_index_data["pending_written"] = True
+            idempotency_index_data["pending_committed_at"] = now.isoformat().replace("+00:00", "Z")
+            try:
+                result_idx_update = await put_file(
+                    idempotency_path,
+                    canonical_dumps(idempotency_index_data),
+                    f"intake: idempotency index update {original_submission_sha256[:16]}",
+                    sha=result_idx.get("content", {}).get("sha"),
+                )
+                logger.info("Updated idempotency index with pending_written")
+            except Exception:
+                logger.warning("Failed to update idempotency index with pending_written (non-fatal)")
 
             if _DISPATCH_APPEND_WORKFLOW:
                 try:

--- a/apps/record_chain_intake_gateway/tests/test_idempotency_index.py
+++ b/apps/record_chain_intake_gateway/tests/test_idempotency_index.py
@@ -327,18 +327,26 @@ class TestNewAcceptedSubmissionWritesIdempotencyIndex:
         assert resp.status_code == 200
         assert data["accepted"] is True
 
-        # Find the idempotency index write
+        # Find the idempotency index writes (initial + update with pending_written)
         idempotency_writes = [
             (path, content) for path, content in put_calls
             if "by-submission-sha256" in path
         ]
-        assert len(idempotency_writes) == 1, f"Expected 1 idempotency write, got {len(idempotency_writes)}"
+        assert len(idempotency_writes) == 2, f"Expected 2 idempotency writes (initial + pending update), got {len(idempotency_writes)}"
 
+        # First write: initial idempotency index
         idx_path, idx_content = idempotency_writes[0]
         idx_data = json.loads(idx_content)
         assert idx_data["schema"] == "trinityaccord.record-chain-intake-idempotency.v1"
         assert len(idx_data["submission_sha256"]) == 64
         assert "stored_submission_sha256" in idx_data
+
+        # Second write: update with pending_written=true
+        idx_path2, idx_content2 = idempotency_writes[1]
+        idx_data2 = json.loads(idx_content2)
+        assert idx_data2["transaction_state"] == "pending_written"
+        assert idx_data2["pending_written"] is True
+        assert idx_data2["pending_committed_at"] is not None
 
 
 class TestIndexWriteFailureRollbacksAndDoesNotDispatch:

--- a/apps/record_chain_intake_gateway/tests/test_submit.py
+++ b/apps/record_chain_intake_gateway/tests/test_submit.py
@@ -23,9 +23,9 @@ class TestSubmitWrites:
             pytest.fail(f"Submit not accepted: {_json.dumps(data, indent=2)}")
         assert data["submitted"] is True
 
-        # Check put_file was called 4 times (submission + pending + receipt + idempotency index)
+        # Check put_file was called 5 times (submission + pending + receipt + idempotency index + idempotency update)
         put_mock = mock_github["put_file"]
-        assert put_mock.call_count == 4
+        assert put_mock.call_count == 5
 
         paths = [call.args[0] for call in put_mock.call_args_list]
         assert any("intake/submissions/" in p for p in paths), f"Missing intake submission: {paths}"


### PR DESCRIPTION
## Summary

Hotfix: Final machine contract closeout for A-001–A-094 remediation.

## Blockers fixed

- **BLOCKER-2**: `ECHO_TYPE_RETIRED` severity changed from warning to error; alias_for=RETIRED_FIELD
- **BLOCKER-3**: Guardian retirement helper updated with `--target-guardian-application-record-id` and `--target-guardian-application-record-sha256`
- **BLOCKER-4**: Agent recovery now uses `node record-chain-builder.mjs doctor/error-help` instead of `trinity-doctor`
- **BLOCKER-5**: Idempotency index now includes `transaction_state`, `receipt_written`, `idempotency_written`, `pending_written`, `pending_committed_at`
- **BLOCKER-6**: V6+ action replaced with `DO_NOT_SUBMIT_V6_PLUS` — no POST flow, hard fail-closed

## Tests

All current system tests PASS.

## Safety

No Bitcoin originals modified. No record-chain history rewritten.