### PR TITLE
ci: treat capsule heartbeat OTS lag as no-op

### DIFF
--- a/.github/workflows/waiting-heartbeat-capsule.yml
+++ b/.github/workflows/waiting-heartbeat-capsule.yml
@@ -45,8 +45,15 @@ jobs:
       - name: Generate waiting heartbeat status
         run: python3 scripts/generate_waiting_heartbeat_status.py
 
+      - name: Capsule OTS coverage preflight
+        id: capsule_preflight
+        run: |
+          set -euo pipefail
+          python3 scripts/build_waiting_heartbeat_arweave_capsule.py
+
       - name: Build capsule
         id: build
+        if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           set -euo pipefail
           capsule_path="$(python3 scripts/build_waiting_heartbeat_arweave_capsule.py)"
@@ -55,6 +62,7 @@ jobs:
           echo "heartbeat_id=${heartbeat_id}" >> "$GITHUB_OUTPUT"
 
       - name: Upload capsule
+        if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           node scripts/arweave_upload_waiting_heartbeat_capsule.mjs \
             --payload "${{ steps.build.outputs.capsule_path }}" \
@@ -62,6 +70,7 @@ jobs:
             --out "record-chain/heartbeat/capsules/${{ steps.build.outputs.heartbeat_id }}.upload-result.json"
 
       - name: Regenerate status and public artifacts
+        if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           python3 scripts/generate_waiting_heartbeat_status.py
           python3 scripts/update_public_generated_artifacts.py
@@ -69,6 +78,7 @@ jobs:
           python3 scripts/trinity_record_chain.py verify
 
       - name: Commit capsule metadata
+        if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           set -euo pipefail
           if git diff --quiet; then
@@ -86,3 +96,10 @@ jobs:
             git pull --rebase origin "${GITHUB_REF_NAME:-main}"
           done
           exit 1
+
+      - name: Capsule waiting summary
+        if: steps.capsule_preflight.outputs.capsule_upload_needed != 'true'
+        run: |
+          echo "Capsule upload skipped."
+          echo "status=${{ steps.capsule_preflight.outputs.capsule_status }}"
+          echo "reason=${{ steps.capsule_preflight.outputs.capsule_skip_reason }}"

--- a/scripts/build_waiting_heartbeat_arweave_capsule.py
+++ b/scripts/build_waiting_heartbeat_arweave_capsule.py
@@ -30,6 +30,17 @@ def dump_json(data: Any) -> str:
     return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False) + "\n"
 
 
+def write_github_output(values: dict[str, str]) -> None:
+    """Write key=value pairs to $GITHUB_OUTPUT if running in Actions."""
+    import os
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}={value}\n")
+
+
 def main() -> int:
     status = read_json(STATUS)
     latest = status.get("latest_heartbeat")
@@ -41,9 +52,21 @@ def main() -> int:
     ots = read_json(OTS)
 
     if ots.get("latest_record_id") != latest.get("record_id"):
-        raise SystemExit("OTS latest does not cover latest waiting heartbeat yet.")
+        print("::notice::OTS latest does not cover latest waiting heartbeat yet; capsule build skipped until next OTS cycle.")
+        write_github_output({
+            "capsule_status": "waiting_for_ots",
+            "capsule_upload_needed": "false",
+            "capsule_skip_reason": "ots_latest_does_not_cover_latest_waiting_heartbeat",
+        })
+        return 0
     if ots.get("latest_record_sha256") != latest.get("record_sha256"):
         raise SystemExit("OTS latest sha does not match latest waiting heartbeat.")
+
+    write_github_output({
+        "capsule_status": "ready",
+        "capsule_upload_needed": "true",
+        "capsule_skip_reason": "",
+    })
 
     payload = {
         "schema": "trinityaccord.waiting-heartbeat-arweave-capsule.v1",


### PR DESCRIPTION
## Summary

- Treat Arweave Capsule waiting-heartbeat OTS lag as a normal waiting/no-op state
- Replace hard failure (exit 1) with notice + exit 0 when OTS latest does not yet cover latest waiting heartbeat
- Add capsule_preflight step with GITHUB_OUTPUT for capsule_status, capsule_upload_needed, capsule_skip_reason
- Gate Build/Upload/Regenerate/Commit steps on capsule_upload_needed
- Add Capsule waiting summary step for audit trail
- Preserve hard failures for real defects (missing heartbeat, sha mismatch, manifest/readback mismatch)

## Why

R-000000054 is already covered by native OTS and native Record-Chain Arweave archive. The failing Capsule run was caused by a newer waiting heartbeat not yet covered by current OTS latest, which is an asynchronous timing condition. This should not be a red CI failure.

## Validation

- [ ] Waiting heartbeat not covered by OTS exits 0
- [ ] Build/upload steps are skipped in waiting state
- [ ] Real data corruption still fails
- [ ] python3 scripts/trinity_record_chain.py verify
- [ ] python3 scripts/detect_record_chain_pipeline_backlog.py