### PR TITLE
ci: allow record-chain overlay mirror in write guard

### DIFF
--- a/scripts/check_record_chain_write_path_guard.py
+++ b/scripts/check_record_chain_write_path_guard.py
@@ -55,6 +55,7 @@ BACKLOG_FILES = {
 }
 
 PUBLIC_GENERATED_FILES = {
+    "api/record-chain-overlays.json",
     "api/record-chain-status.json",
     "api/public-home-status.json",
     "index.md",
@@ -317,4 +318,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/scripts/test_main_write_workflows_safe_push_contract.py
+++ b/scripts/test_main_write_workflows_safe_push_contract.py
@@ -74,8 +74,14 @@ def test_record_chain_index_writers_stage_overlay_mirror():
     assert not offenders, "\n".join(offenders)
 
 
+def test_write_path_guard_classifies_overlay_as_generated():
+    guard = (ROOT / "scripts" / "check_record_chain_write_path_guard.py").read_text(encoding="utf-8")
+    assert "api/record-chain-overlays.json" in guard, "write-path guard must classify overlay mirror as generated"
+
+
 if __name__ == "__main__":
     test_main_writers_use_shared_lock_and_safe_rebase()
     test_archive_workflow_rebuilds_after_rebase()
     test_record_chain_index_writers_stage_overlay_mirror()
+    test_write_path_guard_classifies_overlay_as_generated()
     print("All main-write workflow contract tests passed.")


### PR DESCRIPTION
## Changes

- Classify `api/record-chain-overlays.json` as public generated output in the record-chain write-path guard.
- Extend the main writer contract test so workflows that stage the overlay also require the guard to recognize the overlay mirror.

## Why

PR #537 correctly stages `api/record-chain-overlays.json` with record-chain append and batch updates. Without this follow-up, push guard classification can treat the overlay as unrestricted and reject otherwise approved append commits that include protected record-chain files plus the generated overlay mirror.

## Validation

- `python3 scripts/test_main_write_workflows_safe_push_contract.py`
- `python3 scripts/test_record_chain_write_path_guard_contract.py`