### PR TITLE
Unify main write lock and add robust rebase/push retry logic to anchor and capsule workflows

### DIFF
--- a/.github/workflows/record-chain-anchor.yml
+++ b/.github/workflows/record-chain-anchor.yml
@@ -14,7 +14,7 @@ on:
     - cron: "17 */6 * * *"
 
 concurrency:
-  group: record-chain-anchor
+  group: main-write-lock
   cancel-in-progress: false
 
 permissions:
@@ -61,22 +61,72 @@ jobs:
       - name: Commit anchor updates
         run: |
           set -euo pipefail
-          if ! git diff --quiet; then
-            git config user.name "trinity-record-chain-bot"
-            git config user.email "actions@github.com"
+
+          if git diff --quiet; then
+            echo "No anchor updates."
+            exit 0
+          fi
+
+          git config user.name "trinity-record-chain-bot"
+          git config user.email "actions@github.com"
+
+          stage_anchor_updates() {
+            git status --short
             git add record-chain/ api/record-chain-anchor-status.json
-            git commit -m "anchor: build record-chain batch and OTS status"
+          }
 
-            for attempt in 1 2 3; do
-              if git push; then
-                exit 0
-              fi
-              printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
-              git fetch origin main
-              git rebase origin main || { git rebase --abort; }
-              sleep $((attempt * 5))
-            done
+          rebuild_anchor_outputs() {
+            if [ "${{ github.event.inputs.force_batch }}" = "true" ]; then
+              python scripts/trinity_record_chain.py build-batch --force
+            else
+              python scripts/trinity_record_chain.py build-batch
+            fi
+            python scripts/trinity_record_chain.py ots-stamp
+            python scripts/trinity_record_chain.py ots-upgrade
+            python scripts/trinity_record_chain.py build-anchor-status
+            python scripts/trinity_record_chain.py verify
+          }
 
-            echo "::error::Failed to push anchor updates after retries."
+          stage_anchor_updates
+
+          if git diff --cached --quiet; then
+            echo "No staged anchor updates."
+            exit 0
+          fi
+
+          git commit -m "anchor: build record-chain batch and OTS status"
+
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "Worktree dirty after commit; generated files were not fully staged."
+            git status --short
             exit 1
           fi
+
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              echo "Push succeeded."
+              exit 0
+            fi
+
+            printf 'Push failed on attempt %s; rebasing and retrying.\n' "${attempt}"
+            git fetch origin main --prune
+            git rebase origin/main
+
+            rebuild_anchor_outputs
+            stage_anchor_updates
+
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
+            fi
+
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "Worktree dirty after amend; refusing to push."
+              git status --short
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
+
+          echo "::error::Failed to push anchor updates after retries."
+          exit 1

--- a/.github/workflows/waiting-heartbeat-capsule.yml
+++ b/.github/workflows/waiting-heartbeat-capsule.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: waiting-heartbeat-capsule
+  group: main-write-lock
   cancel-in-progress: false
 
 permissions:
@@ -39,8 +39,11 @@ jobs:
           python3 -m pip install -r requirements-ci.txt
           npm ci
 
-      - name: Rebase
-        run: git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+      - name: Rebase onto latest main
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          git rebase origin/main
 
       - name: Generate waiting heartbeat status
         run: python3 scripts/generate_waiting_heartbeat_status.py
@@ -81,20 +84,67 @@ jobs:
         if: steps.capsule_preflight.outputs.capsule_upload_needed == 'true'
         run: |
           set -euo pipefail
-          if git diff --quiet; then
-            echo "No changes."
-            exit 0
-          fi
+
           git config user.name "trinity-waiting-heartbeat-bot"
           git config user.email "actions@github.com"
-          git add record-chain/heartbeat api/waiting-heartbeat-status.json api/public-home-status.json index.md sitemap.xml
+
+          regenerate_status_artifacts() {
+            python3 scripts/generate_waiting_heartbeat_status.py
+            python3 scripts/update_public_generated_artifacts.py
+            python3 scripts/generate_public_home_status.py --check
+            python3 scripts/trinity_record_chain.py verify
+          }
+
+          stage_capsule_metadata() {
+            git status --short
+            git add -A \
+              record-chain/heartbeat \
+              api/waiting-heartbeat-status.json \
+              api/public-home-status.json \
+              index.md \
+              sitemap.xml
+          }
+
+          stage_capsule_metadata
+
+          if git diff --cached --quiet; then
+            echo "No generated capsule metadata changes to commit."
+            exit 0
+          fi
+
           git commit -m "heartbeat: archive waiting heartbeat capsule"
+
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "Worktree dirty after commit; generated files were not fully staged."
+            git status --short
+            exit 1
+          fi
+
           for attempt in 1 2 3; do
-            if git push origin "HEAD:${GITHUB_REF_NAME:-main}"; then
+            if git push origin HEAD:main; then
+              echo "Push succeeded."
               exit 0
             fi
-            git pull --rebase origin "${GITHUB_REF_NAME:-main}"
+
+            echo "Push rejected; remote main advanced. Rebasing and regenerating. Attempt ${attempt}."
+            git fetch origin main --prune
+            git rebase origin/main
+
+            regenerate_status_artifacts
+            stage_capsule_metadata
+
+            if ! git diff --cached --quiet; then
+              git commit --amend --no-edit
+            fi
+
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "Worktree dirty after amend; refusing to push."
+              git status --short
+              exit 1
+            fi
           done
+
+          echo "Failed to push after retries."
           exit 1
 
       - name: Capsule waiting summary


### PR DESCRIPTION
### Motivation
- Prevent concurrent writes and race conditions when workflow-generated artifacts are committed and pushed to `main` by using a shared write lock and more robust push/rebase behavior. 
- Ensure generated artifacts are fully staged and consistent after rebases so automated commits do not leave a dirty worktree. 

### Description
- Changed `concurrency.group` to `main-write-lock` in both `record-chain-anchor.yml` and `waiting-heartbeat-capsule.yml` to serialize writers. 
- Replaced simple `git diff`/`git push` flows with guarded logic that checks for no-op cases, stages artifacts via helper blocks, commits only staged changes, and fails fast when the worktree remains dirty. 
- Added retry loops that run `git fetch origin main --prune` and `git rebase origin/main`, regenerate outputs with the same scripts, re-stage files, and `git commit --amend` before retrying `git push origin HEAD:main`. 
- For the capsule workflow replaced the `git pull --rebase` approach with an explicit fetch/rebase and added clearer logging and artifact regeneration functions. 

### Testing
- No automated tests were executed as part of this PR because the changes modify CI workflow orchestration and will be exercised on the next workflow runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e3e3f4748331a3dd9d44b00322fd)