### PR TITLE
Make waiting-heartbeat capsule workflow resilient to concurrent main updates

### DIFF
--- a/.github/workflows/waiting-heartbeat-capsule.yml
+++ b/.github/workflows/waiting-heartbeat-capsule.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: waiting-heartbeat-capsule
+  group: main-write-lock
   cancel-in-progress: false
 
 permissions:
@@ -39,8 +39,11 @@ jobs:
           python3 -m pip install -r requirements-ci.txt
           npm ci
 
-      - name: Rebase
-        run: git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+      - name: Rebase onto latest main
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          git rebase origin/main
 
       - name: Generate waiting heartbeat status
         run: python3 scripts/generate_waiting_heartbeat_status.py
@@ -81,20 +84,67 @@ jobs:
         if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           set -euo pipefail
-          if git diff --quiet; then
-            echo "No changes."
-            exit 0
-          fi
+
           git config user.name "trinity-waiting-heartbeat-bot"
           git config user.email "actions@github.com"
-          git add record-chain/heartbeat api/waiting-heartbeat-status.json api/public-home-status.json index.md sitemap.xml
+
+          regenerate_status_artifacts() {
+            python3 scripts/generate_waiting_heartbeat_status.py
+            python3 scripts/update_public_generated_artifacts.py
+            python3 scripts/generate_public_home_status.py --check
+            python3 scripts/trinity_record_chain.py verify
+          }
+
+          stage_capsule_metadata() {
+            git status --short
+            git add -A \
+              record-chain/heartbeat \
+              api/waiting-heartbeat-status.json \
+              api/public-home-status.json \
+              index.md \
+              sitemap.xml
+          }
+
+          stage_capsule_metadata
+
+          if git diff --cached --quiet; then
+            echo "No generated capsule metadata changes to commit."
+            exit 0
+          fi
+
           git commit -m "heartbeat: archive waiting heartbeat capsule"
+
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "Worktree dirty after commit; generated files were not fully staged."
+            git status --short
+            exit 1
+          fi
+
           for attempt in 1 2 3; do
-            if git push origin "HEAD:${GITHUB_REF_NAME:-main}"; then
+            if git push origin HEAD:main; then
+              echo "Push succeeded."
               exit 0
             fi
-            git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+
+            echo "Push rejected; remote main advanced. Rebasing and regenerating. Attempt ${attempt}."
+            git fetch origin main --prune
+            git rebase origin/main
+
+            regenerate_status_artifacts
+            stage_capsule_metadata
+
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
+            fi
+
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "Worktree dirty after amend; refusing to push."
+              git status --short
+              exit 1
+            fi
           done
+
+          echo "Failed to push after retries."
           exit 1
 
       - name: Capsule waiting summary


### PR DESCRIPTION
### Motivation

- Ensure the waiting-heartbeat Arweave capsule workflow can safely rebase and push generated metadata when `main` advances concurrently.
- Prevent partial commits or dirty worktrees by adding stronger checks around staging, committing, and pushing of generated artifacts.
- Reduce accidental parallelism by aligning concurrency with the repository main write lock.

### Description

- Change concurrency group from `waiting-heartbeat-capsule` to `main-write-lock` to coordinate writes with main branch operations.
- Replace a simple `git pull --rebase` with a safer rebase flow that uses `git fetch origin main --prune` and `git rebase origin/main` and add `set -euo pipefail` for robust shell execution.
- Add functions to regenerate status artifacts and stage metadata, use `git add -A` and check `git diff --cached --quiet` to skip commits when nothing changed, and verify the worktree is clean after commits.
- Implement a push retry loop that attempts `git push origin HEAD:main` up to three times, and on rejection it rebases on updated `origin/main`, re-generates artifacts, stages changes, and amends the commit before retrying, failing if the worktree becomes dirty.

### Testing

- No automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e3e3f4748331a3dd9d44b00322fd)