### PR TITLE
ci: remove stale deep-integrity groups

### DIFF
--- a/.github/workflows/deep-integrity.yml
+++ b/.github/workflows/deep-integrity.yml
@@ -17,16 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         group:
-          - guardian
           - claim-gate
           - echo-archive
           - supply-chain
           - trust-root
           - chronicle
           - readback-integrity
-          - route-correction
           - agent-start-docs
-          - gateway-workflows
           - verification-index
           - pages-build
     steps:

--- a/scripts/test_deep_integrity_includes_pages_build.py
+++ b/scripts/test_deep_integrity_includes_pages_build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""deep-integrity.yml must include pages-build so GitHub Pages/Jekyll smoke runs."""
+"""deep-integrity.yml must run only active grouped CI slices."""
 from pathlib import Path
 import re
 import sys
@@ -37,8 +37,17 @@ else:
             elif line.strip() and not line.startswith("          "):
                 break
 
-if "pages-build" not in groups:
-    print("FAIL: deep-integrity.yml matrix missing pages-build")
+required = {"pages-build"}
+stale = {"guardian", "route-correction", "gateway-workflows"}
+
+missing = sorted(required - set(groups))
+if missing:
+    print(f"FAIL: deep-integrity.yml matrix missing required groups: {missing}")
     sys.exit(1)
 
-print("PASS: deep-integrity.yml includes pages-build")
+present_stale = sorted(stale & set(groups))
+if present_stale:
+    print(f"FAIL: deep-integrity.yml matrix includes stale groups: {present_stale}")
+    sys.exit(1)
+
+print("PASS: deep-integrity.yml includes active pages-build group and excludes stale groups")


### PR DESCRIPTION
## Changes

- Remove stale Deep Integrity matrix groups that call retired/missing `run_ci_group.py` entries:
  - `guardian`
  - `route-correction`
  - `gateway-workflows`
- Extend the Deep Integrity matrix contract test so these stale groups cannot be re-added while `pages-build` remains required.

## Why

The latest scheduled Deep Integrity run was failing before any assertion logic because some matrix groups invoked old entries in `scripts/run_ci_group.py` that reference removed files such as:

- `scripts/test_guardian_automated_verification.py`
- `scripts/test_pure_echo_builder_rejects_unproofed_guardian_identity.py`
- `scripts/test_gateway_workflow_docs.py`

This PR fixes the scheduled workflow at the workflow matrix boundary instead of adding empty compatibility tests.

## Validation

- `python3 scripts/test_deep_integrity_includes_pages_build.py`
- Re-run `Deep Integrity` after merge.