### PR TITLE
fix: harden record-chain append gateway imports and downstream archive pipeline

### DIFF
--- a/.github/workflows/record-chain-append.yml
+++ b/.github/workflows/record-chain-append.yml
@@ -35,6 +35,8 @@ jobs:
           python-version: "3.11"
       - name: Install Python dependencies for append verification
         run: python3 -m pip install -r requirements-ci.txt
+      - name: Verify Gateway import path contract
+        run: python -m pytest tests/test_record_chain_gateway_import_path_contract.py -q
       - name: Authorize write workflow actor
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:

--- a/scripts/trinity_record_chain.py
+++ b/scripts/trinity_record_chain.py
@@ -33,6 +33,39 @@ from pathlib import Path
 from typing import Any, Iterable
 
 ROOT = Path(__file__).resolve().parents[1]
+GATEWAY_APP_ROOT = ROOT / "apps" / "record_chain_intake_gateway"
+
+
+def ensure_gateway_import_path() -> None:
+    """Expose the Gateway package to record-chain scripts in clean CI runners.
+
+    GitHub Actions invokes this script from repository root without installing the
+    Gateway app as an editable package. Any lazy import of `gateway.*` must call
+    this helper first.
+    """
+    gateway_root = str(GATEWAY_APP_ROOT)
+    if gateway_root not in sys.path:
+        sys.path.insert(0, gateway_root)
+
+
+def is_infrastructure_append_error(exc: BaseException) -> bool:
+    """Classify whether an exception is an infrastructure/import failure.
+
+    Infrastructure failures (missing modules, broken imports) must NOT be
+    recorded as semantic submission rejections. They must fail CI while
+    keeping the pending file in pending/ so a retry after the fix succeeds.
+    """
+    if isinstance(exc, (ImportError, ModuleNotFoundError)):
+        return True
+    text = str(exc)
+    infrastructure_markers = [
+        "No module named",
+        "cannot import name",
+        "receipt hash verification import failed",
+    ]
+    return any(marker in text for marker in infrastructure_markers)
+
+
 CHAIN = ROOT / "record-chain"
 GENESIS = CHAIN / "genesis"
 LEGACY_RECORDS = GENESIS / "legacy-records"
@@ -530,7 +563,7 @@ def verify_pending_record_authorship(record: dict[str, Any]) -> None:
     _require_guardian_lifecycle_key_binding(record, proof)
 
     # Import lazily so non-authorship commands do not pay this dependency cost.
-    sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+    ensure_gateway_import_path()
     from gateway.authorship import (  # noqa: WPS433
         strip_unsigned_projection_fields,
         verify_authorship_proof,
@@ -567,7 +600,7 @@ def verify_final_record_authorship(record: dict[str, Any], path: Path) -> list[s
     if compat and compat.get("allowed_skip_signature_reverify"):
         return errors
 
-    sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+    ensure_gateway_import_path()
     from gateway.authorship import strip_unsigned_projection_fields, verify_authorship_proof  # noqa: WPS433
 
     signed_scope = strip_unsigned_projection_fields(record)
@@ -586,7 +619,7 @@ def sanitize_pending_record_for_append(record: dict[str, Any]) -> dict[str, Any]
     same signed-scope object rather than verifying a cleaned view but appending
     the polluted raw pending file.
     """
-    sys.path.insert(0, str(ROOT / "apps/record_chain_intake_gateway"))
+    ensure_gateway_import_path()
     from gateway.authorship import strip_unsigned_projection_fields  # noqa: WPS433
 
     return strip_unsigned_projection_fields(record)
@@ -715,6 +748,7 @@ def verify_receipt_sha256(receipt: dict[str, Any]) -> tuple[bool, str]:
 
     Returns (True, "") on success, (False, error_message) on mismatch.
     """
+    ensure_gateway_import_path()
     from gateway.receipts import compute_receipt_sha256
     expected = receipt.get("receipt_sha256")
     if not expected:
@@ -1002,6 +1036,14 @@ def append_records(all_records: bool = False, allow_rejections: bool = False, pe
                         "updated_at": utc_now(),
                     })
             except Exception as exc:
+                # Infrastructure failures (missing modules, broken imports) must
+                # NOT be recorded as semantic rejections. Fail CI immediately
+                # so the pending file stays pending and a retry after fix works.
+                if is_infrastructure_append_error(exc):
+                    raise SystemExit(
+                        f"Append infrastructure failure; pending record was not semantically rejected: {exc}"
+                    ) from exc
+
                 # Phase 6B: --all continues after rejection; writes rejection JSON
                 REJECTED.mkdir(parents=True, exist_ok=True)
                 rejection_path = REJECTED / f"{path.stem}.rejection.json"

--- a/tests/test_record_chain_append_infrastructure_failure_contract.py
+++ b/tests/test_record_chain_append_infrastructure_failure_contract.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module():
+    """Load trinity_record_chain as a module for testing."""
+    spec = importlib.util.spec_from_file_location(
+        "trinity_record_chain_under_test",
+        ROOT / "scripts" / "trinity_record_chain.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+module = _load_module()
+
+
+# --- is_infrastructure_append_error classification tests ---
+
+
+def test_module_not_found_is_infrastructure_failure() -> None:
+    assert module.is_infrastructure_append_error(
+        ModuleNotFoundError("No module named 'gateway'")
+    ) is True
+
+
+def test_import_error_is_infrastructure_failure() -> None:
+    assert module.is_infrastructure_append_error(
+        ImportError("cannot import name 'compute_receipt_sha256' from 'gateway.receipts'")
+    ) is True
+
+
+def test_import_error_cannot_import_name_is_infrastructure_failure() -> None:
+    assert module.is_infrastructure_append_error(
+        ImportError("cannot import name 'verify_authorship_proof'")
+    ) is True
+
+
+def test_receipt_hash_import_failure_is_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        RuntimeError("receipt hash verification import failed")
+    ) is True
+
+
+def test_semantic_validation_error_is_not_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        ValueError("Duplicate signed_payload_sha256")
+    ) is False
+
+
+def test_authorship_proof_error_is_not_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        ValueError("formal record_type=echo requires authorship_proof")
+    ) is False
+
+
+def test_generic_value_error_is_not_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        ValueError("record missing required field: record_type")
+    ) is False
+
+
+def test_generic_runtime_error_is_not_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        RuntimeError("something went wrong")
+    ) is False
+
+
+def test_key_error_is_not_infrastructure() -> None:
+    assert module.is_infrastructure_append_error(
+        KeyError("record_type")
+    ) is False

--- a/tests/test_record_chain_gateway_import_path_contract.py
+++ b/tests/test_record_chain_gateway_import_path_contract.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_trinity_record_chain_can_import_gateway_receipts_without_pythonpath() -> None:
+    """Verify that trinity_record_chain can import gateway.receipts without PYTHONPATH.
+
+    This is the exact failure class that broke the append pipeline: a clean
+    GitHub Actions runner does not have apps/record_chain_intake_gateway on
+    sys.path, so any gateway.* import must go through ensure_gateway_import_path().
+    """
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    code = r'''
+import importlib.util
+from pathlib import Path
+
+root = Path.cwd()
+spec = importlib.util.spec_from_file_location(
+    "trinity_record_chain_under_test",
+    root / "scripts" / "trinity_record_chain.py",
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+module.ensure_gateway_import_path()
+from gateway.receipts import compute_receipt_sha256
+
+receipt = {
+    "schema": "trinityaccord.record-chain-receipt.v1",
+    "server_receipt_id": "rcg-20260617-abcdef1234567890abcdef",
+    "accepted_at": "2026-06-17T00:00:00Z",
+    "record_type": "echo",
+    "pending_file_path": "record-chain/pending/rcg-20260617-abcdef1234567890abcdef.echo.pending.json",
+}
+receipt["receipt_sha256"] = compute_receipt_sha256(receipt)
+ok, err = module.verify_receipt_sha256(receipt)
+assert ok, err
+'''
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- Add a single Gateway import-path helper for record-chain scripts.
- Ensure receipt hash verification can import `gateway.receipts` in clean GitHub Actions environments.
- Prevent infrastructure import failures from being recorded as semantic submission rejections.
- Add regression coverage for append import path and infrastructure-failure classification.
- Verify downstream append → OTS → Arweave pipeline gates remain fail-closed.

## Root cause
`verify_receipt_sha256()` imported `gateway.receipts` before exposing `apps/record_chain_intake_gateway` on `sys.path`. Clean Actions runners therefore failed with `No module named 'gateway'` during append receipt verification.

## Changes
- `scripts/trinity_record_chain.py`: Add `ensure_gateway_import_path()` and `is_infrastructure_append_error()`, replace all raw `sys.path.insert()` calls
- `tests/test_record_chain_gateway_import_path_contract.py`: Regression test for import path contract
- `tests/test_record_chain_append_infrastructure_failure_contract.py`: Regression test for infrastructure failure classification
- `.github/workflows/record-chain-append.yml`: Add Gateway import path verification step before append

## Validation
- [ ] `python -m pytest tests/test_record_chain_gateway_import_path_contract.py -q`
- [ ] `python -m pytest tests/test_record_chain_append_infrastructure_failure_contract.py -q`
- [ ] `python scripts/trinity_record_chain.py verify`
- [ ] GitHub CI green
- [ ] Append workflow green

## Recovery note
If the affected Echo was moved to `record-chain/rejected/` only because of `No module named 'gateway'`, requeue the exact same pending file in a separate evidence-backed repair commit after this fix. Do not mutate or resubmit the Echo payload.