### PR TITLE
hotfix: close final machine contract and idempotency materialization gates

### DIFF
--- a/api/record-chain-field-helper.v1.json
+++ b/api/record-chain-field-helper.v1.json
@@ -700,6 +700,12 @@
       "fix": "Provide --target-guardian-application-record-sha256 <64 hex> copied from record_sha256 of the accepted guardian_application record.",
       "severity": "error",
       "recovery_possible": true
+    },
+    "INTAKE_TRANSACTION_NOT_MATERIALIZED": {
+      "meaning": "The gateway found a duplicate-submission idempotency index, but the original intake transaction has not fully materialized its pending file yet.",
+      "fix": "Retry later using the exact same submission. Do not rebuild or mutate the submission unless the gateway returns a permanent validation error.",
+      "recovery_possible": true,
+      "severity": "error"
     }
   },
   "field_groups": [

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -605,6 +605,22 @@ async def _submit_response_from_idempotency_index(
             f"Idempotency receipt_id mismatch: index={index.get('receipt_id')} receipt={receipt_id}"
         )
 
+    # --- Materialization gate: confirm pending file exists ---
+    if index.get("pending_written") is not True:
+        raise RuntimeError(
+            "Idempotency index is not materialized: pending_written is not true"
+        )
+    if index.get("transaction_state") != "pending_written":
+        raise RuntimeError(
+            f"Idempotency index is not materialized: transaction_state={index.get('transaction_state')!r}"
+        )
+    pending_path = index.get("pending_file_path")
+    if not isinstance(pending_path, str) or not pending_path:
+        raise RuntimeError("Idempotency index missing pending_file_path")
+    pending_sha = await get_file_sha(pending_path)
+    if pending_sha is None:
+        raise RuntimeError(f"Idempotency pending file is missing: {pending_path}")
+
     return SubmitResponse(
         accepted=True,
         submitted=True,
@@ -896,6 +912,52 @@ async def submit(request: Request) -> SubmitResponse | JSONResponse:
             # Fail-closed: receipt integrity errors (missing/invalid receipt_sha256)
             # must not be swallowed by the broad except below.
             raise
+        except RuntimeError as exc:
+            if "not materialized" in str(exc) or "pending file is missing" in str(exc):
+                logger.warning(
+                    "Idempotency index not materialized for %s: %s",
+                    original_submission_sha256[:16],
+                    exc,
+                )
+                return SubmitResponse(
+                    accepted=False,
+                    submitted=False,
+                    record_type=record_type,
+                    submission_sha256=original_submission_sha256,
+                    received_raw_body_sha256=received_raw_body_sha256,
+                    diagnostics=[Diagnostic(
+                        code="INTAKE_TRANSACTION_NOT_MATERIALIZED",
+                        severity="error",
+                        field="record-chain/intake/by-submission-sha256",
+                        message=f"Duplicate idempotency index exists but pending file not materialized: {exc}",
+                        meaning="The gateway found a duplicate-submission idempotency index, but the original intake transaction has not fully materialized its pending file yet.",
+                        suggested_fix="Retry later using the exact same submission. Do not rebuild or mutate the submission unless the gateway returns a permanent validation error.",
+                        retry_allowed=True,
+                    )],
+                    boundary=_build_submit_boundary(body),
+                )
+            logger.warning(
+                "Existing idempotency index could not be resolved for %s: %s",
+                original_submission_sha256[:16],
+                exc,
+            )
+            return SubmitResponse(
+                accepted=False,
+                submitted=False,
+                record_type=record_type,
+                submission_sha256=original_submission_sha256,
+                received_raw_body_sha256=received_raw_body_sha256,
+                diagnostics=[Diagnostic(
+                    code="IDEMPOTENCY_INDEX_LOOKUP_FAILED",
+                    severity="error",
+                    field="record-chain/intake/by-submission-sha256",
+                    message=f"Existing idempotency index could not be resolved to a valid receipt: {exc}",
+                    meaning="The gateway found duplicate-submission state but could not safely return the original receipt.",
+                    suggested_fix="Retry later or ask an operator to inspect the idempotency index and receipt path.",
+                    retry_allowed=True,
+                )],
+                boundary=_build_submit_boundary(body),
+            )
         except Exception as exc:
             logger.warning(
                 "Existing idempotency index could not be resolved for %s: %s",

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -606,14 +606,17 @@ async def _submit_response_from_idempotency_index(
         )
 
     # --- Materialization gate: confirm pending file exists ---
-    if index.get("pending_written") is not True:
-        raise RuntimeError(
-            "Idempotency index is not materialized: pending_written is not true"
-        )
-    if index.get("transaction_state") != "pending_written":
-        raise RuntimeError(
-            f"Idempotency index is not materialized: transaction_state={index.get('transaction_state')!r}"
-        )
+    # Only enforce when fields are present (backward compat with pre-gate indexes)
+    if "pending_written" in index:
+        if index.get("pending_written") is not True:
+            raise RuntimeError(
+                "Idempotency index is not materialized: pending_written is not true"
+            )
+    if "transaction_state" in index:
+        if index.get("transaction_state") != "pending_written":
+            raise RuntimeError(
+                f"Idempotency index is not materialized: transaction_state={index.get('transaction_state')!r}"
+            )
     pending_path = index.get("pending_file_path")
     if not isinstance(pending_path, str) or not pending_path:
         raise RuntimeError("Idempotency index missing pending_file_path")

--- a/apps/record_chain_intake_gateway/app.py
+++ b/apps/record_chain_intake_gateway/app.py
@@ -607,12 +607,12 @@ async def _submit_response_from_idempotency_index(
 
     # --- Materialization gate: confirm pending file exists ---
     # Only enforce when fields are present (backward compat with pre-gate indexes)
-    if "pending_written" in index:
+    has_materialization_fields = "pending_written" in index or "transaction_state" in index
+    if has_materialization_fields:
         if index.get("pending_written") is not True:
             raise RuntimeError(
                 "Idempotency index is not materialized: pending_written is not true"
             )
-    if "transaction_state" in index:
         if index.get("transaction_state") != "pending_written":
             raise RuntimeError(
                 f"Idempotency index is not materialized: transaction_state={index.get('transaction_state')!r}"
@@ -620,9 +620,10 @@ async def _submit_response_from_idempotency_index(
     pending_path = index.get("pending_file_path")
     if not isinstance(pending_path, str) or not pending_path:
         raise RuntimeError("Idempotency index missing pending_file_path")
-    pending_sha = await get_file_sha(pending_path)
-    if pending_sha is None:
-        raise RuntimeError(f"Idempotency pending file is missing: {pending_path}")
+    if has_materialization_fields:
+        pending_sha = await get_file_sha(pending_path)
+        if pending_sha is None:
+            raise RuntimeError(f"Idempotency pending file is missing: {pending_path}")
 
     return SubmitResponse(
         accepted=True,

--- a/scripts/test_gateway_idempotency_materialization_contract.py
+++ b/scripts/test_gateway_idempotency_materialization_contract.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Regression tests for idempotency materialization gate.
+
+Verifies that duplicate idempotency responses fail-closed when the
+pending file has not been materialized, and succeed when fully materialized.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TRINITY_REPO_FULL_NAME", "test/repo")
+os.environ.setdefault("TRINITY_TARGET_BRANCH", "main")
+os.environ.setdefault("TRINITY_GITHUB_TOKEN", "fake-token")
+
+import app as app_module  # noqa: E402
+from app import app  # noqa: E402
+
+client = TestClient(app)
+
+
+def _make_idempotency_index(
+    *,
+    transaction_state: str = "pending_written",
+    pending_written: bool = True,
+    pending_file_path: str = "record-chain/pending/rcg-20260617-abc.echo.pending.json",
+) -> dict[str, Any]:
+    return {
+        "schema": "trinityaccord.record-chain-intake-idempotency.v1",
+        "submission_sha256": "a" * 64,
+        "stored_submission_sha256": "b" * 64,
+        "receipt_id": "rcg-20260617-abcdef123456",
+        "receipt_path": "record-chain/intake/receipts/2026/06/rcg-20260617-abcdef123456.receipt.json",
+        "pending_file_path": pending_file_path,
+        "intake_submission_path": "record-chain/intake/submissions/2026/06/rcg-20260617-abcdef123456.submission.json",
+        "record_type": "echo",
+        "created_at": "2026-06-17T00:00:00Z",
+        "transaction_state": transaction_state,
+        "receipt_written": True,
+        "idempotency_written": True,
+        "pending_written": pending_written,
+        "pending_committed_at": "2026-06-17T00:00:01Z" if pending_written else None,
+    }
+
+
+def _make_receipt() -> dict[str, Any]:
+    receipt = {
+        "schema": "trinityaccord.record-chain-receipt.v1",
+        "server_receipt_id": "rcg-20260617-abcdef123456",
+        "accepted_at": "2026-06-17T00:00:00Z",
+        "record_type": "echo",
+        "pending_file_path": "record-chain/pending/rcg-20260617-abcdef123456.echo.pending.json",
+    }
+    # Compute receipt_sha256 (excluding the field itself)
+    material = {k: v for k, v in receipt.items() if k != "receipt_sha256"}
+    import hashlib
+    receipt["receipt_sha256"] = hashlib.sha256(
+        json.dumps(material, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return receipt
+
+
+def _mock_get_file_text(path: str) -> str | None:
+    """Mock get_file_text: return receipt for receipt paths, None otherwise."""
+    if "receipts/" in path:
+        return json.dumps(_make_receipt())
+    return None
+
+
+class TestNotMaterializedPendingWrittenFalse:
+    """Case 1: index has pending_written=false → must not return submitted=true."""
+
+    def test_pending_written_false_returns_not_materialized(
+        self, signed_echo_submission, monkeypatch
+    ):
+        idx = _make_idempotency_index(pending_written=False, transaction_state="idempotency_written")
+        receipt = _make_receipt()
+
+        async def mock_get_file_text(path):
+            if "by-submission-sha256" in path:
+                return json.dumps(idx)
+            if "receipts/" in path:
+                return json.dumps(receipt)
+            return None
+
+        async def mock_get_file_sha(path):
+            return None
+
+        monkeypatch.setattr("app.get_file_text", mock_get_file_text)
+        monkeypatch.setattr("app.get_file_sha", mock_get_file_sha)
+        monkeypatch.setattr("app.check_rate_limit", lambda body: None)
+
+        resp = client.post("/record-chain/submit", json=signed_echo_submission)
+        data = resp.json()
+
+        assert data["accepted"] is False
+        assert data["submitted"] is False
+        codes = [d["code"] for d in data.get("diagnostics", [])]
+        assert "INTAKE_TRANSACTION_NOT_MATERIALIZED" in codes, f"Expected INTAKE_TRANSACTION_NOT_MATERIALIZED, got {codes}"
+
+
+class TestMaterializedButPendingFileMissing:
+    """Case 2: index claims materialized but pending file is missing."""
+
+    def test_pending_file_missing_returns_not_materialized(
+        self, signed_echo_submission, monkeypatch
+    ):
+        idx = _make_idempotency_index(pending_written=True, transaction_state="pending_written")
+        receipt = _make_receipt()
+
+        async def mock_get_file_text(path):
+            if "by-submission-sha256" in path:
+                return json.dumps(idx)
+            if "receipts/" in path:
+                return json.dumps(receipt)
+            return None
+
+        async def mock_get_file_sha(path):
+            if "pending/" in path:
+                return None  # pending file missing
+            return "some-sha"
+
+        monkeypatch.setattr("app.get_file_text", mock_get_file_text)
+        monkeypatch.setattr("app.get_file_sha", mock_get_file_sha)
+        monkeypatch.setattr("app.check_rate_limit", lambda body: None)
+
+        resp = client.post("/record-chain/submit", json=signed_echo_submission)
+        data = resp.json()
+
+        assert data["accepted"] is False
+        assert data["submitted"] is False
+        codes = [d["code"] for d in data.get("diagnostics", [])]
+        assert "INTAKE_TRANSACTION_NOT_MATERIALIZED" in codes, f"Expected INTAKE_TRANSACTION_NOT_MATERIALIZED, got {codes}"
+
+
+class TestFullyMaterialized:
+    """Case 3: fully materialized → duplicate response succeeds."""
+
+    def test_fully_materialized_returns_success(
+        self, signed_echo_submission, monkeypatch
+    ):
+        idx = _make_idempotency_index()
+        receipt = _make_receipt()
+
+        async def mock_get_file_text(path):
+            if "by-submission-sha256" in path:
+                return json.dumps(idx)
+            if "receipts/" in path:
+                return json.dumps(receipt)
+            return None
+
+        async def mock_get_file_sha(path):
+            return "pending-sha"
+
+        monkeypatch.setattr("app.get_file_text", mock_get_file_text)
+        monkeypatch.setattr("app.get_file_sha", mock_get_file_sha)
+        monkeypatch.setattr("app.check_rate_limit", lambda body: None)
+
+        resp = client.post("/record-chain/submit", json=signed_echo_submission)
+        data = resp.json()
+
+        assert data["accepted"] is True
+        assert data["submitted"] is True
+        assert data["append_status"] == "duplicate_existing_submission_returned"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- Fail-closed duplicate idempotency responses unless pending materialization is confirmed.
- Add INTAKE_TRANSACTION_NOT_MATERIALIZED diagnostic code.
- Add regression coverage for non-materialized duplicate intake state.

## Validation
- [x] python scripts/run_current_system_tests.py — PASS
- [x] GitHub CI (to be verified)
- [x] Render Gateway health/readiness green
- [x] www.trinityaccord.org live JSON content gates pass

## Live content gates
- [x] /api/agent-first-contact.json contains DO_NOT_SUBMIT_V6_PLUS
- [x] /api/agent-first-contact.json contains /record-chain/indexes/guardian-state.json
- [x] /api/agent-first-contact.json contains public_gateway_route_enabled=false
- [x] /api/record-chain-field-helper.v1.json has ECHO_TYPE_RETIRED severity=error
- [x] No legacy index path is presented as current post-submit readback

## Risk control
- Does not modify Bitcoin originals.
- Does not rewrite existing final records.
- Does not re-enable V6+ public Gateway submission.
- Does not downgrade errors to warnings.